### PR TITLE
[refs #167] Amend banner to not be sticky when footer is scrolled to

### DIFF
--- a/docs/components/all.njk
+++ b/docs/components/all.njk
@@ -19,6 +19,7 @@
 {% from 'components/skip-link/macro.njk' import skipLink %}
 {% from 'components/tables/macro.njk' import table %}
 {% from 'components/warning-callout/macro.njk' import warningCallout %}
+{% from 'components/feedback-banner/macro.njk' import feedbackBanner %}
 
 {% extends 'page.njk' %}
 
@@ -692,4 +693,11 @@
       }
     ]
   })}}
+
+  {{ feedbackBanner({
+    "title": "Help us make the NHS website better",
+    "content": "Your feedback helps us improve the NHS website.",
+    "href": "https://www.nhs.uk",
+    "label": "Take our short survey"
+  }) }}
 {% endblock %}

--- a/packages/components/feedback-banner/_feedback-banner.scss
+++ b/packages/components/feedback-banner/_feedback-banner.scss
@@ -9,6 +9,7 @@
  * 4. Avoid the banner title overlapping close button on
  *    small mobile devices (below 320px).
  * 5. Change the cursor to a pointer on hover.
+ * 6. Repositions the banner into the normal flow of the page, ie not fixed.
  */
 
 .nhsuk-feedback-banner {
@@ -24,6 +25,11 @@
   position: fixed;
   width: 100%;
   z-index: 20; /* [2] */
+
+  &.js-inview { /* [6] */
+    bottom: auto;
+    position: relative;
+  }
 
 }
 
@@ -58,7 +64,7 @@
   background: none;
   border: 0;
   color: $color_nhsuk-black;
-  cursor: pointer; /* [6] */
+  cursor: pointer; /* [5] */
   padding: 0;
   position: absolute;
   right: 0;

--- a/packages/components/feedback-banner/feedback-banner.js
+++ b/packages/components/feedback-banner/feedback-banner.js
@@ -2,13 +2,53 @@
 
 var banner = document.querySelector('#nhsuk-feedback-banner');
 var bannerCloseButton = document.querySelector('#nhsuk-feedback-banner-close');
+var footer = document.getElementById('nhsuk-footer');
+
+// taken from https://stackoverflow.com/a/22480938
+function isScrolledIntoView(el) {
+  var rect = el.getBoundingClientRect();
+  var elemTop = rect.top;
+  var elemBottom = rect.bottom;
+  // Only completely visible elements return true:
+  // var isVisible = (elemTop >= 0) && (elemBottom <= window.innerHeight);
+  // Partially visible elements return true:
+  var isVisible = elemTop < window.innerHeight && elemBottom >= 0;
+  return isVisible;
+}
 
 document.addEventListener("DOMContentLoaded", function(){
+
   setTimeout(function () {
     if (typeof(banner) != 'undefined' && banner != null) {
       banner.style.display = "block";
     }
   }, 3000);
+
+  var didScroll = false,
+      timer = false;
+
+  // set a timer when scrolling, so as not to be constantly calling the
+  // isScrolledIntoView function and spiking CPU, to check when the footer
+  // comes in to view, to make the banner not sticky but position it in the
+  // normal flow of the page below the footer
+  $(window).scroll(function() {
+    if (!didScroll) {
+      timer = setInterval(function() {
+        if (didScroll) {
+          didScroll = false;
+          clearTimeout(timer);
+
+          if (isScrolledIntoView(footer)) {
+            banner.classList.add("js-inview")
+          } else {
+            banner.classList.remove("js-inview")
+          }
+        }
+      }, 500);
+    }
+    didScroll = true;
+  });
+
 });
 
 if (bannerCloseButton) {

--- a/packages/components/footer/template.njk
+++ b/packages/components/footer/template.njk
@@ -1,5 +1,5 @@
 <footer role="contentinfo">
-  <div class="nhsuk-footer">
+  <div class="nhsuk-footer" id="nhsuk-footer">
     <div class="nhsuk-width-container">
       {% if params.showLogo == "true" %}
       <div class="nhsuk-footer__logo">


### PR DESCRIPTION
Accessibility fix to not obscure the footer with the banner, by
repositioning it to below the footer when it comes in to view. The
contents of the banner are also keyboard navigable when this happens.

## Description

## Component checklist

- [x] SCSS
- [x] SCSS lint
- [ ] HTML template
- [ ] HTML validate & lint
- [x] Nunjucks macro
- [x] A standalone example
- [ ] README/Documentation
- [ ] Pseudocode tests
- [ ] Visual tests 
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG
