### PR TITLE
Fix broken NHS logo link and update the contact us address

### DIFF
--- a/docs/_templates/page.njk
+++ b/docs/_templates/page.njk
@@ -9,7 +9,12 @@
     "heading": "Skip to main content"
   }) }}
 
-  {{ header() }}
+  {{ header({
+    "showNav": "false",
+    "showSearch": "false",
+    "homeHref": "https://www.nhs.uk"
+    })
+  }}
 {% endblock %}
 
 

--- a/docs/pages/about.njk
+++ b/docs/pages/about.njk
@@ -24,7 +24,7 @@
     <p>Please see our <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/README.md">contributing guidelines</a> on how to set up the project locally and contribute changes to NHS.UK frontend.</p>
 
     <h2>Get in touch</h2>
-    <p>NHS.UK frontend is actively maintained by a team at NHS Digital, you can contact us on <a href="https://nhsuk.slack.com/messages/CCPLQ9YAJ" rel="nofollow">Slack</a> or <a href="mailto:nhsdigital.nhsuk-frontend@nhs.net">send us an email</a>.</p>
+    <p>NHS.UK frontend is actively maintained by a team at NHS Digital, you can <a href="mailto:service-manual@nhs.net">email us</a> or get in touch on the <a href="https://nhsuk.slack.com/messages/standards">NHS.UK #standards Slack channel</a>.
 
   </div>
 

--- a/docs/pages/install.njk
+++ b/docs/pages/install.njk
@@ -27,8 +27,6 @@
 
     <ul>
       <li><a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-with-npm.md">Installing using npm</a></li>
-      <li><a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-with-yarn.md">Installing using yarn</a></li>
-      <li><a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-with-pypi.md">Installing using PyPi</a></li>
     </ul>
 
     <h2>2. Install by using compiled files</h2>


### PR DESCRIPTION
## Description

The NHS logo was linking to a broken page on GitHub pages, it should link back to the NHS.UK website. Also the contact us address has been changed to the standards email and slack channel.