### PR TITLE
[refs #206] Fix incorrect back link and error summary examples

### DIFF
--- a/packages/components/back-link/README.md
+++ b/packages/components/back-link/README.md
@@ -14,7 +14,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-back-link">
-  <a href="#" class="nhsuk-back-link">
+  <a href="#" class="nhsuk-back-link__link">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>

--- a/packages/components/error-summary/README.md
+++ b/packages/components/error-summary/README.md
@@ -13,16 +13,17 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-  <h2 class="govuk-error-summary__title" id="error-summary-title">
-    Message to alert the user to a problem goes here
-  </h2>
-  <div class="govuk-error-summary__body">
+<div class="nhsuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="nhsuk-error-summary__title" id="error-summary-title">Message to alert the user to a problem goes here</h2>
+  <div class="nhsuk-error-summary__body">
     <p>Optional description of the errors and how to correct them</p>
-
-    <ul class="govuk-list govuk-error-summary__list"> 
-      <li><a href="#example-error-1">Descriptive link to the question with an error</a></li>
-      <li><a href="#example-error-1">Descriptive link to the question with an error</a></li>
+    <ul class="nhsuk-list nhsuk-error-summary__list">
+      <li>
+        <a href="#example-error-1">Descriptive link to the question with an error</a>
+      </li>
+      <li>
+        <a href="#example-error-1">Descriptive link to the question with an error</a>
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
The HTML markup for the back link and error summary were wrong,
they have been updated to reflect the correct markup.