### PR TITLE
Fix care-card template

### DIFF
--- a/packages/components/care-card/template.njk
+++ b/packages/components/care-card/template.njk
@@ -1,7 +1,8 @@
 {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
 <div class="nhsuk-care-card {% if params.type %}nhsuk-care-card--{{ params.type }}{% endif %}" {% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="nhsuk-care-card__heading-container">
-    <h{{ headingLevel }} class="nhsuk-care-card__heading"><span class="nhsuk-u-visually-hidden">{% if type == 'grey' %}Non-urgent advice: {% elseif type == 'red' %}Urgent care low: {% elseif type == 'black' %}Urgent care high: {% else %}Non-urgent advice: {% endif %}</span>{{ params.heading }}</h{{ headingLevel }}>
+    <h{{ headingLevel }} class="nhsuk-care-card__heading">
+      <span class="nhsuk-u-visually-hidden">{% if params.type == 'primary' %}Non-urgent advice: {% elseif params.type == 'urgent' %}Urgent care low: {% elseif params.type == 'emergency' %}Urgent care high: {% else %}Non-urgent advice: {% endif %}</span>{{ params.heading }}</h{{ headingLevel }}>
   </div>
   <div class="nhsuk-care-card__content">
   {{ params.HTML | safe }}


### PR DESCRIPTION
The visually-hidden text was always "Non-urgent advice:" due to
incorrect usage of template parameters.

See here for bug: https://nhsuk.github.io/nhsuk-frontend/components/care-card-emergency.html