### PR TITLE
[refs #107] Add underline when focus on main navigation items

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -560,6 +560,7 @@
     background-color: transparent;
     box-shadow: inset 0 0 0 $nhsuk-box-shadow-spread $nhsuk-focus-color;
     color: $color_nhsuk-blue;
+    text-decoration: underline;
   }
 
   &:active {


### PR DESCRIPTION
Looking at the main navigation links in high contrast view on Windows,
the yellow outline border is not seen when using the keyboard to
navigate to them and bringing them into focus. To make them standout
and give a visual clue as to where you are, they should be underlined
when in focus.

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
