### PR TITLE
Use the correct NHS blue for plus and minus icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/assets/icons/icon-minus.svg
+++ b/packages/assets/icons/icon-minus.svg
@@ -1,4 +1,4 @@
 <svg class="nhsuk-icon nhsuk-icon__minus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true">
-  <circle cx="12" cy="12" r="10" fill="#0057ab"></circle>
+  <circle cx="12" cy="12" r="10"></circle>
   <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M8 12h8"></path>
 </svg>

--- a/packages/assets/icons/icon-plus.svg
+++ b/packages/assets/icons/icon-plus.svg
@@ -1,4 +1,4 @@
 <svg class="nhsuk-icon nhsuk-icon__plus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true">
-  <circle cx="12" cy="12" r="10" fill="#0057ab"></circle>
+  <circle cx="12" cy="12" r="10"></circle>
   <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M12 8v8M8 12h8"></path>
 </svg>

--- a/packages/assets/icons/icon-tick.svg
+++ b/packages/assets/icons/icon-tick.svg
@@ -1,3 +1,3 @@
-<svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-  <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
+<svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
+  <path stroke-width="4" stroke-linecap="round" stroke="#007f3b" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
 </svg>

--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -134,7 +134,7 @@
   }
 
   .nhsuk-details__summary-text {
-    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%230057ab'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
     color: $color_nhsuk-blue;
     cursor: pointer;
     display: block;
@@ -158,7 +158,7 @@
   }
 
   .nhsuk-details__summary-text {
-    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%230057ab'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
   }
 
 }

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -18,19 +18,19 @@ Find out more about the do and don't list component and when to use it in the [N
   <h3 class="nhsuk-do-dont-list__label">Do</h3>
   <ul class="nhsuk-list nhsuk-list--tick">
     <li>
-      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
       cover blisters that are likely to burst with a soft plaster or dressing
     </li>
     <li>
-      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
       wash your hands before touching a burst blister
     </li>
     <li>
-      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
       allow the fluid in a burst blister to drain before covering it with a plaster or dressing

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -10,7 +10,7 @@
           <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z"></path>
         </svg>
       {% else %}
-        <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+        <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
           <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
         </svg>
       {% endif %}

--- a/packages/core/styles/_icons.scss
+++ b/packages/core/styles/_icons.scss
@@ -38,7 +38,6 @@
 }
 
 .nhsuk-icon__tick {
-  fill: none;
   stroke: $color_nhsuk-green;
 }
 
@@ -77,6 +76,14 @@
   path {
     fill: $color_nhsuk-grey-3;
   }
+}
+
+.nhsuk-icon__plus {
+  fill: $color_nhsuk-blue;
+}
+
+.nhsuk-icon__minus {
+  fill: $color_nhsuk-blue;
 }
 
 // Icon size adjustments


### PR DESCRIPTION
## Description

The wrong blue was being used for the expander, plus and minus icons.
Also the tick icon stroke colour was not displaying properly in preview.