### PR TITLE
[refs #253] Amended focus styles

### DIFF
--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -72,12 +72,12 @@
 
   &:focus {
     box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-focus-background-color;
-    outline: 3px solid $nhsuk-link-focus-background-color;
+    outline: $nhsuk-focus-width solid $nhsuk-link-focus-background-color;
   }
 
   &:hover {
     box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-hover-background-color;
-    outline: 3px solid $nhsuk-link-hover-background-color;
+    outline: $nhsuk-focus-width solid $nhsuk-link-hover-background-color;
 
     .nhsuk-pagination__page {
       text-decoration: none;

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -60,7 +60,7 @@ $nhsuk-border-radius: 4px !default;
 //
 
 $nhsuk-box-shadow-spread: 4px !default;
-$nhsuk-box-shadow-blur: 3px !default;
+$nhsuk-box-shadow-blur: 4px !default;
 $nhsuk-box-shadow-link: 4px !default;
 $nhsuk-box-details: 8px !default;
 $nhsuk-box-expander: 4px !default;
@@ -79,7 +79,7 @@ $nhsuk-header-spacing: 20px;
 
 $nhsuk-border-width-form-element: 2px !default;
 $nhsuk-border-width-form-element-error: 4px !default;
-$nhsuk-focus-width: 3px !default;
-$nhsuk-border-width: 5px !default;
+$nhsuk-focus-width: 4px !default;
+$nhsuk-border-width: 4px !default;
 $nhsuk-border-width-mobile: 4px !default;
 $nhsuk-border-width-form-group-error: $nhsuk-border-width !default;

--- a/packages/core/tools/_links.scss
+++ b/packages/core/tools/_links.scss
@@ -20,7 +20,8 @@
     background-color: $nhsuk-link-focus-background-color;
     box-shadow: 0 0 0 4px $nhsuk-link-focus-background-color;
     color: $nhsuk-link-focus-color;
-    outline: 0;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
   }
 
   &:hover {
@@ -50,6 +51,8 @@
     background-color: $color_shade_nhsuk-blue-35;
     box-shadow: 0 0 0 4px $color_shade_nhsuk-blue-35;
     color: $color_nhsuk-white;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
   }
 
   &:hover {
@@ -83,6 +86,8 @@
   &:focus {
     color: $nhsuk-link-focus-color;
     text-decoration: underline;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
   }
 
   &:hover {
@@ -122,6 +127,7 @@
     background-color: $nhsuk-link-focus-background-color;
     box-shadow: 0 0 0 4px $nhsuk-link-focus-background-color;
     color: $nhsuk-link-focus-color;
-    outline: 0;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
   }
 }

--- a/packages/core/tools/_mixins.scss
+++ b/packages/core/tools/_mixins.scss
@@ -352,7 +352,8 @@
 @mixin nhsuk-focusable {
   &:focus {
     box-shadow: 0 0 0 4px $nhsuk-link-focus-background-color;
-    outline: 0;
+    outline: $nhsuk-focus-width solid transparent;
+    outline-offset: $nhsuk-focus-width;
   }
 }
 


### PR DESCRIPTION
All links now have a 4px transparent outline on `:focus`, so that the `:focus` state is visible for users using high contrast mode
