### PR TITLE
[refs #106] Move skip link to above the header

### DIFF
--- a/docs/_templates/page.njk
+++ b/docs/_templates/page.njk
@@ -4,12 +4,12 @@
 {% extends 'layout.njk' %}
 
 {% block header %}
-  {{ header() }}
-
   {{ skipLink({
     "URL": "#maincontent",
     "heading": "Skip to main content"
   }) }}
+
+  {{ header() }}
 {% endblock %}
 
 


### PR DESCRIPTION
Move the skip link to above the header as this should be the first
thing that is focusable.

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
