### PR TITLE
[refs #133] Remove extra backtick in HTML readme

### DIFF
--- a/docs/contributing/coding-standards/html.md
+++ b/docs/contributing/coding-standards/html.md
@@ -18,7 +18,7 @@ HTML attributes should come in this particular order for easier reading of code.
 
 - `class`
 - `id`, `name`
-- `data-*``
+- `data-*`
 - `src`, `for`, `type`, `href`, `value`
 - `title`, `alt`
 - `role`, `aria-*`


### PR DESCRIPTION
Fix the markdown so HTML displays properly

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
