### PR TITLE
Fix contributing guideline link

### DIFF
--- a/docs/pages/about.njk
+++ b/docs/pages/about.njk
@@ -21,7 +21,7 @@
   <div class="nhsuk-u-reading-width">
 
     <h2>Contributing</h2>
-    <p>Please see our <a href="/nhsuk/nhsuk-frontend/blob/master/docs/contributing/README.md">contributing guidelines</a> on how to set up the project locally and contribute changes to NHS.UK frontend.</p>
+    <p>Please see our <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/README.md">contributing guidelines</a> on how to set up the project locally and contribute changes to NHS.UK frontend.</p>
 
     <h2>Get in touch</h2>
     <p>NHS.UK frontend is actively maintained by a team at NHS Digital, you can contact us on <a href="https://nhsuk.slack.com/messages/CCPLQ9YAJ" rel="nofollow">Slack</a> or <a href="mailto:nhsdigital.nhsuk-frontend@nhs.net">send us an email</a>.</p>


### PR DESCRIPTION
## Description
Fix the link in the about page to the contributing guideline

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
