### PR TITLE
[refs #161] Fix MacOS VoiceOver issue and Nunjucks updates

### DIFF
--- a/docs/components/contents-list.njk
+++ b/docs/components/contents-list.njk
@@ -6,7 +6,7 @@
 {% block body %}
 
 <div class="nhsuk-width-container">
-  <main id="maincontent" class="nhsuk-main-wrapper">
+  <main class="nhsuk-main-wrapper" id="maincontent">
 
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-two-thirds">

--- a/packages/components/contents-list/README.md
+++ b/packages/components/contents-list/README.md
@@ -16,8 +16,8 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 <nav class="nhsuk-contents-list" aria-label="Pages in this guide">
   <h2 class="nhsuk-u-visually-hidden">Contents</h2>
   <ol class="nhsuk-contents-list__list">
-    <li class="nhsuk-contents-list__item">
-      <span class="nhsuk-contents-list__current" aria-current="page">What is AMD?</span>
+    <li class="nhsuk-contents-list__item" aria-current="page">
+      <span class="nhsuk-contents-list__current">What is AMD?</span>
     </li>
     <li class="nhsuk-contents-list__item">
       <a class="nhsuk-contents-list__link" href="https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/">Symptoms</a>
@@ -73,12 +73,13 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 
 #### Nunjucks arguments
 
-If you are using Nunjucks, then macros take the following arguments: 
+The contents list Nunjucks macro takes the following arguments:
 
-| Name                | Type     | Required  | Description  |
-| --------------------|----------|-----------|--------------|
-| text                | string   | Yes       | text value of the items in the contents list. |
-| href                | string   | Yes       | href value of the items in contents list. |
-| current             | boolean  | No        | Current active page in the contents list. |
-| classes             | string   | No        | Optional additional classes content list container. Separate each class with a space. |
-| attributes          | object   | No        | Any extra HTML attributes (for example data attributes) to items in the list. |
+| Name                    | Type     | Required  | Description  |
+| ------------------------|----------|-----------|--------------|
+| **items**               | array    | Yes       | Array of items in the contents list. |
+| **items.[].href**       | string   | Yes       | Href value of an item in the contents list. |
+| **items.[].text**       | string   | Yes       | Text value of an item in the contents llst. |
+| **current**             | boolean  | No        | Current active page in the contents list. |
+| **classes**             | string   | No        | Optional additional classes content list container. Separate each class with a space. |
+| **attributes**          | object   | No        | Any extra HTML attributes (for example data attributes) to items in the list. |

--- a/packages/components/contents-list/template.html
+++ b/packages/components/contents-list/template.html
@@ -1,8 +1,8 @@
 <nav class="nhsuk-contents-list" aria-label="Pages in this guide">
   <h2 class="nhsuk-u-visually-hidden">Contents</h2>
   <ol class="nhsuk-contents-list__list">
-    <li class="nhsuk-contents-list__item">
-      <span class="nhsuk-contents-list__current" aria-current="page">What is AMD?</span>
+    <li class="nhsuk-contents-list__item" aria-current="page">
+      <span class="nhsuk-contents-list__current">What is AMD?</span>
     </li>
     <li class="nhsuk-contents-list__item">
       <a class="nhsuk-contents-list__link" href="https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/">Symptoms</a>

--- a/packages/components/contents-list/template.njk
+++ b/packages/components/contents-list/template.njk
@@ -1,14 +1,16 @@
-<nav class="nhsuk-contents-list{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} aria-label="Pages in this guide">
+<nav class="nhsuk-contents-list{% if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} role="navigation" aria-label="Pages in this guide">
   <h2 class="nhsuk-u-visually-hidden">Contents</h2>
   <ol class="nhsuk-contents-list__list">
     {% for item in params.items %}
-    <li class="nhsuk-contents-list__item">
       {% if item.current %}
-        <span class="nhsuk-contents-list__current" aria-current="page">{{ item.text }}</span>
-        {% else %}
-        <a class="nhsuk-contents-list__link" href="{{ item.href }}">{{ item.text }}</a>
+        <li class="nhsuk-contents-list__item" aria-current="page">
+          <span class="nhsuk-contents-list__current">{{ item.text }}</span>
+        </li>
+      {% else %}
+        <li class="nhsuk-contents-list__item">
+          <a class="nhsuk-contents-list__link" href="{{ item.href }}">{{ item.text }}</a>
+        </li>
       {% endif %}
-    </li>
     {% endfor %}
   </ol>
 </nav>


### PR DESCRIPTION
The aria-current on the <span> causes a weird VoiceOver issue on
MacOS where it seems to make VoiceOver hang when using the 'read all'
command. So, the aria-current is moved to the `<li>` element.

Updates to the Nunjucks arguments table.

## Description

## Component checklist

- [ ] SCSS
- [ ] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
