### PR TITLE
[refs #291] Added styling for `address` element

### DIFF
--- a/docs/components/typography.njk
+++ b/docs/components/typography.njk
@@ -52,6 +52,12 @@
   <h3>H3 using no class</h3>
   <p>This is a paragraph using no class. Aliquam pulvinar posuere elementum. Fusce tincidunt interdum mauris non pretium.</p>
 
+  <address>
+  7 Test Road <br>
+  Village <br>
+  LS16 2JE
+  </address>
+
   <h1 class="nhsuk-heading-l">H1 using nhsuk-heading-l</h1>
   <h2 class="nhsuk-heading-xl">H2 using nhsuk-heading-xl</h2>
   <h3 class="nhsuk-heading-l">H3 using nhsuk-heading-l</h3>

--- a/packages/core/styles/_typography.scss
+++ b/packages/core/styles/_typography.scss
@@ -175,6 +175,12 @@ p,
   @extend %nhsuk-body-s;
 }
 
+address {
+  @extend %nhsuk-body-m;
+
+  font-style: normal;
+}
+
 
 /**
  * Contextual adjustments


### PR DESCRIPTION
The address element has been added to core typography styles. 

It uses the same styling as the main body copy.
