### PR TITLE
Allow the dev server over external IP

### DIFF
--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -74,6 +74,7 @@ function serve() {
     root: config.dest,
     livereload: true,
     port: 3000,
+    host: '0.0.0.0',
   });
 }
 


### PR DESCRIPTION
By default, the gulp-connect server is restricted to serving over
localhost. We add a host setting to allow all IP addresses.