### PR TITLE
[refs #296] Allow button to be an <a> or <input>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 0.7.0 (Prerelease) - TBC
+
+:new: **New features**
+
+- Button component - Add option for button to be also an `<a>` or `<input>` element. ([PR 324](https://github.com/nhsuk/nhsuk-frontend/pull/324))
+
 ## 0.6.0 (Prerelease) - Dec 18, 2018
 
 :boom: **Breaking changes**

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -11,7 +11,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" class="nhsuk-button">
+<button class="nhsuk-button" type="submit">
   Save and continue
 </button>
 ```
@@ -33,7 +33,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" disabled="disabled" aria-disabled="true" class="nhsuk-button nhsuk-button--disabled">
+<button class="nhsuk-button nhsuk-button--disabled" type="submit" disabled="disabled" aria-disabled="true">
   Disabled button
 </button>
 ```
@@ -56,7 +56,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" class="nhsuk-button nhsuk-button--secondary">
+<button class="nhsuk-button nhsuk-button--secondary" type="submit">
   Save and continue
 </button>
 ```
@@ -79,7 +79,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" class="nhsuk-button nhsuk-button--secondary nhsuk-button--disabled">
+<button class="nhsuk-button nhsuk-button--secondary nhsuk-button--disabled" type="submit">
   Find my location
 </button>
 ```
@@ -103,7 +103,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" class="nhsuk-button nhsuk-button--reverse">
+<button class="nhsuk-button nhsuk-button--reverse" type="submit">
   Save and continue
 </button>
 ```
@@ -126,7 +126,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<button type="submit" class="nhsuk-button nhsuk-button--reverse nhsuk-button--disabled">
+<button class="nhsuk-button nhsuk-button--reverse nhsuk-button--disabled" type="submit">
   Save and continue
 </button>
 ```
@@ -162,4 +162,3 @@ If you are using Nunjucks, then macros take the following arguments:
 ## Thanks to the Government Digital Service (GDS)
 
 This component and documentation has been taken from [GOV.UK Frontend - Button component](https://github.com/alphagov/govuk-frontend/tree/master/package/components/button) with a few minor adaptations.
-

--- a/packages/components/button/_button.scss
+++ b/packages/components/button/_button.scss
@@ -58,6 +58,7 @@ $button-shadow-size: 4px;
   &:hover,
   &:focus {
     background-color: $nhsuk-button-hover-colour;
+    box-shadow: 0 4px 0 $nhsuk-button-shadow-colour;
   }
 
   &:active {
@@ -107,6 +108,10 @@ $button-shadow-size: 4px;
     background-color: $nhsuk-secondary-button-hover-colour;
   }
 
+  &.nhsuk-button--disabled {
+    background-color: $nhsuk-secondary-button-colour;
+  }
+
 }
 
 .nhsuk-button--reverse {
@@ -120,6 +125,18 @@ $button-shadow-size: 4px;
     color: $nhsuk-reverse-button-text-colour;
   }
 
+  &:link {
+    color: $nhsuk-reverse-button-text-colour;
+  }
+
+  &.nhsuk-button--disabled {
+    background-color: $nhsuk-reverse-button-colour;
+
+    &:focus {
+      background-color: $nhsuk-reverse-button-colour;
+    }
+  }
+
 }
 
 /**
@@ -129,8 +146,9 @@ $button-shadow-size: 4px;
 .nhsuk-button--disabled,
 .nhsuk-button[disabled="disabled"], // sass-lint:disable-line quotes
 .nhsuk-button[disabled] {
-  background: $nhsuk-button-colour;
+  background-color: $nhsuk-button-colour;
   opacity: (.5);
+  pointer-events: none;
 
   &:hover {
     background-color: $nhsuk-button-colour;
@@ -138,6 +156,7 @@ $button-shadow-size: 4px;
   }
 
   &:focus {
+    background-color: $nhsuk-button-colour;
     outline: none;
   }
 
@@ -148,10 +167,9 @@ $button-shadow-size: 4px;
 
 }
 
-.nhsuk-button--secondary--disabled, // sass-lint:disable-line
 .nhsuk-button--secondary[disabled="disabled"], // sass-lint:disable-line quotes
 .nhsuk-button--secondary[disabled] {
-  background: $nhsuk-secondary-button-colour;
+  background-color: $nhsuk-secondary-button-colour;
   opacity: (.5);
 
   &:hover {
@@ -170,10 +188,9 @@ $button-shadow-size: 4px;
 
 }
 
-.nhsuk-button--reverse--disabled, // sass-lint:disable-line
 .nhsuk-button--reverse[disabled="disabled"], // sass-lint:disable-line quotes
 .nhsuk-button--reverse[disabled] {
-  background: $nhsuk-reverse-button-colour;
+  background-color: $nhsuk-reverse-button-colour;
   opacity: (.5);
 
   &:hover {

--- a/packages/components/button/template.njk
+++ b/packages/components/button/template.njk
@@ -1,11 +1,32 @@
-{#- Define common attributes that we can use across all element types #}
+{# Define type of element to use, if not explicitly set #}
 
-{%- set commonAttributes %} class="nhsuk-button{% if params.classes %} {{ params.classes }}{% endif %}{% if params.disabled %} nhsuk-button--disabled{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}{% endset %}
+{% if params.element %}
+  {% set element = params.element | lower %}
+{% else %}
+  {% if params.href %}
+    {% set element = 'a' %}
+  {% else %}
+    {% set element = 'button' %}
+  {% endif %}
+{% endif %}
 
-{#- Define common attributes we can use for both button and input types #}
+{# Define common attributes that we can use across all element types #}
+{% set commonAttributes %} class="nhsuk-button{% if params.classes %} {{ params.classes }}{% endif %}{% if params.disabled %} nhsuk-button--disabled{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}{% endset %}
 
-{%- set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% endset %}
+{# Define common attributes we can use for both button and input types #}
+{% set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% endset %}
 
-<button {%- if params.value %} value="{{ params.value }}"{% endif %} {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
+{% if element == 'a' %}
+<a{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" role="button" draggable="false">
+  {{ params.html | safe if params.html else params.text }}
+</a>
+
+{% elseif element == 'button' %}
+<button{{ commonAttributes | safe }}{% if params.value %} value="{{ params.value }}"{% endif %}{{ buttonAttributes | safe }}>
   {{ params.html | safe if params.html else params.text }}
 </button>
+
+{% elseif element == 'input' %}
+<input{{ commonAttributes | safe }} value="{{ params.text }}"{{ buttonAttributes | safe }}>
+
+{% endif %}

--- a/packages/components/button/template.njk
+++ b/packages/components/button/template.njk
@@ -17,7 +17,7 @@
 {% set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% endset %}
 
 {% if element == 'a' %}
-<a{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" role="button" draggable="false">
+<a{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" role="button" draggable="false"{% if params.disabled %} aria-disabled="true"{% endif %}>
   {{ params.html | safe if params.html else params.text }}
 </a>
 


### PR DESCRIPTION
Add options in Nunjucks template to allow for button to be also either
an <a> or <input> element.
Update css accordingly to take account of allowing <a> and <input>
Update README regarding attribute order in HTML example.

## Description

## Checklist

- [x] SCSS
- [x] Nunjucks macro
- [ ] A standalone example
- [x] README/Documentation with HTML snippet
- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [x] CHANGELOG entry
