### PR TITLE
[refs #161] Change em-dash content to background svg

### DIFF
--- a/packages/assets/icons/icon-emdash-small.svg
+++ b/packages/assets/icons/icon-emdash-small.svg
@@ -1,0 +1,3 @@
+<svg class="nhsuk-icon nhsuk-icon__emdash" xmlns="http://www.w3.org/2000/svg" width="16" height="1" aria-hidden="true">
+  <path d="M0 0h16v1H0z"></path>
+</svg>

--- a/packages/assets/icons/icon-emdash.svg
+++ b/packages/assets/icons/icon-emdash.svg
@@ -1,0 +1,3 @@
+<svg class="nhsuk-icon nhsuk-icon__emdash" xmlns="http://www.w3.org/2000/svg" width="19" height="1" aria-hidden="true">
+  <path d="M0 0h19v1H0z"></path>
+</svg>

--- a/packages/components/contents-list/_contents-list.scss
+++ b/packages/components/contents-list/_contents-list.scss
@@ -17,15 +17,12 @@
 }
 
 .nhsuk-contents-list__item {
+  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__emdash' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' width='19' height='1' aria-hidden='true'%3E%3Cpath d='M0 0h19v1H0z'%3E%3C/path%3E%3C/svg%3E") left nhsuk-px-to-rem(12px) no-repeat; // sass-lint:disable-line quotes
   padding: 0 0 0 nhsuk-spacing(5);
   position: relative;
 
-  &:before {
-    color: $color_nhsuk-grey-3;
-    content: '\2014'; /* [1] */
-    left: 0;
-    position: absolute;
-    top: 0;
+  @include mq($from: tablet) {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__emdash' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' width='16' height='1' aria-hidden='true'%3E%3Cpath d='M0 0h19v1H0z'%3E%3C/path%3E%3C/svg%3E") left nhsuk-px-to-rem(14px) no-repeat; // sass-lint:disable-line quotes
   }
 
 }

--- a/packages/core/styles/_icons.scss
+++ b/packages/core/styles/_icons.scss
@@ -73,6 +73,12 @@
   }
 }
 
+.nhsuk-icon__emdash {
+  path {
+    fill: $color_nhsuk-grey-3;
+  }
+}
+
 // Icon size adjustments
 
 .nhsuk-icon--size-25 {


### PR DESCRIPTION
The em-dash added content in css is read out in screen readers so
have changed it to an svg background image.

## Description

## Component checklist

- [x] SCSS
- [x] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
