### PR TITLE
[refs #172] Escape quote marks in README example and changed preview …

### DIFF
--- a/app/components/inset-text/index.njk
+++ b/app/components/inset-text/index.njk
@@ -11,7 +11,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
           {{ insetText({
-            "HTML": "<p>If you drive you must tell the <a href=\"https://www.gov.uk/contact-the-dvla\" title=\"External website\">DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href=\"https://www.gov.uk/dizziness-and-driving\" title=\"External website\">driving with vertigo</a></p>"
+            "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
           }) }}
         </div>
       </div>

--- a/packages/components/inset-text/README.md
+++ b/packages/components/inset-text/README.md
@@ -29,7 +29,7 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 {% from 'components/inset-text/macro.njk' import insetText %}
 
 {{ insetText({
-  "HTML": "<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/" title="External website">UK safety scheme</a>.</p>"
+  "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
 }) }}
 ```
 


### PR DESCRIPTION
…text

Changed the text in the preview page to something more appropriate!

## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
