### PR TITLE
Update use of 'focused' in documentation

### DIFF
--- a/packages/components/error-summary/_error-summary.scss
+++ b/packages/components/error-summary/_error-summary.scss
@@ -5,8 +5,8 @@
 /**
  * 1. Cross-component class - adjusts styling of list component.
  * 2. Override default link styling to use error colour
- * 3. When focused, the text colour needs to be darker to ensure that colour
- *    contrast is still acceptable
+ * 3. When the link has focus, the text colour needs to be darker to ensure that
+ *    colour contrast is still acceptable
  */
 
 .nhsuk-error-summary {

--- a/packages/components/radios/_radios.scss
+++ b/packages/components/radios/_radios.scss
@@ -83,7 +83,7 @@ $nhsuk-radios-focus-width: $nhsuk-focus-width + 1px;
 }
 
 /**
- * Focused state
+ * Focus state
  *
  * 1. Since box-shadows are removed when users customise their colours
  *    We set a transparent outline that is shown instead.

--- a/packages/components/skip-link/_skip-link.scss
+++ b/packages/components/skip-link/_skip-link.scss
@@ -4,7 +4,7 @@
 
 /**
  * 1. Hides the skip link off the page,
- * 2. until the link is focused to with keyboard tab.
+ * 2. until the link gains focus from keyboard tabbing.
  */
 
 .nhsuk-skip-link {

--- a/packages/core/tools/_mixins.scss
+++ b/packages/core/tools/_mixins.scss
@@ -344,8 +344,8 @@
 
 /// Focusable helper
 ///
-/// Provides an additional outline to clearly indicate when the target element is
-/// focused. Used for interactive elements which themselves have some background
+/// Provides an additional outline to clearly indicate when the target element
+/// has focus. Used for interactive elements which themselves have some background
 /// or border, such as most form elements.
 ///
 
@@ -360,7 +360,7 @@
 /// Focusable with fill helper
 ///
 /// Provides an additional outline and background colour to clearly indicate when
-/// the target element is focused. Used for interactive text-based elements such
+/// the target element has focus. Used for interactive text-based elements such
 /// as links.
 ///
 


### PR DESCRIPTION
Used the term 'has focus' rather than 'focused' (or 'focussed').

## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
