### PR TITLE
Update components HTML snippet to match nunjucks templates

### DIFF
--- a/app/components/radios/inline.njk
+++ b/app/components/radios/inline.njk
@@ -11,7 +11,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
           {{ radios({
-            "idPrefix": "example'",
+            "idPrefix": "example",
             "classes": "nhsuk-radios--inline",
             "name": "example",
             "fieldset": {

--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -54,7 +54,7 @@ If you require any of this functionality, you should [install using npm](/docs/i
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
 
-    <title>NHS.UK example</title>
+    <title>NHS.UK page template</title>
 
     <!-- Styles -->
     <link rel="stylesheet" href="css/nhsuk-[latest version].min.css">
@@ -69,17 +69,154 @@ If you require any of this functionality, you should [install using npm](/docs/i
   </head>
 
   <body>
-    <!-- Header -->
+    <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
+
+    <header class="nhsuk-header" role="banner">
+      <div class="nhsuk-width-container nhsuk-header__container">
+        <div class="nhsuk-header__logo">
+          <a class="nhsuk-header__link" href="/" aria-label="NHS homepage">
+            <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+              <path fill="#fff" d="M0 0h40v16H0z"></path>
+              <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+              <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+            </svg>
+          </a>
+        </div>
+        <div class="nhsuk-header__content" id="content-header">
+          <div class="nhsuk-header__menu">
+            <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+          </div>
+          <div class="nhsuk-header__search">
+            <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
+              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
+              <span class="nhsuk-u-visually-hidden">Search</span>
+            </button>
+            <div class="nhsuk-header__search-wrap" id="wrap-search">
+              <form class="nhsuk-header__search-form" id="search"  action="/search/" method="get" role="search">
+                <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
+                <div class="autocomplete-container" id="autocomplete-container"></div>
+                <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
+                <button class="nhsuk-search__submit" type="submit">
+                  <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+                  </svg>
+                  <span class="nhsuk-u-visually-hidden">Search</span>
+                </button>
+                <button class="nhsuk-search__close" id="close-search">
+                  <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+                  </svg>
+                  <span class="nhsuk-u-visually-hidden">Close search</span>
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
+        <p class="nhsuk-header__navigation-title">
+          <span id="label-navigation">Menu</span>
+          <button class="nhsuk-header__navigation-close" id="close-menu">
+            <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            <span class="nhsuk-u-visually-hidden">Close menu</span>
+          </button>
+        </p>
+        <ul class="nhsuk-header__navigation-list">
+          <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
+            <a class="nhsuk-header__navigation-link" href="/">
+              Home
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/conditions" >
+              Health A-Z
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/live-well/" >
+              Live Well
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/conditions/social-care-and-support/" >
+              Care and support
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/news/" >
+              Health news
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/service-search" >
+              Services near you
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+      <div class="nhsuk-width-container">
+        <ol class="nhsuk-breadcrumb__list">
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one">Level one</a></li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two">Level two</a></li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two/level-three">Level three</a></li>
+        </ol>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="/level-one/level-two/level-three">Back to Level three</a></p>
+      </div>
+    </nav>
+
     <div class="nhsuk-width-container">
       <main class="nhsuk-main-wrapper" id="maincontent">
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-three-quarters">
-            <!-- Components -->
+
+            <h1>Page template</h1>
+
           </div>
         </div>
       </main>
     </div>
-    <!-- Footer -->
+
+    <footer role="contentinfo">
+      <div class="nhsuk-footer" id="nhsuk-footer">
+        <div class="nhsuk-width-container">
+          <h2 class="nhsuk-u-visually-hidden">Support links</h2>
+          <ul class="nhsuk-footer__list">
+            <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://www.nhs.uk/Pages/nhs-sites.aspx">NHS sites</a></li>
+            <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://www.nhs.uk/about-us">About us</a></li>
+            <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://www.nhs.uk/contact-us/">Contact us</a></li>
+            <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://www.nhs.uk/about-us/sitemap/">Sitemap</a></li>
+            <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://www.nhs.uk/our-policies/">Our policies</a></li>
+          </ul>
+          <p class="nhsuk-footer__copyright">&copy; Crown Copyright</p>
+        </div>
+      </div>
+    </footer>
+
   </body>
 </html>
 ```

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -14,9 +14,9 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one"> Level one</a> </li>
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two"> Level two</a> </li>
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two/level-three"> Level three</a></li>
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one">Level one</a></li>
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two">Level two</a></li>
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/level-one/level-two/level-three">Level three</a></li>
     </ol>
     <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="/level-one/level-two/level-three">Back to Level three</a></p>
   </div>

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -3,10 +3,10 @@
     <ol class="nhsuk-breadcrumb__list">
       {% for item in params.items %}
         {% if item.href %}
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"> {% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}">{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
         {% endif %}
       {% endfor %}
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}"> {% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ params.text}}</a></li>
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}">{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ params.text}}</a></li>
     </ol>
     <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="{{ params.href }}">Back to {{ params.text }}</a></p>
   </div>

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -3,10 +3,10 @@
     <ol class="nhsuk-breadcrumb__list">
       {% for item in params.items %}
         {% if item.href %}
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}">{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
         {% endif %}
       {% endfor %}
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}">{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}{{ params.text}}</a></li>
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.text}}</a></li>
     </ol>
     <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="{{ params.href }}">Back to {{ params.text }}</a></p>
   </div>

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -171,7 +171,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
       </label>
     </div>
     <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled="">
+      <input class="nhsuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled>
       <label class="nhsuk-label nhsuk-checkboxes__label" for="colours-3">
       Blue
       </label>

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -157,32 +157,26 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group">
-
   <div class="nhsuk-checkboxes">
-
     <div class="nhsuk-checkboxes__item">
       <input class="nhsuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
       <label class="nhsuk-label nhsuk-checkboxes__label" for="colours-1">
-        Red
+      Red
       </label>
     </div>
-
     <div class="nhsuk-checkboxes__item">
       <input class="nhsuk-checkboxes__input" id="colours-2" name="colours" type="checkbox" value="green">
       <label class="nhsuk-label nhsuk-checkboxes__label" for="colours-2">
-        Green
+      Green
       </label>
     </div>
-
     <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled>
+      <input class="nhsuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled="">
       <label class="nhsuk-label nhsuk-checkboxes__label" for="colours-3">
-        Blue
+      Blue
       </label>
     </div>
-
   </div>
-
 </div>
 ```
 
@@ -294,43 +288,34 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group nhsuk-form-group--error">
-
   <fieldset class="nhsuk-fieldset" aria-describedby="waste-error">
-
-  <legend class="nhsuk-fieldset__legend">
-    Which types of waste do you transport regularly?
-  </legend>
-
-  <span id="waste-error" class="nhsuk-error-message">
+    <legend class="nhsuk-fieldset__legend">
+      Which types of waste do you transport regularly?
+    </legend>
+    <span id="waste-error" class="nhsuk-error-message">
     Please select an option
-  </span>
-
-  <div class="nhsuk-checkboxes">
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-1">
+    </span>
+    <div class="nhsuk-checkboxes">
+      <div class="nhsuk-checkboxes__item">
+        <input class="nhsuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+        <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-1">
         Waste from animal carcasses
-      </label>
-    </div>
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-2">
+        </label>
+      </div>
+      <div class="nhsuk-checkboxes__item">
+        <input class="nhsuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+        <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-2">
         Waste from mines or quarries
-      </label>
-    </div>
-
-    <div class="nhsuk-checkboxes__item">
-      <input class="nhsuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
-      <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-3">
+        </label>
+      </div>
+      <div class="nhsuk-checkboxes__item">
+        <input class="nhsuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+        <label class="nhsuk-label nhsuk-checkboxes__label" for="waste-3">
         Farm or agricultural waste
-      </label>
+        </label>
+      </div>
     </div>
-
-  </div>
   </fieldset>
-
 </div>
 ```
 

--- a/packages/components/footer/README.md
+++ b/packages/components/footer/README.md
@@ -36,30 +36,30 @@ Find out more about the footer component and when to use it in the [NHS Digital 
 ```
 {% from 'components/footer/macro.njk' import footer %}
 
-  {{ footer({
-    "links": [
-      {
-        "URL": "https://www.nhs.uk/Pages/nhs-sites.aspx",
-        "label": "NHS sites"
-      },
-      {
-        "URL": "https://www.nhs.uk/about-us",
-        "label": "About us"
-      },
-      {
-        "URL": "https://www.nhs.uk/contact-us/",
-        "label": "Contact us"
-      },
-      {
-        "URL": "https://www.nhs.uk/about-us/sitemap/",
-        "label": "Sitemap"
-      },
-      {
-        "URL": "https://www.nhs.uk/our-policies/",
-        "label": "Our policies"
-      }
-    ]
-  })}}
+{{ footer({
+  "links": [
+    {
+      "URL": "https://www.nhs.uk/Pages/nhs-sites.aspx",
+      "label": "NHS sites"
+    },
+    {
+      "URL": "https://www.nhs.uk/about-us",
+      "label": "About us"
+    },
+    {
+      "URL": "https://www.nhs.uk/contact-us/",
+      "label": "Contact us"
+    },
+    {
+      "URL": "https://www.nhs.uk/about-us/sitemap/",
+      "label": "Sitemap"
+    },
+    {
+      "URL": "https://www.nhs.uk/our-policies/",
+      "label": "Our policies"
+    }
+  ]
+})}}
 ```
 ## Nunjucks arguments
 

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -45,6 +45,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
         <div class="nhsuk-header__search-wrap" id="wrap-search">
           <form class="nhsuk-header__search-form" id="search"  action="/search/" method="get" role="search">
             <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
+            <div class="autocomplete-container" id="autocomplete-container"></div>
             <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
             <button class="nhsuk-search__submit" type="submit">
               <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -107,7 +108,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
         </a>
       </li>
       <li class="nhsuk-header__navigation-item">
-        <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/news/" >
+        <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/news/">
           Health news
           <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -312,8 +313,9 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
         <div class="nhsuk-header__search-wrap" id="wrap-search">
           <form class="nhsuk-header__search-form" id="search" action="/search/" method="get" role="search">
             <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
-            <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off" >
-            <button type="submit" class="nhsuk-search__submit">
+            <div class="autocomplete-container" id="autocomplete-container"></div>
+            <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
+            <button class="nhsuk-search__submit" type="submit">
               <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
               </svg>
@@ -527,49 +529,49 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 ```HTML
 <header class="nhsuk-header" role="banner">
-  <div class="nhsuk-width-container nhsuk-header__container">
-    <div class="nhsuk-header__logo">
-      <a class="nhsuk-header__link nhsuk-header__link--service " href="/" aria-label="NHS homepage">
-        <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
-          <path fill="#fff" d="M0 0h40v16H0z"></path>
-          <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-          <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+<div class="nhsuk-width-container nhsuk-header__container">
+  <div class="nhsuk-header__logo">
+    <a class="nhsuk-header__link nhsuk-header__link--service " href="/" aria-label="NHS homepage">
+      <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+        <path fill="#fff" d="M0 0h40v16H0z"></path>
+        <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+        <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+      </svg>
+      <span class="nhsuk-header__service-name">
+      Digital service manual
+      </span>
+    </a>
+  </div>
+  <div class="nhsuk-header__content" id="content-header">
+    <div class="nhsuk-header__search">
+      <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
+        <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
         </svg>
-        <span class="nhsuk-header__service-name">
-        Digital service manual
-        </span>
-      </a>
-    </div>
-    <div class="nhsuk-header__content" id="content-header">
-      <div class="nhsuk-header__search">
-        <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
-          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-          </svg>
-          <span class="nhsuk-u-visually-hidden">Search</span>
-        </button>
-        <div class="nhsuk-header__search-wrap" id="wrap-search">
-          <form class="nhsuk-header__search-form" id="search" action="/search/" method="get" role="search">
-            <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
-            <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
-            <button class="nhsuk-search__submit" type="submit">
-              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-              </svg>
-              <span class="nhsuk-u-visually-hidden">Search</span>
-            </button>
-            <button class="nhsuk-search__close" id="close-search">
-              <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-              </svg>
-              <span class="nhsuk-u-visually-hidden">Close search</span>
-            </button>
-          </form>
-        </div>
+        <span class="nhsuk-u-visually-hidden">Search</span>
+      </button>
+      <div class="nhsuk-header__search-wrap" id="wrap-search">
+        <form class="nhsuk-header__search-form" id="search" action="/search/" method="get" role="search">
+          <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
+          <div class="autocomplete-container" id="autocomplete-container"></div>
+          <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
+          <button class="nhsuk-search__submit" type="submit">
+            <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+            </svg>
+            <span class="nhsuk-u-visually-hidden">Search</span>
+          </button>
+          <button class="nhsuk-search__close" id="close-search">
+            <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+            </svg>
+            <span class="nhsuk-u-visually-hidden">Close search</span>
+          </button>
+        </form>
       </div>
     </div>
   </div>
-</header>
+</div>
 ```
 
 ### Nunjucks macro

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -18,7 +18,7 @@
     {% if params.showNav == "false" and params.showSearch == "false"%}
 
       {% if params.transactionalService%}
-        <div class="nhsuk-header__transactional-service-name{% if params.transactionalService.longName %} nhsuk-header__transactional-service-name--long {% endif %}">
+        <div class="nhsuk-header__transactional-service-name{% if params.transactionalService.longName %} nhsuk-header__transactional-service-name--long{% endif %}">
           <a class="nhsuk-header__transactional-service-name--link" href="{% if params.transactionalService.href %}{{ params.transactionalService.href }}{% else %}/{% endif %}">{{ params.transactionalService.name }}</a>
         </div>
       {% endif %}
@@ -87,7 +87,7 @@
         </li>
         {% for item in params.primaryLinks %}
           <li class="nhsuk-header__navigation-item">
-            <a class="nhsuk-header__navigation-link" href="{{item.url}}" >
+            <a class="nhsuk-header__navigation-link" href="{{item.url}}">
               {{item.label}}
               <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -115,7 +115,7 @@
             <form class="nhsuk-header__search-form" id="search" action="/search/" method="get" role="search">
               <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
               <div class="autocomplete-container" id="autocomplete-container"></div>
-              <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off" >
+              <input class="nhsuk-search__input" id="search-field" name="search-field" type="search" placeholder="Search" autocomplete="off">
               <button class="nhsuk-search__submit" type="submit">
                 <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                   <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
@@ -158,7 +158,7 @@
       </p>
       <ul class="nhsuk-header__navigation-list">
         <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
-          <a class="nhsuk-header__navigation-link" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}" >
+          <a class="nhsuk-header__navigation-link" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}">
             Home
             <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
@@ -167,7 +167,7 @@
         </li>
         {% for item in params.primaryLinks %}
         <li class="nhsuk-header__navigation-item">
-          <a class="nhsuk-header__navigation-link" href="{{item.url}}" >
+          <a class="nhsuk-header__navigation-link" href="{{item.url}}">
             {{item.label}}
             <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>

--- a/packages/components/hero/README.md
+++ b/packages/components/hero/README.md
@@ -78,7 +78,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<section class="nhsuk-hero nhsuk-hero--image"  style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');">
+<section class="nhsuk-hero nhsuk-hero--image" style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');">
   <div class="nhsuk-hero__overlay">
   </div>
 </section>

--- a/packages/components/hero/README.md
+++ b/packages/components/hero/README.md
@@ -43,7 +43,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<section class="nhsuk-hero nhsuk-hero--image nhsuk-hero--image-description"  style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');" >
+<section class="nhsuk-hero nhsuk-hero--image nhsuk-hero--image-description" style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');">
   <div class="nhsuk-hero__overlay">
     <div class="nhsuk-width-container nhsuk-hero--border">
       <div class="nhsuk-grid-row">
@@ -78,7 +78,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ### HTML markup
 
 ```html
-<section class="nhsuk-hero nhsuk-hero--image"  style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');" >
+<section class="nhsuk-hero nhsuk-hero--image"  style="background-image: url('https://www.nhs.uk/static/nhsuk_shared/img/homepage/hero-2.jpg');">
   <div class="nhsuk-hero__overlay">
   </div>
 </section>

--- a/packages/components/hero/template.njk
+++ b/packages/components/hero/template.njk
@@ -1,4 +1,4 @@
-<section class="nhsuk-hero{% if params.imageURL and params.heading %} nhsuk-hero--image nhsuk-hero--image-description{% elif params.imageURL %} nhsuk-hero--image{% endif %}" {% if params.imageURL %} style="background-image: url('{{ params.imageURL }}');" {% endif %}>
+<section class="nhsuk-hero{% if params.imageURL and params.heading %} nhsuk-hero--image nhsuk-hero--image-description{% elif params.imageURL %} nhsuk-hero--image{% endif %}"{% if params.imageURL %} style="background-image: url('{{ params.imageURL }}');"{% endif %}>
 {% if params.imageURL %}<div class="nhsuk-hero__overlay">{% endif %}
   {% if params.heading %}
   <div class="nhsuk-width-container nhsuk-hero--border">

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -15,7 +15,6 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <label class="nhsuk-label" for="input-example">
     National Insurance number
   </label>
-
   <input class="nhsuk-input" id="input-example" name="test-name" type="text">
 </div>
 ```

--- a/packages/components/list-panel/README.md
+++ b/packages/components/list-panel/README.md
@@ -15,7 +15,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <li>
     <div class="nhsuk-list-panel">
       <h2 class="nhsuk-list-panel__label" id="A">A</h2>
-      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label ">
+      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label">
         <li class="nhsuk-list-panel__item">
           <a class="nhsuk-list-panel__link" href="/conditions/abdominal-aortic-aneurysm/">AAA</a>
         </li>
@@ -39,7 +39,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <li>
     <div class="nhsuk-list-panel">
       <h2 class="nhsuk-list-panel__label" id="B">B</h2>
-      <div class="nhsuk-list-panel__box nhsuk-list-panel__box--with-label ">
+      <div class="nhsuk-list-panel__box nhsuk-list-panel__box--with-label">
         <p class="nhsuk-list-panel--results-items__no-results">There are currently no conditions listed</p>
       </div>
       <div class="nhsuk-back-to-top">
@@ -55,7 +55,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <li>
     <div class="nhsuk-list-panel">
       <h2 class="nhsuk-list-panel__label" id="C">C</h2>
-      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label ">
+      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label">
         <li class="nhsuk-list-panel__item">
           <a class="nhsuk-list-panel__link" href="/conditions/chest-pain/">Chest pain</a>
         </li>
@@ -76,7 +76,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <li>
     <div class="nhsuk-list-panel">
       <h2 class="nhsuk-list-panel__label" id="D">D</h2>
-      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label ">
+      <ul class="nhsuk-list-panel__list nhsuk-list-panel__list--with-label">
         <li class="nhsuk-list-panel__item">
           <a class="nhsuk-list-panel__link" href="/conditions/dandruff/">Dandruff</a>
         </li>

--- a/packages/components/list-panel/template.njk
+++ b/packages/components/list-panel/template.njk
@@ -4,11 +4,11 @@
   <h{{ headingLevel }} class="nhsuk-list-panel__label" id="{{ params.id }}">{{ params.label }}</h{{ headingLevel }}>
   {% endif %}
   {% if params.disable %}
-  <div class="nhsuk-list-panel__box{% if params.label %} nhsuk-list-panel__box--with-label {% endif %}">
+  <div class="nhsuk-list-panel__box{% if params.label %} nhsuk-list-panel__box--with-label{% endif %}">
     <p class="nhsuk-list-panel--results-items__no-results">{{ params.message }}</p>
   </div>
   {% else %}
-  <ul class="nhsuk-list-panel__list{% if params.label %} nhsuk-list-panel__list--with-label {% endif %}">
+  <ul class="nhsuk-list-panel__list{% if params.label %} nhsuk-list-panel__list--with-label{% endif %}">
     {% for item in params.items %}
     <li class="nhsuk-list-panel__item">
       <a class="nhsuk-list-panel__link" href="{{ item.URL }}">{{ item.link }}</a>

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -74,7 +74,7 @@ The pagination Nunjucks macro takes the following arguments:
     <li class="nhsuk-pagination-item--next">
       <a class="nhsuk-pagination__link nhsuk-pagination__link--next" href="/section/symptoms">
         <span class="nhsuk-pagination__title">Next</span>
-        <span class="visually-hidden">:</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">Symptoms</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
@@ -119,7 +119,7 @@ The next pagination Nunjucks macro takes the following arguments:
     <li class="nhsuk-pagination-item--previous">
       <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="/section/treatments">
         <span class="nhsuk-pagination__title">Previous</span>
-        <span class="visually-hidden">:</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">Treatments</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>

--- a/packages/components/panel/README.md
+++ b/packages/components/panel/README.md
@@ -92,13 +92,13 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 ```html
 <div class="nhsuk-grid-row nhsuk-panel-group">
   <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
-    <div class="nhsuk-panel ">
+    <div class="nhsuk-panel">
       <h3>Panel title</h3>
       <p>If you drive you must tell the <a href="https://www.gov.uk/contact-the-dvla" title="External website">DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href="https://www.gov.uk/dizziness-and-driving" title="External website">driving with vertigo</a></p>
     </div>
   </div>
   <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
-    <div class="nhsuk-panel ">
+    <div class="nhsuk-panel">
       <h3>Panel title</h3>
       <p>If you drive you must tell the <a href="https://www.gov.uk/contact-the-dvla" title="External website">DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href="https://www.gov.uk/dizziness-and-driving" title="External website">driving with vertigo</a></p>
     </div>
@@ -106,16 +106,18 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 </div>
 <div class="nhsuk-grid-row nhsuk-panel-group">
   <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
-    <div class="nhsuk-panel ">
+    <div class="nhsuk-panel">
       <h3>Panel title</h3>
       <p>If you drive you must tell the <a href="https://www.gov.uk/contact-the-dvla" title="External website">DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href="https://www.gov.uk/dizziness-and-driving" title="External website">driving with vertigo</a></p>
     </div>
   </div>
   <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
-    <div class="nhsuk-panel ">
+    <div class="nhsuk-panel">
       <h3>Panel title</h3>
       <p>If you drive you must tell the <a href="https://www.gov.uk/contact-the-dvla" title="External website">DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href="https://www.gov.uk/dizziness-and-driving" title="External website">driving with vertigo</a></p>
     </div>
+  </div>
+</div>
 ```
 
 ### Nunjucks macro

--- a/packages/components/panel/template.njk
+++ b/packages/components/panel/template.njk
@@ -1,10 +1,10 @@
 {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
 {% if params.label %}
-<div class="nhsuk-panel-with-label {% if params.colour %}nhsuk-panel--{{ params.colour }}{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div class="nhsuk-panel-with-label{% if params.colour %} nhsuk-panel--{{ params.colour }}{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <h{{ headingLevel }} class="nhsuk-panel-with-label__label">{{ params.label | safe }}</h{{ headingLevel }}>
 {% else %}
-<div class="nhsuk-panel {% if params.colour %}nhsuk-panel--{{ params.colour }}{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}"
+<div class="nhsuk-panel{% if params.colour %} nhsuk-panel--{{ params.colour }}{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 {% endif %}
   {{ params.HTML | safe }}

--- a/packages/components/promo/README.md
+++ b/packages/components/promo/README.md
@@ -156,7 +156,7 @@ The small promo Nunjucks macro takes the following arguments:
 <div class="nhsuk-grid-row nhsuk-promo-group">
   <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -167,7 +167,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -180,7 +180,7 @@ The small promo Nunjucks macro takes the following arguments:
 <div class="nhsuk-grid-row nhsuk-promo-group">
   <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -191,7 +191,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -202,7 +202,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -215,7 +215,7 @@ The small promo Nunjucks macro takes the following arguments:
 <div class="nhsuk-grid-row nhsuk-promo-group">
   <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
     <div class="nhsuk-promo nhsuk-promo--small">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
         </div>
@@ -224,7 +224,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
     <div class="nhsuk-promo nhsuk-promo--small">
-      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
         </div>

--- a/packages/components/promo/README.md
+++ b/packages/components/promo/README.md
@@ -191,7 +191,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -202,7 +202,7 @@ The small promo Nunjucks macro takes the following arguments:
   </div>
   <div class="nhsuk-grid-column-one-third nhsuk-promo-group__item">
     <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper" href="https://www.nhs.uk">
+      <a class="nhsuk-promo__link-wrapper"  href="https://www.nhs.uk">
         <img class="nhsuk-promo__img" src="https://www.nhs.uk/static/nhsuk_shared/img/homepage/give-blood.png" alt=""/>
         <div class="nhsuk-promo__content">
           <h3 class="nhsuk-promo__heading">Save a life: give blood</h3>
@@ -230,6 +230,7 @@ The small promo Nunjucks macro takes the following arguments:
         </div>
       </a>
     </div>
+  </div>
 </div>
 ```
 

--- a/packages/components/promo/template.njk
+++ b/packages/components/promo/template.njk
@@ -1,6 +1,6 @@
 <div class="nhsuk-promo {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <a class="nhsuk-promo__link-wrapper"  href="{{ params.href }}">
+  <a class="nhsuk-promo__link-wrapper" href="{{ params.href }}">
     {% if params.imgURL %}
     <img class="nhsuk-promo__img" src="{{ params.imgURL }}" alt="{{ params.imgALT }}"/>
     {% endif %}

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -411,13 +411,13 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
     </span>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-1" name="example"type="radio" value="yes">
+        <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
         <label class="nhsuk-label nhsuk-radios__label" for="example-1">
         Yes
         </label>
       </div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-2" name="example"type="radio" value="no" checked>
+        <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
         <label class="nhsuk-label nhsuk-radios__label" for="example-2">
         No
         </label>

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -75,36 +75,28 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group">
-
-  <fieldset class="nhsuk-fieldset" aria-describedby="example-hint">
-
-  <legend class="nhsuk-fieldset__legend">
-    Have you changed your name?
-  </legend>
-
-  <span class="nhsuk-hint" id="example-hint">
+  <fieldset class="nhsuk-fieldset" aria-describedby="example&#39;-hint">
+    <legend class="nhsuk-fieldset__legend">
+      Have you changed your name?
+    </legend>
+    <span class="nhsuk-hint" id="example&#39;-hint">
     This includes changing your last name or spelling your name differently.
-  </span>
-
-  <div class="nhsuk-radios nhsuk-radios--inline">
-
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
-      <label class="nhsuk-label nhsuk-radios__label" for="example-1">
+    </span>
+    <div class="nhsuk-radios nhsuk-radios--inline">
+      <div class="nhsuk-radios__item">
+        <input class="nhsuk-radios__input" id="example&#39;-1" name="example"type="radio" value="yes">
+        <label class="nhsuk-label nhsuk-radios__label" for="example&#39;-1">
         Yes
-      </label>
-    </div>
-
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
-      <label class="nhsuk-label nhsuk-radios__label" for="example-2">
+        </label>
+      </div>
+      <div class="nhsuk-radios__item">
+        <input class="nhsuk-radios__input" id="example&#39;-2" name="example"type="radio" value="no" checked>
+        <label class="nhsuk-label nhsuk-radios__label" for="example&#39;-2">
         No
-      </label>
+        </label>
+      </div>
     </div>
-
-  </div>
   </fieldset>
-
 </div>
 ```
 
@@ -147,36 +139,28 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group">
-
   <fieldset class="nhsuk-fieldset" aria-describedby="example-disabled-hint">
-
-  <legend class="nhsuk-fieldset__legend">
-    Have you changed your name?
-  </legend>
-
-  <span class="nhsuk-hint" id="example-disabled-hint">
+    <legend class="nhsuk-fieldset__legend">
+      Have you changed your name?
+    </legend>
+    <span class="nhsuk-hint" id="example-disabled-hint">
     This includes changing your last name or spelling your name differently.
-  </span>
-
-  <div class="nhsuk-radios">
-
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
-      <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-1">
+    </span>
+    <div class="nhsuk-radios">
+      <div class="nhsuk-radios__item">
+        <input class="nhsuk-radios__input" id="example-disabled-1" name="example-disabled"type="radio" value="yes" disabled>
+        <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-1">
         Yes
-      </label>
-    </div>
-
-    <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
-      <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-2">
+        </label>
+      </div>
+      <div class="nhsuk-radios__item">
+        <input class="nhsuk-radios__input" id="example-disabled-2" name="example-disabled"type="radio" value="no" disabled>
+        <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-2">
         No
-      </label>
+        </label>
+      </div>
     </div>
-
-  </div>
   </fieldset>
-
 </div>
 ```
 
@@ -225,20 +209,20 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
     </legend>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-divider-1" name="example"type="radio" value="government-gateway">
+        <input class="nhsuk-radios__input" id="example-divider-1" name="example" type="radio" value="government-gateway">
         <label class="nhsuk-label nhsuk-radios__label" for="example-divider-1">
         Use Government Gateway
         </label>
       </div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-divider-2" name="example"type="radio" value="nhsuk-login">
+        <input class="nhsuk-radios__input" id="example-divider-2" name="example" type="radio" value="nhsuk-login">
         <label class="nhsuk-label nhsuk-radios__label" for="example-divider-2">
         Use NHS.UK Login
         </label>
       </div>
       <div class="nhsuk-radios__divider">or</div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-divider-4" name="example"type="radio" value="create-account">
+        <input class="nhsuk-radios__input" id="example-divider-4" name="example" type="radio" value="create-account">
         <label class="nhsuk-label nhsuk-radios__label" for="example-divider-4">
         Create an account
         </label>
@@ -360,32 +344,26 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group">
-
   <div class="nhsuk-radios">
-
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
+      <input class="nhsuk-radios__input" id="colours-1" name="colours"type="radio" value="red">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-1">
-        Red
+      Red
       </label>
     </div>
-
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-2" name="colours" type="radio" value="green">
+      <input class="nhsuk-radios__input" id="colours-2" name="colours"type="radio" value="green">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-2">
-        Green
+      Green
       </label>
     </div>
-
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-3" name="colours" type="radio" value="blue">
+      <input class="nhsuk-radios__input" id="colours-3" name="colours"type="radio" value="blue">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-3">
-        Blue
+      Blue
       </label>
     </div>
-
   </div>
-
 </div>
 ```
 

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -75,23 +75,23 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 ```html
 <div class="nhsuk-form-group">
-  <fieldset class="nhsuk-fieldset" aria-describedby="example&#39;-hint">
+  <fieldset class="nhsuk-fieldset" aria-describedby="example-hint">
     <legend class="nhsuk-fieldset__legend">
       Have you changed your name?
     </legend>
-    <span class="nhsuk-hint" id="example&#39;-hint">
+    <span class="nhsuk-hint" id="example-hint">
     This includes changing your last name or spelling your name differently.
     </span>
     <div class="nhsuk-radios nhsuk-radios--inline">
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example&#39;-1" name="example"type="radio" value="yes">
-        <label class="nhsuk-label nhsuk-radios__label" for="example&#39;-1">
+        <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+        <label class="nhsuk-label nhsuk-radios__label" for="example-1">
         Yes
         </label>
       </div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example&#39;-2" name="example"type="radio" value="no" checked>
-        <label class="nhsuk-label nhsuk-radios__label" for="example&#39;-2">
+        <input class="nhsuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+        <label class="nhsuk-label nhsuk-radios__label" for="example-2">
         No
         </label>
       </div>
@@ -148,13 +148,13 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
     </span>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-disabled-1" name="example-disabled"type="radio" value="yes" disabled>
+        <input class="nhsuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
         <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-1">
         Yes
         </label>
       </div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="example-disabled-2" name="example-disabled"type="radio" value="no" disabled>
+        <input class="nhsuk-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
         <label class="nhsuk-label nhsuk-radios__label" for="example-disabled-2">
         No
         </label>
@@ -281,7 +281,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
     </legend>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="gov-1" name="gov"type="radio" value="gateway" aria-describedby="gov-1-item-hint">
+        <input class="nhsuk-radios__input" id="gov-1" name="gov" type="radio" value="gateway" aria-describedby="gov-1-item-hint">
         <label class="nhsuk-label nhsuk-radios__label" for="gov-1">
         Sign in with Government Gateway
         </label>
@@ -290,7 +290,7 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
         </span>
       </div>
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input" id="gov-2" name="gov"type="radio" value="verify" aria-describedby="gov-2-item-hint">
+        <input class="nhsuk-radios__input" id="gov-2" name="gov" type="radio" value="verify" aria-describedby="gov-2-item-hint">
         <label class="nhsuk-label nhsuk-radios__label" for="gov-2">
         Sign in with NHS.UK Login
         </label>
@@ -346,19 +346,19 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 <div class="nhsuk-form-group">
   <div class="nhsuk-radios">
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-1" name="colours"type="radio" value="red">
+      <input class="nhsuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-1">
       Red
       </label>
     </div>
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-2" name="colours"type="radio" value="green">
+      <input class="nhsuk-radios__input" id="colours-2" name="colours" type="radio" value="green">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-2">
       Green
       </label>
     </div>
     <div class="nhsuk-radios__item">
-      <input class="nhsuk-radios__input" id="colours-3" name="colours"type="radio" value="blue">
+      <input class="nhsuk-radios__input" id="colours-3" name="colours" type="radio" value="blue">
       <label class="nhsuk-label nhsuk-radios__label" for="colours-3">
       Blue
       </label>

--- a/packages/components/radios/template.njk
+++ b/packages/components/radios/template.njk
@@ -54,8 +54,7 @@
     {% set itemHintId = id + '-item-hint' %}
     <div class="nhsuk-radios__item">
       <input class="nhsuk-radios__input" id="{{ id }}" name="{{ params.name }}"
-      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      type="radio" value="{{ item.value }}"
+      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%} type="radio" value="{{ item.value }}"
       {{-" checked" if item.checked }}
       {{-" disabled" if item.disabled }}
       {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -15,7 +15,6 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <label class="nhsuk-label" for="select-1">
     Label text goes here
   </label>
-
   <select class="nhsuk-select" id="select-1" name="select-1">
     <option value="1">NHS.UK frontend option 1</option>
     <option value="2" selected>NHS.UK frontend option 2</option>

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -50,11 +50,9 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
   <label class="nhsuk-label" for="no-ni-reason">
     Why can&#39;t you provide a National Insurance number?
   </label>
-
   <span id="no-ni-reason-error" class="nhsuk-error-message">
     You must provide an explanation
   </span>
-
   <textarea class="nhsuk-textarea nhsuk-textarea--error" id="no-ni-reason" name="no-ni-reason" rows="5" aria-describedby="no-ni-reason-error"></textarea>
 </div>
 ```


### PR DESCRIPTION
## Description

- Update installing with compiled documentation page template with skip link, header and footer components.
- Remove white space and empty lines from nunjucks templates and make sure that each component HTML snippets match the nunjuck example.
- Make sure that each of the HTML snippets work using compiled files rather than npm package.
- Header HTML snippet was missing the new autocomplete `<div>`
- Pagination HTML snippet was using the old class name for the visually hidden utility class
- Add missing closing `</div>` to the promo HTML snippet.
