### PR TITLE
Skip cleanup before publishing npm package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
         api_key: $NPM_API_KEY
         on:
           tags: true
+        skip_cleanup: true
 
 
 notifications:


### PR DESCRIPTION
By default, travis will clean up all artefacts left over from npm install which means the `npm publish` command fails.
We need to specify `skip_cleanup: true` as we have done in the other jobs.