### PR TITLE
Docs/Homepage link routing from the examples page.

### DIFF
--- a/docs/pages/examples.njk
+++ b/docs/pages/examples.njk
@@ -9,7 +9,7 @@
 
 {% block breadcrumb %}
   {{ breadcrumb({
-    href: "/",
+    href: "../",
     text: "Home"
   }) }}
 {% endblock %}


### PR DESCRIPTION
## Description

A very small PR to fix routing bug in the docs for the Example page, which I noticed after seeing this repo on HN.
Feel free to close the PR if it's being fixed elsewhere, just bugged me