### PR TITLE
[refs #158] Refactor breadcrumb SVG icons to background images

### DIFF
--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -16,26 +16,10 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
-      <li class="nhsuk-breadcrumb__item">
-        <a href="https://www.nhs.uk/" class="nhsuk-breadcrumb__link" >Home</a> 
-        <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"/>
-        </svg>
-      </li>
-      <li class="nhsuk-breadcrumb__item">
-        <a href="https://www.nhs.uk/conditions" class="nhsuk-breadcrumb__link" >Health A-Z</a> 
-        <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"/>
-        </svg>
-      </li>
-      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__link">Abscess</a></li>
+      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/" class="nhsuk-breadcrumb__link">Home</a></li>
+      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/conditions" class="nhsuk-breadcrumb__link">Health A-Z</a></li>
     </ol>
-    <p class="nhsuk-breadcrumb__back">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"/>
-      </svg>
-      <a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__backlink">Back to Abscess</a>
-    </p>
+    <p class="nhsuk-breadcrumb__back"><a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__backlink">Back to Abscess</a></p>
   </div>
 </nav>
 ```
@@ -44,7 +28,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
 
-``` 
+```
 {% from 'components/breadcrumb/macro.njk' import breadcrumb %}
 
 {{ breadcrumb({
@@ -65,7 +49,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 
 #### Nunjucks arguments
 
-If you are using Nunjucks, then macros take the following arguments: 
+If you are using Nunjucks, then macros take the following arguments:
 
 | Name                | Type     | Required  | Description  |
 | --------------------|----------|-----------|--------------|
@@ -75,5 +59,5 @@ If you are using Nunjucks, then macros take the following arguments:
 | items.{}.attributes	| object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item. |
 | href                | string   | Yes       | Link of the current page  |
 | text                | string   | Yes       | Text for the current page |
-| classes             | string   | No        | Optional additional classes to add to the anchor tag. Separate each class with a space. |
+| classes             | string   | No        | Optional additional classes to add to the breadcrumnbs container. Separate each class with a space. |
 | attributes          | object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container. |

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -11,6 +11,7 @@
  * 5. and core/settings/_typography for size maps.
  * 5. .. but show a back to index page link.
  * 6. Remove spacing between back icon and label.
+ * 7. Custom padding for the chevron separator icon.
  */
 
 .nhsuk-breadcrumb {
@@ -57,13 +58,26 @@
 
 .nhsuk-breadcrumb__item {
   @include nhsuk-font(16); /* [4] */
+  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-right' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' height='18' width='18' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z'%3E%3C/path%3E%3C/svg%3E") right 5px no-repeat; // sass-lint:disable-line quotes
   display: inline-block;
-  margin: 0;
+  margin-bottom: 0;
+  padding-left: 3px; /* [7] */
+  padding-right: 27px; /* [7] */
+}
+
+.nhsuk-breadcrumb__list > .nhsuk-breadcrumb__item:first-child {
+  padding-left: 0;
+}
+
+.nhsuk-breadcrumb__list > .nhsuk-breadcrumb__item:last-child {
+  background: none;
 }
 
 .nhsuk-breadcrumb__back {
   @include nhsuk-font(16); /* [4] */
+  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-left' xmlns='http://www.w3.org/2000/svg' fill='%23005eb8' height='24' width='24' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z'%3E%3C/path%3E%3C/svg%3E") -8px center no-repeat;
   margin: 0;
+  padding-left: nhsuk-spacing(4);
 
   @include mq($from: tablet) {
     display: none; /* [5] */

--- a/packages/components/breadcrumb/template.html
+++ b/packages/components/breadcrumb/template.html
@@ -1,25 +1,9 @@
 <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
-      <li class="nhsuk-breadcrumb__item">
-        <a href="https://www.nhs.uk/" class="nhsuk-breadcrumb__link" >Home</a>
-        <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"/>
-        </svg>
-      </li>
-      <li class="nhsuk-breadcrumb__item">
-        <a href="https://www.nhs.uk/conditions" class="nhsuk-breadcrumb__link" >Health A-Z</a>
-        <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"/>
-        </svg>
-      </li>
-      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__link">Abscess</a></li>
+      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/" class="nhsuk-breadcrumb__link">Home</a></li>
+      <li class="nhsuk-breadcrumb__item"><a href="https://www.nhs.uk/conditions" class="nhsuk-breadcrumb__link">Health A-Z</a></li>
     </ol>
-    <p class="nhsuk-breadcrumb__back">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"/>
-      </svg>
-      <a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__backlink">Back to Abscess</a>
-    </p>
+    <p class="nhsuk-breadcrumb__back"><a href="https://www.nhs.uk/conditions/abscess/" class="nhsuk-breadcrumb__backlink">Back to Abscess</a></p>
   </div>
 </nav>

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -1,13 +1,12 @@
-<nav class="nhsuk-breadcrumb{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} aria-label="Breadcrumb">
+<nav class="nhsuk-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} aria-label="Breadcrumb">
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
       {% for item in params.items %}
         {% if item.href %}
-          <li class="nhsuk-breadcrumb__item"><a href="{{ item.href }}" class="nhsuk-breadcrumb__link" {% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a> {% include 'assets/icons/icon-chevron-right.svg' %}</li>
+          <li class="nhsuk-breadcrumb__item"><a href="{{ item.href }}" class="nhsuk-breadcrumb__link" {% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a> {% if not loop.last %}{% endif %}</li>
         {% endif %}
       {% endfor %}
-      <li class="nhsuk-breadcrumb__item"><a href="{{ params.href }}" class="nhsuk-breadcrumb__link">{{ params.text }}</a></li>
     </ol>
-    <p class="nhsuk-breadcrumb__back">{% include 'assets/icons/icon-chevron-left.svg' %}<a href="{{ params.href }}" class="nhsuk-breadcrumb__backlink">Back to {{ params.text }}</a></p>
+    <p class="nhsuk-breadcrumb__back"><a href="{{ params.href }}" class="nhsuk-breadcrumb__backlink">Back to {{ params.text }}</a></p>
   </div>
 </nav>


### PR DESCRIPTION
Remove inline SVG icons and make them background images.
Update to HTML templates to remove current page item and deal with
background images correctly.

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
