### PR TITLE
refs #107] Expander SVG background image

### DIFF
--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -133,8 +133,8 @@
 
   }
 
-  .nhsuk-details__summary-text { // Do not use base64. TODO: Refactor this in the future
-    background: url(data:image/svg+xml;base64,PHN2ZyBjbGFzcz0ibmhzdWstaWNvbiBuaHN1ay1pY29uX19wbHVzIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjMycHgiIGFyaWEtaGlkZGVuPSJ0cnVlIj4gIDxkZWZzPiAgICA8c3R5bGU+ICAgICAgLmNscy0ye2ZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDtzdHJva2Utd2lkdGg6MnB4fSAgICA8L3N0eWxlPiAgPC9kZWZzPiAgPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiIGZpbGw9IiMwMDU3YWIiLz4gIDxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTEyIDh2OE04IDEyaDgiLz48L3N2Zz4=) left -2px center no-repeat;
+  .nhsuk-details__summary-text {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%230057ab'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
     color: $color_nhsuk-blue;
     cursor: pointer;
     display: block;
@@ -157,8 +157,8 @@
     border-bottom: 1px solid $color_nhsuk-grey-5;
   }
 
-  .nhsuk-details__summary-text { // Do not use base64. TODO: Refactor this in the future
-    background: url(data:image/svg+xml;base64,PHN2ZyBjbGFzcz0ibmhzdWstaWNvbiBuaHN1ay1pY29uX19taW51cyIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjMycHgiIGFyaWEtaGlkZGVuPSJ0cnVlIj4gIDxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEwIiBmaWxsPSIjMDA1N2FiIi8+ICA8cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLW1pdGVybGltaXQ9IjEwIiBzdHJva2Utd2lkdGg9IjIiIGQ9Ik04IDEyaDgiLz48L3N2Zz4=) left -2px center no-repeat; /* [3] */
+  .nhsuk-details__summary-text {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%230057ab'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
   }
 
 }


### PR DESCRIPTION
Instead of base64 encoding the SVG icon, just encode the SVG
icon using https://yoksel.github.io/url-encoder/
