### PR TITLE
[refs #138] Colour variables changed from `colour` to `color`

### DIFF
--- a/packages/components/action-link/_action-link.scss
+++ b/packages/components/action-link/_action-link.scss
@@ -28,16 +28,16 @@
   }
 
   @include mq($media-type: print) {
-    color: $nhsuk-print-text-colour;
+    color: $nhsuk-print-text-color;
 
     &:visited {
-      color: $nhsuk-print-text-colour;
+      color: $nhsuk-print-text-color;
     }
   }
 
 
   &:focus {
-    box-shadow: 0 0 0 8px $nhsuk-link-focus-background-colour; /* [5] */
+    box-shadow: 0 0 0 8px $nhsuk-link-focus-background-color; /* [5] */
 
     span {
       text-decoration: underline;
@@ -46,7 +46,7 @@
   }
 
   &:hover {
-    box-shadow: 0 0 0 8px $nhsuk-link-hover-background-colour; /* [5] */
+    box-shadow: 0 0 0 8px $nhsuk-link-hover-background-color; /* [5] */
 
     span {
       text-decoration: underline; /* [6] */
@@ -55,7 +55,7 @@
   }
 
   .nhsuk-icon__arrow-right-circle {
-    fill: $colour_nhsuk-green;
+    fill: $color_nhsuk-green;
     height: 40px;
     left: -3px;
     position: absolute;
@@ -70,7 +70,7 @@
     }
 
     @include mq($media-type: print) {
-      fill: $nhsuk-print-text-colour;
+      fill: $nhsuk-print-text-color;
     }
 
   }

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -14,7 +14,7 @@
 **/
 
 .nhsuk-c-breadcrumb {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   padding-bottom: 12px; // [1] //
   padding-top: 12px; // [1] //
 
@@ -23,7 +23,7 @@
   }
 
   .nhsuk-icon__chevron-right {
-    fill: $colour_nhsuk-grey-3;
+    fill: $color_nhsuk-grey-3;
     height: 18px;
     position: relative;
     top: 5px;

--- a/packages/components/care-card/_care-card.scss
+++ b/packages/components/care-card/_care-card.scss
@@ -21,7 +21,7 @@
 .nhsuk-c-care-card {
   @include nhsuk-responsive-margin(7, 'bottom');
   @include nhsuk-responsive-margin(7, 'top');
-  @include care-card($colour_nhsuk-blue, $colour_nhsuk-white, 4px); /* [1] */
+  @include care-card($color_nhsuk-blue, $color_nhsuk-white, 4px); /* [1] */
   border: 1px solid transparent; /* [6] */
 }
 
@@ -48,7 +48,7 @@
 
 .nhsuk-c-care-card__heading {
   @include nhsuk-font(24, $weight: bold);
-  @include print-colour($nhsuk-print-text-colour);
+  @include print-color($nhsuk-print-text-color);
 
   margin: 0;
 }
@@ -56,7 +56,7 @@
 .nhsuk-c-care-card__content {
   @include top-and-bottom();
 
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   padding: nhsuk-spacing(5) nhsuk-spacing(4) nhsuk-spacing(4); /* [5] */
 
   @include mq($from: tablet) {
@@ -64,7 +64,7 @@
     padding-top: 36px; /* [5] */
   }
 
-  @include print-colour($nhsuk-print-text-colour);
+  @include print-color($nhsuk-print-text-color);
 
 }
 
@@ -75,26 +75,26 @@
  */
 
 .nhsuk-c-care-card--grey {
-  @include care-card($colour_nhsuk-grey-4, $colour_nhsuk-black, 2px);
+  @include care-card($color_nhsuk-grey-4, $color_nhsuk-black, 2px);
 }
 
 .nhsuk-c-care-card--red {
-  @include care-card($colour_nhsuk-red, $colour_nhsuk-white, 6px);
+  @include care-card($color_nhsuk-red, $color_nhsuk-white, 6px);
 }
 
 .nhsuk-c-care-card--black {
-  @include care-card($colour_nhsuk-red, $colour_nhsuk-white, 8px);
+  @include care-card($color_nhsuk-red, $color_nhsuk-white, 8px);
 
   .nhsuk-c-care-card__content {
-    background-color: $colour_nhsuk-black;
-    color: $colour_nhsuk-white;
+    background-color: $color_nhsuk-black;
+    color: $color_nhsuk-white;
 
     a {
-      color: $colour_nhsuk-white; /* [1] */
+      color: $color_nhsuk-white; /* [1] */
 
       &:hover,
       &:focus {
-        color: $colour_nhsuk-black; /* [1] */
+        color: $color_nhsuk-black; /* [1] */
       }
 
     }

--- a/packages/components/contents-list/_contents-list.scss
+++ b/packages/components/contents-list/_contents-list.scss
@@ -21,7 +21,7 @@
   position: relative;
 
   &:before {
-    color: $colour_nhsuk-grey-3;
+    color: $color_nhsuk-grey-3;
     content: '\2014'; /* [1] */
     left: 0;
     position: absolute;

--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -18,14 +18,14 @@
  */
 
 .nhsuk-details {
-  @include nhsuk-text-colour;
+  @include nhsuk-text-color;
   @include nhsuk-responsive-margin(6, 'bottom');
   @include nhsuk-typography-responsive(19);
   display: block;
 }
 
 .nhsuk-details__summary {
-  color: $colour_nhsuk-blue; // [1] //
+  color: $color_nhsuk-blue; // [1] //
   cursor: pointer;
   display: inline-block; // [2] //
   padding-left: nhsuk-spacing(4);
@@ -50,20 +50,20 @@
   }
 
   &:focus {
-    box-shadow: 0 0 0 $nhsuk-box-details $nhsuk-link-focus-background-colour;
-    color: $nhsuk-link-focus-colour;
+    box-shadow: 0 0 0 $nhsuk-box-details $nhsuk-link-focus-background-color;
+    color: $nhsuk-link-focus-color;
 
     .nhsuk-details__summary-text {
-      color: $nhsuk-link-focus-colour;
+      color: $nhsuk-link-focus-color;
     }
   }
 
   &:hover {
-    background-color: $nhsuk-link-hover-background-colour;
-    box-shadow: 0 0 0 $nhsuk-box-details $nhsuk-link-hover-background-colour;
+    background-color: $nhsuk-link-hover-background-color;
+    box-shadow: 0 0 0 $nhsuk-box-details $nhsuk-link-hover-background-color;
 
     .nhsuk-details__summary-text {
-      color: $nhsuk-link-hover-colour;
+      color: $nhsuk-link-hover-color;
       text-decoration: none;
     }
 
@@ -80,7 +80,7 @@
 }
 
 .nhsuk-details__text {
-  border-left: nhsuk-spacing(1) solid $colour_nhsuk-grey-4;
+  border-left: nhsuk-spacing(1) solid $color_nhsuk-grey-4;
   margin-top: nhsuk-spacing(2);
   padding: nhsuk-spacing(3);
   padding-left: nhsuk-spacing(4);
@@ -106,11 +106,11 @@
  */
 
 .nhsuk-c-expander {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
 
   .nhsuk-details__summary {
     @include nhsuk-responsive-padding(4);
-    background-color: $colour_nhsuk-white;
+    background-color: $color_nhsuk-white;
     display: block;
 
     &:before {
@@ -118,11 +118,11 @@
     }
 
     &:focus {
-      box-shadow: 0 0 0 $nhsuk-box-expander $nhsuk-link-focus-background-colour;
+      box-shadow: 0 0 0 $nhsuk-box-expander $nhsuk-link-focus-background-color;
     }
 
     &:hover {
-      box-shadow: 0 0 0 $nhsuk-box-expander $nhsuk-link-hover-background-colour;
+      box-shadow: 0 0 0 $nhsuk-box-expander $nhsuk-link-hover-background-color;
     }
 
     &:hover,
@@ -135,7 +135,7 @@
 
   .nhsuk-details__summary-text {
     background: url(/assets/icons/icon-plus.svg) left -2px center no-repeat;
-    color: $colour_nhsuk-blue;
+    color: $color_nhsuk-blue;
     cursor: pointer;
     display: block;
     padding: nhsuk-spacing(2) nhsuk-spacing(2) nhsuk-spacing(2) 38px;
@@ -154,7 +154,7 @@
 .nhsuk-c-expander[open] { // sass-lint:disable-line force-attribute-nesting
 
   .nhsuk-details__summary {
-    border-bottom: 1px solid $colour_nhsuk-grey-5;
+    border-bottom: 1px solid $color_nhsuk-grey-5;
   }
 
   .nhsuk-details__summary-text {

--- a/packages/components/do-dont-list/_do-dont-list.scss
+++ b/packages/components/do-dont-list/_do-dont-list.scss
@@ -11,10 +11,10 @@
  */
 
 .nhsuk-c-do-dont-list {
-  @include panel-with-label($colour_nhsuk-white, $nhsuk-text-colour); /* [1] */
+  @include panel-with-label($color_nhsuk-white, $nhsuk-text-color); /* [1] */
 }
 
 .nhsuk-c-do-dont-list__label {
-  @include heading-label($colour_nhsuk-blue, $colour_nhsuk-white); /* [2] */
-  @include print-colour($nhsuk-print-text-colour);
+  @include heading-label($color_nhsuk-blue, $color_nhsuk-white); /* [2] */
+  @include print-color($nhsuk-print-text-color);
 }

--- a/packages/components/emergency-alert/_emergency-alert.scss
+++ b/packages/components/emergency-alert/_emergency-alert.scss
@@ -4,11 +4,11 @@
 
 /**
  * 1. Use inverted link colours due to the yellow
- *    ($colour_nhsuk-yellow) background.
+ *    ($color_nhsuk-yellow) background.
  */
 
 .nhsuk-c-global-alert {
-  background-color: $colour_nhsuk-yellow;
+  background-color: $color_nhsuk-yellow;
   padding-bottom: nhsuk-spacing(4);
   padding-top: nhsuk-spacing(4);
 

--- a/packages/components/feedback-banner/_feedback-banner.scss
+++ b/packages/components/feedback-banner/_feedback-banner.scss
@@ -13,7 +13,7 @@
  */
 
 .nhsuk-c-feedback-banner {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   bottom: 0;
   box-shadow: 0 -4px 0 0 $nhsuk-box-shadow;
   display: none; // [1] //
@@ -60,7 +60,7 @@
 
   background: none;
   border: 0;
-  color: $colour_nhsuk-black;
+  color: $color_nhsuk-black;
   cursor: pointer; // [6] //
   padding: 0;
   position: absolute;

--- a/packages/components/footer/_footer.scss
+++ b/packages/components/footer/_footer.scss
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 .nhsuk-footer {
-  background-color: $colour_nhsuk-blue;
-  color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-blue;
+  color: $color_nhsuk-white;
 
   @include mq($media-type: print) {
     display: none;
@@ -37,7 +37,7 @@
     }
 
     &:hover {
-      box-shadow: 0 0 0 4px $colour_shade_nhsuk-blue-35;
+      box-shadow: 0 0 0 4px $color_shade_nhsuk-blue-35;
     }
 
   }
@@ -52,7 +52,7 @@
   padding-top: nhsuk-spacing(4);
 
   &:last-child {
-    border-top: 1px solid $nhsuk-secondary-border-colour;
+    border-top: 1px solid $nhsuk-secondary-border-color;
   }
 
 }

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -39,7 +39,7 @@
 
 .nhsuk-header {
   @include clearfix();
-  background-color: $colour_nhsuk-blue;
+  background-color: $color_nhsuk-blue;
 }
 
 .nhsuk-header__logo {
@@ -58,7 +58,7 @@
   width: 99px; /* [1] */
 
   &:hover {
-    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $colour_shade_nhsuk-blue-35;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $color_shade_nhsuk-blue-35;
   }
 }
 
@@ -72,7 +72,7 @@
   @include clearfix();
 
   &.js-show {
-    border-bottom: 4px solid $colour_nhsuk-grey-5; /* [12] */
+    border-bottom: 4px solid $color_nhsuk-grey-5; /* [12] */
   }
 
   @include mq($from: tablet) {
@@ -105,7 +105,7 @@
   top: nhsuk-spacing(3);
 
   .nhsuk-icon__search {
-    fill: $colour_nhsuk-white;
+    fill: $color_nhsuk-white;
     height: 21px; /* [3] */
     width: 21px; /* [3] */
   }
@@ -142,7 +142,7 @@
   }
 
   .nhsuk-header__search-form {
-    background-color: $colour_nhsuk-white;
+    background-color: $color_nhsuk-white;
     display: -ms-flexbox; /* [14] */
     display: flex; // sass-lint:disable-line no-duplicate-properties
     padding: nhsuk-spacing(3);
@@ -152,13 +152,13 @@
   .nhsuk-search__input {
     -ms-flex-positive: 2; /* [14] */
     -webkit-appearance: listbox; // sass-lint:disable-line prefixes /* [5] */
-    background-color: $colour_nhsuk-white !important; // sass-lint:disable-line no-important /* [6] */
-    border-bottom: 1px solid $colour_nhsuk-grey-3;
+    background-color: $color_nhsuk-white !important; // sass-lint:disable-line no-important /* [6] */
+    border-bottom: 1px solid $color_nhsuk-grey-3;
     border-bottom-left-radius: $nhsuk-border-radius;
     border-bottom-right-radius: 0;
-    border-left: 1px solid $colour_nhsuk-grey-3;
+    border-left: 1px solid $color_nhsuk-grey-3;
     border-right: 0;
-    border-top: 1px solid $colour_nhsuk-grey-3;
+    border-top: 1px solid $color_nhsuk-grey-3;
     border-top-left-radius: $nhsuk-border-radius;
     border-top-right-radius: 0;
     flex-grow: 2;
@@ -170,12 +170,12 @@
     width: 100%; /* [2] */
 
     &:focus {
-      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-colour;
+      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
     }
   }
 
   .nhsuk-search__submit {
-    background-color: $colour_nhsuk-green;
+    background-color: $color_nhsuk-green;
     border: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: $nhsuk-border-radius;
@@ -190,7 +190,7 @@
     padding: nhsuk-spacing(2) nhsuk-spacing(2) 0;
 
     .nhsuk-icon__search {
-      fill: $colour_nhsuk-white;
+      fill: $color_nhsuk-white;
       height: 38px; /* [3] */
       width: 38px; /* [3] */
     }
@@ -200,16 +200,16 @@
     }
 
     &:hover {
-      background-color: $nhsuk-button-hover-colour;
+      background-color: $nhsuk-button-hover-color;
       cursor: pointer;
     }
 
     &:focus {
-      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-colour;
+      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
     }
 
     &:active {
-      background-color: $nhsuk-button-active-colour;
+      background-color: $nhsuk-button-active-color;
     }
 
   }
@@ -235,8 +235,8 @@
 
   .nhsuk-search__input {
     -webkit-appearance: listbox; // sass-lint:disable-line prefixes /* [5] */
-    background-color: $colour_nhsuk-white !important; // sass-lint:disable-line no-important /* [6] */
-    border: 1px solid $colour_nhsuk-white;
+    background-color: $color_nhsuk-white !important; // sass-lint:disable-line no-important /* [6] */
+    border: 1px solid $color_nhsuk-white;
     border-bottom-left-radius: $nhsuk-border-radius;
     border-bottom-right-radius: 0;
     border-top-left-radius: $nhsuk-border-radius;
@@ -249,19 +249,19 @@
     width: 235px; /* [2] */
 
     &:focus {
-      border: 1px solid $nhsuk-focus-colour;
-      box-shadow: inset 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-colour;
+      border: 1px solid $nhsuk-focus-color;
+      box-shadow: inset 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-color;
       outline: none;
     }
 
     &::placeholder {
-      color: $colour_nhsuk-grey-2;
+      color: $color_nhsuk-grey-2;
       font-size: $nhsuk-base-font-size;
     }
   }
 
   .nhsuk-search__submit {
-    background-color: $colour_nhsuk-grey-5;
+    background-color: $color_nhsuk-grey-5;
     border: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: $nhsuk-border-radius;
@@ -287,20 +287,20 @@
     }
 
     &:focus {
-      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-colour;
+      box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
     }
 
     &:hover {
-      background-color: $colour_shade_nhsuk-blue-35;
+      background-color: $color_shade_nhsuk-blue-35;
       cursor: pointer;
 
       .nhsuk-icon__search {
-        fill: $colour_nhsuk-white;
+        fill: $color_nhsuk-white;
       }
     }
 
     &:active {
-      background-color: $colour_shade_nhsuk-blue-50;
+      background-color: $color_shade_nhsuk-blue-50;
     }
 
   }
@@ -326,16 +326,16 @@
 }
 
 .suggestions-list {
-  -moz-box-shadow: 0 3px 5px 0 rgba($nhsuk-box-shadow-colour, $alpha-transparency-50); // sass-lint:disable-line no-vendor-prefixes, no-color-literals /* [8] */
-  -webkit-box-shadow: 0 3px 5px 0 rgba($nhsuk-box-shadow-colour, $alpha-transparency-50); // sass-lint:disable-line no-vendor-prefixes, no-color-literals /* [8] */
-  background-color: $colour_nhsuk-white;
-  border-bottom: 1px solid $colour_nhsuk-grey-4;
+  -moz-box-shadow: 0 3px 5px 0 rgba($nhsuk-box-shadow-color, $alpha-transparency-50); // sass-lint:disable-line no-vendor-prefixes, no-color-literals /* [8] */
+  -webkit-box-shadow: 0 3px 5px 0 rgba($nhsuk-box-shadow-color, $alpha-transparency-50); // sass-lint:disable-line no-vendor-prefixes, no-color-literals /* [8] */
+  background-color: $color_nhsuk-white;
+  border-bottom: 1px solid $color_nhsuk-grey-4;
   border-bottom-left-radius: $nhsuk-border-radius;
   border-bottom-right-radius: $nhsuk-border-radius;
-  border-left: 1px solid $colour_nhsuk-grey-4;
-  border-right: 1px solid $colour_nhsuk-grey-4;
-  border-top: 2px solid $colour_nhsuk-blue;
-  box-shadow: 0 0 ($nhsuk-box-shadow-spread - 1) 0 rgba($nhsuk-box-shadow-colour, $alpha-transparency-50); // sass-lint:disable-line no-color-literals /* [8] */
+  border-left: 1px solid $color_nhsuk-grey-4;
+  border-right: 1px solid $color_nhsuk-grey-4;
+  border-top: 2px solid $color_nhsuk-blue;
+  box-shadow: 0 0 ($nhsuk-box-shadow-spread - 1) 0 rgba($nhsuk-box-shadow-color, $alpha-transparency-50); // sass-lint:disable-line no-color-literals /* [8] */
   height: auto;
   list-style: none;
   margin-top: 0;
@@ -369,8 +369,8 @@
 }
 
 .suggestions-item {
-  border-bottom: 1px solid $colour_nhsuk-grey-5;
-  color: $colour_nhsuk-blue;
+  border-bottom: 1px solid $color_nhsuk-grey-5;
+  color: $color_nhsuk-blue;
   cursor: pointer;
   font-size: $nhsuk-base-font-size;
   font-weight: $nhsuk-font-light;
@@ -379,7 +379,7 @@
   text-decoration: underline;
 
   .nhsuk-icon__search {
-    fill: $colour_nhsuk-grey-3;
+    fill: $color_nhsuk-grey-3;
     float: left;
     height: 22px; /* [2] */
     margin: 5px 4px 0 0; /* [7] */
@@ -394,9 +394,9 @@
   &:hover,
   &:focus {
     div {
-      background-color: $colour_nhsuk-warm-yellow;
-      box-shadow: 0 0 0 $nhsuk-box-shadow-spread $colour_nhsuk-warm-yellow;
-      color: $colour_nhsuk-black;
+      background-color: $color_nhsuk-warm-yellow;
+      box-shadow: 0 0 0 $nhsuk-box-shadow-spread $color_nhsuk-warm-yellow;
+      color: $color_nhsuk-black;
       display: inline;
     }
   }
@@ -405,17 +405,17 @@
 
 .suggestions-item--selected {
   a {
-    background-color: $colour_nhsuk-warm-yellow;
-    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $colour_nhsuk-warm-yellow;
-    color: $colour_nhsuk-black;
+    background-color: $color_nhsuk-warm-yellow;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $color_nhsuk-warm-yellow;
+    color: $color_nhsuk-black;
     display: inline;
     text-decoration: none;
   }
 }
 
 .suggestions-title {
-  border-bottom: 1px solid $colour_nhsuk-grey-4;
-  color: $nhsuk-text-colour;
+  border-bottom: 1px solid $color_nhsuk-grey-4;
+  color: $nhsuk-text-color;
   font-size: $nhsuk-base-font-size;
   font-weight: $nhsuk-font-bold;
   padding-bottom: 12px; /* [9] */
@@ -479,7 +479,7 @@
 }
 
 .nhsuk-header__navigation {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   clear: both;
   display: none;
   overflow: hidden;
@@ -512,49 +512,49 @@
 }
 
 .nhsuk-header__navigation-item {
-  border-top: 1px solid $colour_nhsuk-grey-5;
+  border-top: 1px solid $color_nhsuk-grey-5;
   margin-bottom: 0;
   position: relative;
 }
 
 .nhsuk-header__navigation-link {
-  color: $colour_nhsuk-blue;
+  color: $color_nhsuk-blue;
   display: block;
   padding: nhsuk-spacing(3);
   text-decoration: none;
 
   .nhsuk-icon__chevron-right {
-    fill: $colour_nhsuk-grey-3;
+    fill: $color_nhsuk-grey-3;
     position: absolute;
     right: nhsuk-spacing(1);
     top: 11px;
   }
 
   &:hover {
-    background-color: $colour_nhsuk-blue;
+    background-color: $color_nhsuk-blue;
     box-shadow: none;
-    color: $colour_nhsuk-white;
+    color: $color_nhsuk-white;
     text-decoration: underline;
 
     .nhsuk-icon__chevron-right {
-      fill: $colour_nhsuk-white;
+      fill: $color_nhsuk-white;
     }
 
   }
 
   &:focus {
     background-color: transparent;
-    box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-colour;
-    color: $colour_nhsuk-blue;
+    box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
+    color: $color_nhsuk-blue;
   }
 
   &:active {
-    background-color: $colour_shade_nhsuk-blue-35;
+    background-color: $color_shade_nhsuk-blue-35;
     box-shadow: none;
-    color: $colour_nhsuk-white;
+    color: $color_nhsuk-white;
 
     .nhsuk-icon__chevron-right {
-      fill: $colour_nhsuk-white;
+      fill: $color_nhsuk-white;
     }
 
   }
@@ -580,14 +580,14 @@
   }
 
   .nhsuk-header__navigation {
-    background-color: $colour_nhsuk-blue;
+    background-color: $color_nhsuk-blue;
     display: block;
     margin: 0 auto;
     max-width: $nhsuk-page-width;
   }
 
   .nhsuk-header__navigation-list {
-    border-top: 1px solid $nhsuk-secondary-border-colour;
+    border-top: 1px solid $nhsuk-secondary-border-color;
     display: -ms-flexbox; /* [14] */
     display: flex; // sass-lint:disable-line no-duplicate-properties
     justify-content: space-between;
@@ -607,29 +607,29 @@
   }
 
   .nhsuk-header__navigation-link {
-    color: $colour_nhsuk-white;
+    color: $color_nhsuk-white;
     font-size: 17px;
     line-height: normal;
 
     &:visited {
-      color: $colour_nhsuk-white;
+      color: $color_nhsuk-white;
     }
 
     &:hover {
-      background-color: $colour_shade_nhsuk-blue-35;
+      background-color: $color_shade_nhsuk-blue-35;
     }
 
     &:focus {
-      color: $colour_nhsuk-white;
+      color: $color_nhsuk-white;
     }
 
     &:active {
-      background-color: $colour_shade_nhsuk-blue-50;
-      color: $colour_nhsuk-grey-5;
+      background-color: $color_shade_nhsuk-blue-50;
+      color: $color_nhsuk-grey-5;
     }
 
     &.active {
-      background-color: $colour_shade_nhsuk-blue-20;
+      background-color: $color_shade_nhsuk-blue-20;
     }
 
   }

--- a/packages/components/hero/_hero.scss
+++ b/packages/components/hero/_hero.scss
@@ -11,16 +11,16 @@
  */
 
 .nhsuk-c-hero {
-  background-color: $colour_nhsuk-blue;
-  color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-blue;
+  color: $color_nhsuk-white;
   position: relative; // [1] //
 
   @include mq($media-type: print) {
-    color: $colour_nhsuk-black;
+    color: $color_nhsuk-black;
   }
 
   .nhsuk-c-hero--border { // [2] //
-    border-top: $nhsuk-hero-border solid $nhsuk-secondary-border-colour;
+    border-top: $nhsuk-hero-border solid $nhsuk-secondary-border-color;
   }
 
 }
@@ -53,7 +53,7 @@
   }
 
   .nhsuk-c-hero__overlay {
-    background-color: $colour_transparent_nhsuk-blue-50; // [6] //
+    background-color: $color_transparent_nhsuk-blue-50; // [6] //
     height: 100%; // [7] //
   }
 
@@ -80,9 +80,9 @@
 
   .nhsuk-c-hero-content {
     @include top-and-bottom();
-    background-color: $colour_nhsuk-blue;
+    background-color: $color_nhsuk-blue;
     bottom: -48px; // [9] //
-    color: $colour_nhsuk-white;
+    color: $color_nhsuk-white;
     max-width: 565px; // [10] //
     padding: nhsuk-spacing(5) nhsuk-spacing(6);
     position: absolute;
@@ -99,7 +99,7 @@
     }
 
     @include mq($media-type: print) {
-      color: $colour_nhsuk-black;
+      color: $color_nhsuk-black;
       left: 0;
       max-width: 100%;
       padding: 0;
@@ -111,7 +111,7 @@
       clip-path: polygon(0 0, 50% 100%, 100% 0); // sass-lint:disable-line property-sort-order // [12] //
       border-left: $nhsuk-hero-content-triangle-border solid transparent; // sass-lint:disable-line property-sort-order
       border-right: $nhsuk-hero-content-triangle-border solid transparent; // sass-lint:disable-line property-sort-order
-      border-top: $nhsuk-hero-content-triangle-border solid $colour_nhsuk-blue; // sass-lint:disable-line property-sort-order
+      border-top: $nhsuk-hero-content-triangle-border solid $color_nhsuk-blue; // sass-lint:disable-line property-sort-order
       bottom: -15px; // sass-lint:disable-line property-sort-order
       content: '';
       display: block;

--- a/packages/components/images/_images.scss
+++ b/packages/components/images/_images.scss
@@ -10,8 +10,8 @@
  */
 
 .nhsuk-c-image {
-  background-color: $colour_nhsuk-white;
-  border-bottom: 1px solid $colour_nhsuk-grey-4;
+  background-color: $color_nhsuk-white;
+  border-bottom: 1px solid $color_nhsuk-grey-4;
 
   @include nhsuk-responsive-margin(6, 'bottom');
   @include nhsuk-responsive-margin(6, 'top');

--- a/packages/components/inset-text/_inset-text.scss
+++ b/packages/components/inset-text/_inset-text.scss
@@ -16,10 +16,10 @@
   @include nhsuk-responsive-margin(7, 'bottom');
   @include nhsuk-responsive-margin(7, 'top');
 
-  border-left: $nhsuk-border-width-inset-text solid $colour_nhsuk-blue;
+  border-left: $nhsuk-border-width-inset-text solid $color_nhsuk-blue;
   padding: nhsuk-spacing(3);
 
   @include mq($media-type: print) {
-    border-color: $nhsuk-print-text-colour;
+    border-color: $nhsuk-print-text-color;
   }
 }

--- a/packages/components/list-panel/_list-panel.scss
+++ b/packages/components/list-panel/_list-panel.scss
@@ -24,14 +24,14 @@
 .nhsuk-c-list-panel__label {
   @include nhsuk-typography-responsive(32);
 
-  background-color: $colour_nhsuk-blue;
-  color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-blue;
+  color: $color_nhsuk-white;
   display: inline-block; /* [1] */
   margin-bottom: 0; /* [2] */
   padding: nhsuk-spacing(2) nhsuk-spacing(3);
 
   @include mq($media-type: print) {
-    color: $colour_nhsuk-black;
+    color: $color_nhsuk-black;
     margin-top: 0;
   }
 
@@ -39,7 +39,7 @@
 
 .nhsuk-c-list-panel__list,
 .nhsuk-c-list-panel__box {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   margin: 0;
   padding: 0;
 
@@ -51,7 +51,7 @@
 
 .nhsuk-c-list-panel__list--with-label,
 .nhsuk-c-list-panel__box--with-label {
-  border-top: $nhsuk-border-list-panel solid $colour_nhsuk-blue;
+  border-top: $nhsuk-border-list-panel solid $color_nhsuk-blue;
   margin: -28px 0 0; /* [3] */
   padding: 27px 0 0; /* [3] */
 
@@ -63,23 +63,23 @@
 }
 
 .nhsuk-c-list-panel__item {
-  background-color: $colour_nhsuk-white;
+  background-color: $color_nhsuk-white;
   list-style: none; /* [4] */
   margin-bottom: 0;
 }
 
 .nhsuk-c-list-panel__link {
-  border-bottom: $nhsuk-border-list-panel-item solid $colour_nhsuk-grey-4;
+  border-bottom: $nhsuk-border-list-panel-item solid $color_nhsuk-grey-4;
   display: block;
   padding: 12px nhsuk-spacing(3);
   text-decoration: none;
 
   &:hover {
-    box-shadow: 0 -1px 0 0 $nhsuk-link-hover-background-colour; /* [5] */
+    box-shadow: 0 -1px 0 0 $nhsuk-link-hover-background-color; /* [5] */
   }
 
   &:focus {
-    box-shadow: 0 -1px 0 0 $nhsuk-link-focus-background-colour; /* [5] */
+    box-shadow: 0 -1px 0 0 $nhsuk-link-focus-background-color; /* [5] */
   }
 
   &:hover,
@@ -95,8 +95,8 @@
 }
 
 .nhsuk-c-list-panel--results-items__no-results {
-  border-bottom: $nhsuk-border-list-panel-item solid $colour_nhsuk-grey-4;
-  color: $nhsuk-secondary-text-colour;
+  border-bottom: $nhsuk-border-list-panel-item solid $color_nhsuk-grey-4;
+  color: $nhsuk-secondary-text-color;
   margin: 0;
   padding: nhsuk-spacing(3);
 }
@@ -137,7 +137,7 @@
   .nhsuk-icon {
     -ms-transform: rotate(270deg);
     -webkit-transform: rotate(270deg);
-    fill: $colour_nhsuk-blue; /* [4] */
+    fill: $color_nhsuk-blue; /* [4] */
     height: 19px; /* [5] */
     left: -8px; /* [6] */
     position: absolute;
@@ -152,15 +152,15 @@
   }
 
   &:visited {
-    color: $colour_nhsuk-blue;
+    color: $color_nhsuk-blue;
   }
 
   &:hover,
   &:focus {
-    color: $nhsuk-link-hover-colour;
+    color: $nhsuk-link-hover-color;
 
     .nhsuk-icon {
-      fill: $nhsuk-link-hover-colour;
+      fill: $nhsuk-link-hover-color;
     }
 
   }

--- a/packages/components/nav-a-z/_nav-a-z.scss
+++ b/packages/components/nav-a-z/_nav-a-z.scss
@@ -47,15 +47,15 @@
 }
 
 .nhsuk-nav-a-z__link--disabled {
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
   margin-bottom: 0;
 }
 
 .nhsuk-nav-a-z__link {
 
   &.active {
-    background-color: $colour_nhsuk-blue;
-    color: $colour_nhsuk-white;
+    background-color: $color_nhsuk-blue;
+    color: $color_nhsuk-white;
   }
 
 }

--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -22,7 +22,7 @@
   width: 50%;
 
   @include mq($media-type: print) {
-    color: $colour_nhsuk-black;
+    color: $color_nhsuk-black;
   }
 
   .nhsuk-icon {
@@ -30,18 +30,18 @@
     top: -2px;
 
     @include mq($media-type: print) {
-      color: $colour_nhsuk-black;
+      color: $color_nhsuk-black;
       margin-top: 0;
     }
 
   }
 
   &:focus {
-    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-focus-background-colour;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-focus-background-color;
   }
 
   &:hover {
-    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-hover-background-colour;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-hover-background-color;
 
     .nhsuk-pagination__page {
       text-decoration: none;
@@ -53,7 +53,7 @@
   &:focus {
 
     .nhsuk-icon {
-      fill: $colour_nhsuk-black;
+      fill: $color_nhsuk-black;
     }
 
   }
@@ -61,7 +61,7 @@
   &:visited {
 
     .nhsuk-icon {
-      fill: $nhsuk-link-visited-colour;
+      fill: $nhsuk-link-visited-color;
     }
 
   }

--- a/packages/components/panel/_panel.scss
+++ b/packages/components/panel/_panel.scss
@@ -3,26 +3,26 @@
    ========================================================================== */
 
 .nhsuk-c-panel {
-  @include panel($colour_nhsuk-white, $nhsuk-text-colour);
+  @include panel($color_nhsuk-white, $nhsuk-text-color);
 }
 
 /* Panel colour variant
    ========================================================================== */
 
 .nhsuk-c-panel--grey {
-  background-color: $colour_nhsuk-grey-5;
+  background-color: $color_nhsuk-grey-5;
 }
 
 /* Panel with label
    ========================================================================== */
 
 .nhsuk-c-panel-with-label {
-  @include panel-with-label($colour_nhsuk-white, $nhsuk-text-colour);
+  @include panel-with-label($color_nhsuk-white, $nhsuk-text-color);
 }
 
 .nhsuk-c-panel-with-label__label {
-  @include heading-label($colour_nhsuk-blue, $colour_nhsuk-white);
-  @include print-colour($nhsuk-print-text-colour);
+  @include heading-label($color_nhsuk-blue, $color_nhsuk-white);
+  @include print-color($nhsuk-print-text-color);
 }
 
 /* Panel group

--- a/packages/components/promo/_promo.scss
+++ b/packages/components/promo/_promo.scss
@@ -20,16 +20,16 @@
 }
 
 .nhsuk-c-promo__link-wrapper {
-  background-color: $colour_nhsuk-white;
-  box-shadow: 0 $nhsuk-box-shadow-link 0 0 $colour_nhsuk-grey-4; /* [2] */
+  background-color: $color_nhsuk-white;
+  box-shadow: 0 $nhsuk-box-shadow-link 0 0 $color_nhsuk-grey-4; /* [2] */
   display: block;
   height: 100%; /* [3] */
   position: relative; /* [4] */
   text-decoration: none; /* [5] */
 
   &:focus {
-    background-color: $colour_nhsuk-white;
-    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-focus-colour;
+    background-color: $color_nhsuk-white;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-focus-color;
 
     .nhsuk-c-promo__heading {
       text-decoration: underline; /* [6] */
@@ -37,20 +37,20 @@
 
     .nhsuk-c-promo__heading,
     .nhsuk-c-promo__description {
-      color: $nhsuk-link-focus-colour;
+      color: $nhsuk-link-focus-color;
     }
 
   }
 
   &:hover {
-    background-color: $colour_nhsuk-white;
-    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-focus-colour;
-    color: $colour_nhsuk-blue;
+    background-color: $color_nhsuk-white;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-focus-color;
+    color: $color_nhsuk-blue;
   }
 
   &:active {
-    background-color: $colour_nhsuk-grey-5; /* [7] */
-    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-link-active-background-colour;
+    background-color: $color_nhsuk-grey-5; /* [7] */
+    box-shadow: 0 0 0 $nhsuk-box-shadow-link $nhsuk-link-active-background-color;
     top: $nhsuk-box-shadow-link; /* [7] */
   }
 
@@ -64,7 +64,7 @@
 }
 
 .nhsuk-c-promo__img {
-  border-bottom: 1px solid $colour_nhsuk-grey-5; /* [8] */
+  border-bottom: 1px solid $color_nhsuk-grey-5; /* [8] */
   display: block;
   width: 100%;
 
@@ -85,7 +85,7 @@
 }
 
 .nhsuk-c-promo__description {
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
 }
 
 /* Promo size variant

--- a/packages/components/review-date/_review-date.scss
+++ b/packages/components/review-date/_review-date.scss
@@ -4,5 +4,5 @@
 
 .nhsuk-c-review-date {
   @include nhsuk-responsive-margin(7, 'top');
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
 }

--- a/packages/components/skip-link/_skip-link.scss
+++ b/packages/components/skip-link/_skip-link.scss
@@ -20,7 +20,7 @@
   }
 
   &:visited {
-    color: $colour_nhsuk-black;
+    color: $color_nhsuk-black;
   }
 
 }

--- a/packages/components/tables/_tables.scss
+++ b/packages/components/tables/_tables.scss
@@ -12,7 +12,7 @@
 
 .nhsuk-table__row {
   &:hover {
-    background-color: $colour_nhsuk-grey-5;
+    background-color: $color_nhsuk-grey-5;
   }
 }
 
@@ -24,7 +24,7 @@
  */
 
 .nhsuk-table__panel-with-heading-tab {
-  @include panel-with-label($colour_nhsuk-white, $nhsuk-text-colour);
+  @include panel-with-label($color_nhsuk-white, $nhsuk-text-color);
 
   .nhsuk-table-responsive,
   .nhsuk-table {
@@ -33,7 +33,7 @@
 }
 
 .nhsuk-table__heading-tab {
-  @include heading-label($colour_nhsuk-blue, $colour_nhsuk-white);
+  @include heading-label($color_nhsuk-blue, $color_nhsuk-white);
 }
 
 /* Responsive table

--- a/packages/components/warning-callout/_warning-callout.scss
+++ b/packages/components/warning-callout/_warning-callout.scss
@@ -8,9 +8,9 @@
  */
 
 .nhsuk-c-warning-callout {
-  @include panel-with-label($colour_nhsuk-pale-yellow, $nhsuk-text-colour); /* [1] */
+  @include panel-with-label($color_nhsuk-pale-yellow, $nhsuk-text-color); /* [1] */
 }
 
 .nhsuk-c-warning-callout__label {
-  @include heading-label($colour_nhsuk-yellow, $nhsuk-text-colour); /* [2] */
+  @include heading-label($color_nhsuk-yellow, $nhsuk-text-color); /* [2] */
 }

--- a/packages/core/elements/_links.scss
+++ b/packages/core/elements/_links.scss
@@ -17,7 +17,7 @@ a {
 
   @include mq($media-type: print) {
     &:after {
-      color: $colour_nhsuk-black;
+      color: $color_nhsuk-black;
       content: ' (Link: ' attr(href) ')'; /* [1] */
       font-size: 14pt; /* [2] */
     }

--- a/packages/core/elements/_page.scss
+++ b/packages/core/elements/_page.scss
@@ -16,7 +16,7 @@
  */
 
 html {
-  background-color: $colour_nhsuk-blue;
+  background-color: $color_nhsuk-blue;
   font-family: $nhsuk-font, $nhsuk-font-fallback;
   overflow-y: scroll; /* [1] */
 }
@@ -24,8 +24,8 @@ html {
 body {
   -moz-osx-font-smoothing: grayscale; /* [2] */
   -webkit-font-smoothing: antialiased; /* [2] */
-  background-color: $colour_nhsuk-grey-5;
-  color: $nhsuk-text-colour;
+  background-color: $color_nhsuk-grey-5;
+  color: $nhsuk-text-color;
   font-size: $nhsuk-base-font-size;
   line-height: _nhsuk-line-height($nhsuk-base-line-height, $nhsuk-base-font-size);
   margin: 0; /* [3] */

--- a/packages/core/elements/_table.scss
+++ b/packages/core/elements/_table.scss
@@ -24,7 +24,7 @@ table {
 
 thead {
   th {
-    border-bottom: $nhsuk-border-table-header-width solid $nhsuk-border-colour;
+    border-bottom: $nhsuk-border-table-header-width solid $nhsuk-border-color;
   }
 }
 
@@ -33,7 +33,7 @@ td {
   @include nhsuk-typography-responsive(19);
   @include nhsuk-responsive-padding(3);
 
-  border-bottom: $nhsuk-border-table-cell-width solid $nhsuk-border-colour;
+  border-bottom: $nhsuk-border-table-cell-width solid $nhsuk-border-color;
   text-align: left;
 }
 

--- a/packages/core/settings/_colours.scss
+++ b/packages/core/settings/_colours.scss
@@ -4,40 +4,43 @@
 
 //
 // NHS colour palette
-// Colours are prefixed with colour_ to make them easier to
+//
+// Colours are prefixed with color_ to make them easier to
 // search for within the code base.
+//
 // We also prefix them with nhsuk- to prevent clashing with
 // other colours in existing code bases.
+//
+// We use the word color, not colour, for variables.
 //
 
 // sass-lint:disable no-color-hex
 
-$colour_nhsuk-blue: #005EB8;
-$colour_nhsuk-white: #FFFFFF;
-$colour_nhsuk-black: #212B32;
-$colour_nhsuk-green: #007F3B;
-$colour_nhsuk-red: #DA291C;
-$colour_nhsuk-yellow: #ffeb3b;
-$colour_nhsuk-purple: #330072;
+$color_nhsuk-blue: #005eb8;
+$color_nhsuk-white: #ffffff;
+$color_nhsuk-black: #212b32;
+$color_nhsuk-green: #007f3b;
+$color_nhsuk-red: #da291c;
+$color_nhsuk-yellow: #ffeb3b;
+$color_nhsuk-purple: #330072;
 
 //
 // Secondary colours
 //
 
-$colour_nhsuk-pale-yellow: #FFFBCE;
-$colour_nhsuk-pale-yellow: #fff9c4;
-$colour_nhsuk-warm-yellow: #FFB81C;
-$colour_nhsuk-aqua-green: #00A499;
+$color_nhsuk-pale-yellow: #fff9c4;
+$color_nhsuk-warm-yellow: #ffb81C;
+$color_nhsuk-aqua-green: #00A499;
 
 //
 // Greyscale
 //
 
-$colour_nhsuk-grey-1: #425563;
-$colour_nhsuk-grey-2: #768692;
-$colour_nhsuk-grey-3: #AEB7BD;
-$colour_nhsuk-grey-4: #D8DDE0;
-$colour_nhsuk-grey-5: #f0f4f5;
+$color_nhsuk-grey-1: #425563;
+$color_nhsuk-grey-2: #768692;
+$color_nhsuk-grey-3: #aeb7bd;
+$color_nhsuk-grey-4: #d8dde0;
+$color_nhsuk-grey-5: #f0f4f5;
 
 
 //
@@ -46,17 +49,17 @@ $colour_nhsuk-grey-5: #f0f4f5;
 // Used to create drop/box shadows e.g. for search suggestions dropdown
 //
 
-$colour_nhsuk-grey-1-rgb: rgb(66, 84, 98);
+$color_nhsuk-grey-1-rgb: rgb(66, 84, 98);
 $alpha-transparency-50: .5;
 
 
 //
 // Functions for tint and shade
 //
-// Usage: tint(colour, percentage)
-//        tint($colour_nhsuk-black, 10%)
-//        shade(colour, percentage)
-//        shade($colour_nhsuk-blue, 50%)
+// Usage: tint(color, percentage)
+//        tint($color_nhsuk-black, 10%)
+//        shade(color, percentage)
+//        shade($color_nhsuk-blue, 50%)
 //
 
 @function tint($color, $percentage) {
@@ -80,46 +83,46 @@ $alpha-transparency-50: .5;
 // 8. used for link :active states
 //
 
-$colour_tint_nhsuk-black-10: tint($colour_nhsuk-black, 10%); // [1] //
+$color_tint_nhsuk-black-10: tint($color_nhsuk-black, 10%); // [1] //
 
-$colour_shade_nhsuk-blue-20: shade($colour_nhsuk-blue, 20%); // [2] //
-$colour_shade_nhsuk-blue-35: shade($colour_nhsuk-blue, 35%); // [3] //
-$colour_shade_nhsuk-blue-50: shade($colour_nhsuk-blue, 50%); // [4] //
+$color_shade_nhsuk-blue-20: shade($color_nhsuk-blue, 20%); // [2] //
+$color_shade_nhsuk-blue-35: shade($color_nhsuk-blue, 35%); // [3] //
+$color_shade_nhsuk-blue-50: shade($color_nhsuk-blue, 50%); // [4] //
 
-$colour_shade_nhsuk-green-35: shade($colour_nhsuk-green, 35%); // [5] //
-$colour_shade_nhsuk-green-50: shade($colour_nhsuk-green, 50%); // [6] //
+$color_shade_nhsuk-green-35: shade($color_nhsuk-green, 35%); // [5] //
+$color_shade_nhsuk-green-50: shade($color_nhsuk-green, 50%); // [6] //
 
-$colour_tint_nhsuk-warm-yellow-30: tint($colour_nhsuk-warm-yellow, 30%); // [7] //
-$colour_tint_nhsuk-warm-yellow-10: tint($colour_nhsuk-warm-yellow, 10%); // [8] //
+$color_tint_nhsuk-warm-yellow-30: tint($color_nhsuk-warm-yellow, 30%); // [7] //
+$color_tint_nhsuk-warm-yellow-10: tint($color_nhsuk-warm-yellow, 10%); // [8] //
 
-$colour_transparent_nhsuk-white-20: rgba($colour_nhsuk-white, .2);
-$colour_transparent_nhsuk-blue-50: rgba($colour_shade_nhsuk-blue-50, .1);
+$color_transparent_nhsuk-white-20: rgba($color_nhsuk-white, .2);
+$color_transparent_nhsuk-blue-50: rgba($color_shade_nhsuk-blue-50, .1);
 
 //
 // Colour aliases
 //
 
-$nhsuk-text-colour: $colour_nhsuk-black;
-$nhsuk-secondary-text-colour: $colour_nhsuk-grey-1;
-$nhsuk-print-text-colour: $colour_nhsuk-black;
+$nhsuk-text-color: $color_nhsuk-black;
+$nhsuk-secondary-text-color: $color_nhsuk-grey-1;
+$nhsuk-print-text-color: $color_nhsuk-black;
 
-$nhsuk-link-colour: $colour_nhsuk-blue;
-$nhsuk-link-hover-colour: $colour_nhsuk-black;
-$nhsuk-link-focus-colour: $colour_nhsuk-black;
-$nhsuk-link-active-colour: $colour_tint_nhsuk-black-10;
-$nhsuk-link-visited-colour: $colour_nhsuk-purple;
-$nhsuk-link-hover-background-colour: $colour_tint_nhsuk-warm-yellow-30;
-$nhsuk-link-focus-background-colour: $colour_nhsuk-warm-yellow;
-$nhsuk-link-active-background-colour: $colour_tint_nhsuk-warm-yellow-10;
+$nhsuk-link-color: $color_nhsuk-blue;
+$nhsuk-link-hover-color: $color_nhsuk-black;
+$nhsuk-link-focus-color: $color_nhsuk-black;
+$nhsuk-link-active-color: $color_tint_nhsuk-black-10;
+$nhsuk-link-visited-color: $color_nhsuk-purple;
+$nhsuk-link-hover-background-color: $color_tint_nhsuk-warm-yellow-30;
+$nhsuk-link-focus-background-color: $color_nhsuk-warm-yellow;
+$nhsuk-link-active-background-color: $color_tint_nhsuk-warm-yellow-10;
 
-$nhsuk-border-colour: $colour_nhsuk-grey-4;
-$nhsuk-secondary-border-colour: $colour_transparent_nhsuk-white-20;
+$nhsuk-border-color: $color_nhsuk-grey-4;
+$nhsuk-secondary-border-color: $color_transparent_nhsuk-white-20;
 $nhsuk-box-shadow: rgba(33, 43, 50, .16);
 
-$nhsuk-button-hover-colour: $colour_shade_nhsuk-green-35;
-$nhsuk-button-active-colour: $colour_shade_nhsuk-green-50;
-$nhsuk-secondary-button-hover-colour: $colour_shade_nhsuk-blue-35;
+$nhsuk-button-hover-color: $color_shade_nhsuk-green-35;
+$nhsuk-button-active-color: $color_shade_nhsuk-green-50;
+$nhsuk-secondary-button-hover-color: $color_shade_nhsuk-blue-35;
 
-$nhsuk-focus-colour: $colour_nhsuk-warm-yellow;
+$nhsuk-focus-color: $color_nhsuk-warm-yellow;
 
-$nhsuk-box-shadow-colour: $colour_nhsuk-grey-1-rgb;
+$nhsuk-box-shadow-color: $color_nhsuk-grey-1-rgb;

--- a/packages/core/styles/_icons.scss
+++ b/packages/core/styles/_icons.scss
@@ -20,40 +20,40 @@
    ========================================================================== */
 
 .nhsuk-icon__search {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__chevron-left {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__chevron-right {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__close {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__cross {
-  fill: $colour_nhsuk-red;
+  fill: $color_nhsuk-red;
 }
 
 .nhsuk-icon__tick {
   fill: none;
-  stroke: $colour_nhsuk-green;
+  stroke: $color_nhsuk-green;
 }
 
 .nhsuk-icon__arrow-right {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__arrow-left {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
 }
 
 .nhsuk-icon__arrow-right-circle {
-  fill: $colour_nhsuk-green;
+  fill: $color_nhsuk-green;
 }
 
 .nhsuk-icon__chevron-down {
@@ -62,16 +62,16 @@
   -o-transform: rotate(180deg);
   -webkit-transform: rotate(180deg);
   transform: rotate(180deg); // sass-lint:disable-line property-sort-order
-  fill: $colour_nhsuk-blue; // sass-lint:disable-line property-sort-order
+  fill: $color_nhsuk-blue; // sass-lint:disable-line property-sort-order
   path {
-    fill: $colour_nhsuk-white;
+    fill: $color_nhsuk-white;
   }
 }
 
 .nhsuk-icon__chevron-up {
-  fill: $colour_nhsuk-blue;
+  fill: $color_nhsuk-blue;
   path {
-    fill: $colour_nhsuk-white;
+    fill: $color_nhsuk-white;
   }
 }
 

--- a/packages/core/styles/_section-break.scss
+++ b/packages/core/styles/_section-break.scss
@@ -55,7 +55,7 @@
 }
 
 %nhsuk-section-break--visible {
-  border-bottom: 1px solid $nhsuk-border-colour;
+  border-bottom: 1px solid $nhsuk-border-color;
 }
 
 .nhsuk-section-break--visible {

--- a/packages/core/styles/_typography.scss
+++ b/packages/core/styles/_typography.scss
@@ -111,7 +111,7 @@ h6,
 .nhsuk-caption-xl {
   @include nhsuk-font($size: 32);
 
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
   display: block;
   margin-bottom: nhsuk-spacing(1);
 }
@@ -119,7 +119,7 @@ h6,
 .nhsuk-caption-l {
   @include nhsuk-font($size: 24);
 
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
   display: block;
   margin-bottom: nhsuk-spacing(1);
 }
@@ -127,7 +127,7 @@ h6,
 .nhsuk-caption-m {
   @include nhsuk-font($size: 19);
 
-  color: $nhsuk-secondary-text-colour;
+  color: $nhsuk-secondary-text-color;
   display: block;
 }
 

--- a/packages/core/tools/_links.scss
+++ b/packages/core/tools/_links.scss
@@ -10,28 +10,28 @@
 
 @mixin nhsuk-link-style-default {
 
-  color: $nhsuk-link-colour;
+  color: $nhsuk-link-color;
 
   &:visited {
-    color: $nhsuk-link-visited-colour;
+    color: $nhsuk-link-visited-color;
   }
 
   &:focus {
-    background-color: $nhsuk-link-focus-background-colour;
-    box-shadow: 0 0 0 4px $nhsuk-link-focus-background-colour;
-    color: $nhsuk-link-focus-colour;
+    background-color: $nhsuk-link-focus-background-color;
+    box-shadow: 0 0 0 4px $nhsuk-link-focus-background-color;
+    color: $nhsuk-link-focus-color;
     outline: 0;
   }
 
   &:hover {
-    background-color: $nhsuk-link-hover-background-colour;
-    box-shadow: 0 0 0 4px $nhsuk-link-hover-background-colour;
-    color: $nhsuk-link-hover-colour;
+    background-color: $nhsuk-link-hover-background-color;
+    box-shadow: 0 0 0 4px $nhsuk-link-hover-background-color;
+    color: $nhsuk-link-hover-color;
     text-decoration: none;
   }
 
   &:active {
-    color: $nhsuk-link-active-colour;
+    color: $nhsuk-link-active-color;
   }
 
 }
@@ -44,24 +44,24 @@
 
 @mixin nhsuk-link-style-inverted {
 
-  color: $nhsuk-link-colour;
+  color: $nhsuk-link-color;
 
   &:focus {
-    background-color: $colour_shade_nhsuk-blue-35;
-    box-shadow: 0 0 0 4px $colour_shade_nhsuk-blue-35;
-    color: $colour_nhsuk-white;
+    background-color: $color_shade_nhsuk-blue-35;
+    box-shadow: 0 0 0 4px $color_shade_nhsuk-blue-35;
+    color: $color_nhsuk-white;
   }
 
   &:hover {
-    background-color: $colour_nhsuk-blue;
-    box-shadow: 0 0 0 4px $colour_nhsuk-blue;
-    color: $colour_nhsuk-white;
+    background-color: $color_nhsuk-blue;
+    box-shadow: 0 0 0 4px $color_nhsuk-blue;
+    color: $color_nhsuk-white;
   }
 
   &:active {
-    background-color: $colour_shade_nhsuk-blue-50;
-    box-shadow: 0 0 0 4px $colour_shade_nhsuk-blue-35;
-    color: $colour_nhsuk-white;
+    background-color: $color_shade_nhsuk-blue-50;
+    box-shadow: 0 0 0 4px $color_shade_nhsuk-blue-35;
+    color: $color_nhsuk-white;
   }
 
 }
@@ -74,22 +74,22 @@
 
 @mixin nhsuk-link-style-white {
 
-  color: $colour_nhsuk-white;
+  color: $color_nhsuk-white;
 
   &:visited {
-    color: $colour_nhsuk-grey-5;
+    color: $color_nhsuk-grey-5;
   }
 
   &:focus {
-    color: $nhsuk-link-focus-colour;
+    color: $nhsuk-link-focus-color;
   }
 
   &:hover {
-    color: $nhsuk-link-hover-colour;
+    color: $nhsuk-link-hover-color;
   }
 
   &:active {
-    color: $nhsuk-link-active-colour;
+    color: $nhsuk-link-active-color;
   }
 
 }
@@ -102,9 +102,9 @@
 
 @mixin nhsuk-link-style-hover {
   &:hover {
-    background-color: $nhsuk-link-hover-background-colour;
-    box-shadow: 0 0 0 4px $nhsuk-link-hover-background-colour;
-    color: $nhsuk-link-hover-colour;
+    background-color: $nhsuk-link-hover-background-color;
+    box-shadow: 0 0 0 4px $nhsuk-link-hover-background-color;
+    color: $nhsuk-link-hover-color;
     text-decoration: none;
   }
 }
@@ -117,9 +117,9 @@
 
 @mixin nhsuk-link-style-focus {
   &:focus {
-    background-color: $nhsuk-link-focus-background-colour;
-    box-shadow: 0 0 0 4px $nhsuk-link-focus-background-colour;
-    color: $nhsuk-link-focus-colour;
+    background-color: $nhsuk-link-focus-background-color;
+    box-shadow: 0 0 0 4px $nhsuk-link-focus-background-color;
+    color: $nhsuk-link-focus-color;
     outline: 0;
   }
 }

--- a/packages/core/tools/_mixins.scss
+++ b/packages/core/tools/_mixins.scss
@@ -68,22 +68,22 @@
 //
 // Panel mixin
 //
-// Usage: @include panel-with-label($colour_nhsuk-blue, $colour_nhsuk-white);
+// Usage: @include panel-with-label($color_nhsuk-blue, $color_nhsuk-white);
 // See components/_panel
 //
 
-@mixin panel($panel-background-colour, $panel-text-colour) {
+@mixin panel($panel-background-color, $panel-text-color) {
 
   @include top-and-bottom();
   @include nhsuk-responsive-margin(7, 'bottom');
   @include nhsuk-responsive-margin(7, 'top');
   @include nhsuk-responsive-padding(5);
 
-  background-color: $panel-background-colour;
-  color: $panel-text-colour;
+  background-color: $panel-background-color;
+  color: $panel-text-color;
 
   @include mq($media-type: print) {
-    border: 1px solid $nhsuk-print-text-colour;
+    border: 1px solid $nhsuk-print-text-color;
     page-break-inside: avoid;
   }
 
@@ -95,12 +95,12 @@
 //
 // Used in-conjunction with @mixin heading-label
 //
-// Usage: @include panel-with-label($colour_nhsuk-blue, $colour_nhsuk-white);
+// Usage: @include panel-with-label($color_nhsuk-blue, $color_nhsuk-white);
 // See components/_warning-component
 //
 
-@mixin panel-with-label($panel-background-colour, $panel-text-colour) {
-  @include panel($panel-background-colour, $panel-text-colour);
+@mixin panel-with-label($panel-background-color, $panel-text-color) {
+  @include panel($panel-background-color, $panel-text-color);
 
   padding-top: 0 !important;  // sass-lint:disable-line no-important
 }
@@ -111,7 +111,7 @@
 //
 // Used in-conjunction with @mixin panel-with-label
 //
-// Usage: @include heading-label($colour_nhsuk-blue, $colour_nhsuk-white);
+// Usage: @include heading-label($color_nhsuk-blue, $color_nhsuk-white);
 // See components/_warning-component
 //
 // 1. Background colour to be set on the @include.
@@ -122,11 +122,11 @@
 //    sit just outside the box.
 //
 
-@mixin heading-label($heading-background-colour, $heading-text-colour) {
+@mixin heading-label($heading-background-color, $heading-text-color) {
   @include nhsuk-typography-responsive(24);
 
-  background-color: $heading-background-colour; // [1] //
-  color: $heading-text-colour; // [2] //
+  background-color: $heading-background-color; // [1] //
+  color: $heading-text-color; // [2] //
   display: inline-block; // [3] //
   margin: nhsuk-spacing(0) -32px nhsuk-spacing(2);
   padding: nhsuk-spacing(2) nhsuk-spacing(5);
@@ -142,7 +142,7 @@
 
   @include mq($media-type: print) {
     background: none;
-    color: $colour_nhsuk-black;
+    color: $color_nhsuk-black;
     top: 0;
   }
 }
@@ -151,15 +151,15 @@
 // Care card mixin, used for creating
 // different coloured care cards.
 //
-// Usage: @include care-card($colour_nhsuk-blue, $colour_nhsuk-white, 4px);
+// Usage: @include care-card($color_nhsuk-blue, $color_nhsuk-white, 4px);
 // See components/_care-card
 //
 
-@mixin care-card($heading-background-color, $heading-text-colour, $print-border-size) {
+@mixin care-card($heading-background-color, $heading-text-color, $print-border-size) {
 
   .nhsuk-c-care-card__heading-container {
     background-color: $heading-background-color;
-    color: $heading-text-colour;
+    color: $heading-text-color;
 
     &:after {
       border-top: $nhsuk-care-card-triangle-border solid $heading-background-color;
@@ -167,8 +167,8 @@
   }
 
   @include mq($media-type: print) {
-    border: $print-border-size solid $nhsuk-print-text-colour;
-    color: $nhsuk-print-text-colour;
+    border: $print-border-size solid $nhsuk-print-text-color;
+    color: $nhsuk-print-text-color;
     page-break-inside: avoid;
   }
 }
@@ -177,14 +177,14 @@
 // Print colour mixin, sets the text print colour
 // warning callout, do and don't lists and panels.
 //
-// Usage: @include print-colour($nhsuk-print-text-colour);
+// Usage: @include print-color($nhsuk-print-text-color);
 // See components/_care-card
 //
 
-@mixin print-colour($print-colour) {
+@mixin print-color($print-color) {
 
   @include mq($media-type: print) {
-    color: $print-colour;
+    color: $print-color;
   }
 
 }
@@ -241,9 +241,9 @@
 
 @mixin toggle-button() {
   background-color: transparent;
-  border: 1px solid $colour_nhsuk-white;
+  border: 1px solid $color_nhsuk-white;
   border-radius: $nhsuk-border-radius;
-  color: $colour_nhsuk-white;
+  color: $color_nhsuk-white;
   cursor: pointer;
 
 
@@ -252,29 +252,29 @@
   }
 
   &:hover {
-    background-color: $colour_shade_nhsuk-blue-35;
-    border-color: $colour_nhsuk-grey-5;
+    background-color: $color_shade_nhsuk-blue-35;
+    border-color: $color_nhsuk-grey-5;
     box-shadow: none;
   }
 
   &:focus {
     background-color: transparent;
-    border-color: $nhsuk-focus-colour;
-    box-shadow: 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-colour;
+    border-color: $nhsuk-focus-color;
+    box-shadow: 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-color;
     outline: 0;
   }
 
   &:active,
   &.active {
-    background-color: $colour_shade_nhsuk-blue-50;
-    border-color: $colour_nhsuk-grey-5;
+    background-color: $color_shade_nhsuk-blue-50;
+    border-color: $color_nhsuk-grey-5;
     box-shadow: none;
-    color: $colour_nhsuk-grey-5;
+    color: $color_nhsuk-grey-5;
   }
 
   &.active {
     &:focus {
-      box-shadow: 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-colour;
+      box-shadow: 0 0 0 ($nhsuk-box-shadow-spread - 1) $nhsuk-focus-color;
     }
   }
 
@@ -302,7 +302,7 @@
   width: 40px; // [1] //
 
   .nhsuk-icon__close {
-    fill: $colour_nhsuk-blue;
+    fill: $color_nhsuk-blue;
     height: 40px; // [2] //
     width: 40px; // [2] //
   }
@@ -313,13 +313,13 @@
 
   &:hover {
     .nhsuk-icon__close {
-      fill: $nhsuk-secondary-button-hover-colour;
+      fill: $nhsuk-secondary-button-hover-color;
     }
   }
 
   &:focus {
     border-radius: $nhsuk-border-radius;
-    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-colour;
+    box-shadow: 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
     outline: 0;
   }
 

--- a/packages/core/tools/_typography.scss
+++ b/packages/core/tools/_typography.scss
@@ -19,11 +19,11 @@
 
 // sass-lint:disable no-important, no-duplicate-properties
 
-@mixin nhsuk-text-colour {
-  color: $nhsuk-text-colour;
+@mixin nhsuk-text-color {
+  color: $nhsuk-text-color;
 
   @include govuk-media-query($media-type: print) {
-    color: $nhsuk-print-text-colour;
+    color: $nhsuk-print-text-color;
   }
 }
 


### PR DESCRIPTION
## Description

- Changed all colour variables to use the word `color` instead of `colour`.
- Changed all colour hex values to lowercase. Eg: `#FFFFFF` is now `#ffffff`.