### PR TITLE
[refs #107] Fix feedback banner JS to prevent console errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # NHS.UK Frontend Changelog
 
+## 0.5.1 (Prerelease) - Dec 11, 2018
+
+:wrench: **Fixes**
+
+- Feedback banner - Fix an issue with the JavaScript reporting errors within the console log
+when scrolling down the page if the feedback banner did not exist on the page.  ([PR 293](https://github.com/nhsuk/nhsuk-frontend/pull/293))
+
+- Details - Add the missing component JavaScript to the `nhsuk.min.js` bundle. ([PR 285](https://github.com/nhsuk/nhsuk-frontend/pull/285))
+
 ## 0.5.0 (Prerelease) - Dec 07, 2018
 
 :boom: **Breaking changes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The NHS website frontend styles, for creating NHS websites and services.",
   "sasslintConfig": "config/sass-lint.yml",
   "scripts": {

--- a/packages/components/feedback-banner/feedback-banner.js
+++ b/packages/components/feedback-banner/feedback-banner.js
@@ -31,23 +31,25 @@ document.addEventListener("DOMContentLoaded", function(){
   // isScrolledIntoView function and spiking CPU, to check when the footer
   // comes in to view, to make the banner not sticky but position it in the
   // normal flow of the page below the footer
-  $(window).scroll(function() {
-    if (!didScroll) {
-      timer = setInterval(function() {
-        if (didScroll) {
-          didScroll = false;
-          clearTimeout(timer);
+  if (typeof(banner) != 'undefined' && banner != null) {
+    $(window).scroll(function() {
+      if (!didScroll) {
+        timer = setInterval(function() {
+          if (didScroll) {
+            didScroll = false;
+            clearTimeout(timer);
 
-          if (isScrolledIntoView(footer)) {
-            banner.classList.add("js-inview")
-          } else {
-            banner.classList.remove("js-inview")
+            if (isScrolledIntoView(footer)) {
+              banner.classList.add("js-inview")
+            } else {
+              banner.classList.remove("js-inview")
+            }
           }
-        }
-      }, 500);
-    }
-    didScroll = true;
-  });
+        }, 500);
+      }
+      didScroll = true;
+    });
+  }
 
 });
 


### PR DESCRIPTION
## Description

If the feedback banner element did not exist on the page, the JavaScript console in browsers would throw an error when users were scrolling down the page because it couldn't find that element.