### PR TITLE
Align care card with service manual

### DIFF
--- a/packages/components/care-card/README.md
+++ b/packages/components/care-card/README.md
@@ -1,8 +1,10 @@
 # Care cards
 
-Find out more about the care card component and when to use it in the [NHS Digital service manual](https://beta.nhs.uk/service-manual/patterns/care-cards/).
-
 To discuss or contribute to this component, visit the [GitHub issue for this component](https://github.com/nhsuk/nhsuk-frontend/issues/160).
+
+## Guidance
+
+Find out more about the care card component and when to use it in the [NHS Digital service manual](https://beta.nhs.uk/service-manual/patterns/care-cards/).
 
 ## Quick start examples
 
@@ -71,6 +73,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
       <li>you have a weakened immune system and you've been near someone with chickenpox</li>
       <li>you think your newborn baby has chickenpox</li>
     </ul>
+  <p>In these situations, your GP can prescribe medicine to prevent complications. You need to take it within 24 hours of the spots coming out.</p>
   </div>
 </div>
 ```
@@ -92,6 +95,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
     <li>you have a weakened immune system and you've been near someone with chickenpox</li>
     <li>you think your newborn baby has chickenpox</li>
   </ul>
+   <p>In these situations, your GP can prescribe medicine to prevent complications. You need to take it within 24 hours of the spots coming out.</p>
   "
 }) }}
 ```
@@ -114,7 +118,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
       <li>makes your chest feel tight or heavy</li>
       <li>also started with shortness of breath, sweating and feeling or being sick</li>
     </ul>
-    <p>You could be having a <a href="https://www.nhs.uk">heart attack</a>. Call 999 immediately as you need immediate treatment in hospital.</p>
+    <p>You could be having a heart attack. Call 999 immediately as you need immediate treatment in hospital.</p>
   </div>
 </div>
 ```
@@ -135,7 +139,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
     <li>makes your chest feel tight or heavy</li>
     <li>also started with shortness of breath, sweating and feeling or being sick</li>
   </ul>
-  <p>You could be having a <a href=\"https://www.nhs.uk\">heart attack</a>. Call 999 immediately as you need immediate treatment in hospital.</p>
+  <p>You could be having a heart attack. Call 999 immediately as you need immediate treatment in hospital.</p>
   "
 }) }}
 ```


### PR DESCRIPTION
Add a para of text to red (urgent) care card.
Delete hyperlink from red and black (immediate) care card. 
Add H2 for Guidance to make link to service manual more prominent.

