### PR TITLE
[refs #107] Remove SVG includes to fix npm usage

### DIFF
--- a/packages/components/action-link/template.njk
+++ b/packages/components/action-link/template.njk
@@ -1,7 +1,10 @@
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link{% if params.classes %} {{ params.classes }}{% endif %}"
   href="{% if params.href %}{{ params.href }}{% else %}#{% endif %}"{% if params.openInNewWindow %} target="_blank"{% endif %} {% for attribute, value in params.attributes %} {{attribute}}="{{ value }}"{% endfor %}>
-    {% include 'assets/icons/icon-arrow-right-circle.svg' %}
+    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M0 0h24v24H0z" fill="none"></path>
+      <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
+    </svg>
     <span class="nhsuk-action-link__text">{{ params.text }}</span>
   </a>
 </div>

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -5,9 +5,14 @@
       {% for data in params.items %}
       <li>
       {% if params.type == 'cross' %}
-        {% include 'assets/icons/icon-cross.svg' %}
+        <svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z"></path>
+          <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z"></path>
+        </svg>
       {% else %}
-        {% include 'assets/icons/icon-tick.svg' %}
+        <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
+        </svg>
       {% endif %}
       {% if params.type == 'cross' %}do not {% endif %}{{ data.item | safe}}
       </li>

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -19,7 +19,9 @@
 
       <div class="nhsuk-header__search">
         <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
-          {% include 'assets/icons/icon-search.svg' %}
+          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+          </svg>
           <span class="nhsuk-u-visually-hidden">Search</span>
         </button>
         <div class="nhsuk-header__search-wrap" id="wrap-search">
@@ -27,11 +29,15 @@
             <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
             <input class="nhsuk-search__input" id="search-field" placeholder="Enter a search term" autocomplete="off" name="search-field" type="search">
             <button type="submit" class="nhsuk-search__submit">
-              {% include 'assets/icons/icon-search.svg' %}
+              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
               <span class="nhsuk-u-visually-hidden">Search</span>
             </button>
             <button class="nhsuk-search__close" id="close-search">
-              {% include 'assets/icons/icon-close.svg' %}
+              <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+              </svg>
               <span class="nhsuk-u-visually-hidden">Close search</span>
             </button>
           </form>
@@ -45,14 +51,28 @@
   <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
     <p class="nhsuk-header__navigation-title"><span id="label-navigation">Menu</span>
       <button class="nhsuk-header__navigation-close" id="close-menu">
-        {% include 'assets/icons/icon-close.svg' %}
+        <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
         <span class="nhsuk-u-visually-hidden">Close menu</span>
       </button>
     </p>
     <ul class="nhsuk-header__navigation-list">
-      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile"><a href="/" class="nhsuk-header__navigation-link">Home {% include 'assets/icons/icon-chevron-right.svg' %}</a></li>
+      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
+        <a href="/" class="nhsuk-header__navigation-link">Home
+          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+          </svg>
+        </a>
+      </li>
       {% for item in params.primaryLinks %}
-      <li class="nhsuk-header__navigation-item"><a href="{{item.url}}" class="nhsuk-header__navigation-link">{{item.label}} {% include 'assets/icons/icon-chevron-right.svg' %}</a></li>
+      <li class="nhsuk-header__navigation-item">
+        <a href="{{item.url}}" class="nhsuk-header__navigation-link">{{item.label}}
+          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+          </svg>
+        </a>
+      </li>
       {% endfor %}
     </ul>
   </nav>
@@ -65,7 +85,9 @@
 
       <div class="nhsuk-header__search">
         <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
-          {% include 'assets/icons/icon-search.svg' %}
+          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+          </svg>
           <span class="nhsuk-u-visually-hidden">Search</span>
         </button>
         <div class="nhsuk-header__search-wrap" id="wrap-search">
@@ -73,11 +95,15 @@
             <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
             <input class="nhsuk-search__input" id="search-field" placeholder="Enter a search term" autocomplete="off" name="search-field" type="search">
             <button type="submit" class="nhsuk-search__submit">
-              {% include 'assets/icons/icon-search.svg' %}
+              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
               <span class="nhsuk-u-visually-hidden">Search</span>
             </button>
             <button class="nhsuk-search__close" id="close-search">
-              {% include 'assets/icons/icon-close.svg' %}
+              <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+              </svg>
               <span class="nhsuk-u-visually-hidden">Close search</span>
             </button>
           </form>
@@ -102,14 +128,28 @@
   <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
     <p class="nhsuk-header__navigation-title"><span id="label-navigation">Menu</span>
       <button class="nhsuk-header__navigation-close" id="close-menu">
-        {% include 'assets/icons/icon-close.svg' %}
+        <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
         <span class="nhsuk-u-visually-hidden">Close menu</span>
       </button>
     </p>
     <ul class="nhsuk-header__navigation-list">
-      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile"><a href="/" class="nhsuk-header__navigation-link">Home {% include 'assets/icons/icon-chevron-right.svg' %}</a></li>
+      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
+        <a href="/" class="nhsuk-header__navigation-link">Home
+          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+          </svg>
+        </a>
+      </li>
       {% for item in params.primaryLinks %}
-      <li class="nhsuk-header__navigation-item"><a href="{{item.url}}" class="nhsuk-header__navigation-link">{{item.label}} {% include 'assets/icons/icon-chevron-right.svg' %}</a></li>
+      <li class="nhsuk-header__navigation-item">
+        <a href="{{item.url}}" class="nhsuk-header__navigation-link">{{item.label}}
+          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+          </svg>
+        </a>
+      </li>
       {% endfor %}
     </ul>
   </nav>

--- a/packages/components/list-panel/template.njk
+++ b/packages/components/list-panel/template.njk
@@ -19,7 +19,9 @@
   {% if params.backToTop %}
   <div class="nhsuk-back-to-top">
     <a class="nhsuk-back-to-top__link" href="{{ params.backToTopLink }}">
-      {% include 'assets/icons/icon-arrow-right.svg' %}
+      <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+      </svg>
       Back to top
     </a>
   </div>

--- a/packages/components/pagination/template.njk
+++ b/packages/components/pagination/template.njk
@@ -3,14 +3,17 @@
   <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{ params.previousUrl }}">
     <span class="nhsuk-pagination__title">Previous</span>
     <span class="nhsuk-pagination__page">{{ params.previousPage }}</span>
-    {% include 'assets/icons/icon-arrow-left.svg' %}
-  </a>
+    <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+    </svg>
   {% endif %}
   {% if params.nextUrl and params.nextPage %}
   <a class="nhsuk-pagination__link nhsuk-pagination__link--next" href="{{ params.nextUrl }}">
     <span class="nhsuk-pagination__title">Next</span>
     <span class="nhsuk-pagination__page">{{ params.nextPage }}</span>
-    {% include 'assets/icons/icon-arrow-right.svg' %}
+    <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+    </svg>
   </a>
   {% endif %}
 </nav>


### PR DESCRIPTION
When trying to use the nunjucks macros using npm, the paths for
the SVG includes were broken because they were absolute paths. using
SVG inline icons fixes this issue.
