### PR TITLE
[refs #57] Refactored header spacing

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -44,7 +44,7 @@
 
 .nhsuk-header__logo {
   float: left;
-  padding: nhsuk-spacing(3);
+  padding: $nhsuk-header-spacing;
 
   @include mq($from: tablet) {
     padding-left: 0;
@@ -96,7 +96,7 @@
 
   @include mq($from: tablet) {
     float: left;
-    margin-top: nhsuk-spacing(3);
+    margin-top: $nhsuk-header-spacing;
   }
 
 }
@@ -109,7 +109,7 @@
   padding: nhsuk-spacing(1) nhsuk-spacing(2) 0;
   position: absolute;
   right: nhsuk-spacing(3);
-  top: nhsuk-spacing(3);
+  top: $nhsuk-header-spacing;
 
   .nhsuk-icon__search {
     fill: $color_nhsuk-white;
@@ -173,7 +173,7 @@
     height: 52px; /* [2] */
     margin: 0;
     outline: none;
-    padding: 0 nhsuk-spacing(2);
+    padding: 0 nhsuk-spacing(3);
     width: 100%; /* [2] */
 
     &:focus {
@@ -443,7 +443,7 @@
 
 .nhsuk-header__menu {
   float: right;
-  margin: nhsuk-spacing(3);
+  margin: $nhsuk-header-spacing;
 
   @include mq($from: tablet) {
     float: left;
@@ -495,6 +495,10 @@
 
   &.js-show {
     display: block;
+
+    @include mq($until: large-desktop) {
+      border-bottom: 4px solid $color_nhsuk-grey-5; /* [12] */
+    }
   }
 
 }
@@ -517,6 +521,7 @@
 
 .nhsuk-header__navigation-list {
   list-style: none;
+  margin-bottom: 0;
   padding-left: 0;
 }
 

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -458,7 +458,7 @@
   font-size: 18px;
   font-weight: 400;
   line-height: $nhsuk-base-line-height;
-  margin-right: 56px; /* [11] */
+  margin-right: 52px; /* [11] */
   padding: 7px nhsuk-spacing(3);
   position: relative;
   text-decoration: none;

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -66,3 +66,9 @@ $nhsuk-box-details: 8px !default;
 $nhsuk-box-expander: 4px !default;
 $nhsuk-box-shadow-pagination: 16px !default;
 $nhsuk-box-shadow-link: 4px !default;
+
+//
+// Header spacing
+//
+
+$nhsuk-header-spacing: 20px;


### PR DESCRIPTION
- The header spacing was 16px and the original design is 20px.
- A variable `$nhsuk-header-spacing` has been added to /core/settings.
- Removed extra margin from nav list.
- Added border to nav list to create a divider between the breadcrumb.

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
