### PR TITLE
[refs #177] Remove <time> element

### DIFF
--- a/packages/components/review-date/README.md
+++ b/packages/components/review-date/README.md
@@ -13,8 +13,8 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 ```html
 <div class="nhsuk-review-date">
   <p class="nhsuk-body-s">
-    Page last reviewed: <time>12 February 2016</time><br>
-    Next review due: <time>1 February 2019</time>
+    Page last reviewed: 12 February 2016<br>
+    Next review due: 1 February 2019
   </p>
 </div>
 ```

--- a/packages/components/review-date/template.njk
+++ b/packages/components/review-date/template.njk
@@ -3,8 +3,8 @@
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
     <p class="nhsuk-body-s">
-      {% if params.lastReview %}Page last reviewed: <time>{{ params.lastReview }}</time><br>{% endif %}
-      {% if params.nextReview %}Next review due: <time>{{ params.nextReview }}</time>{% endif %}
+      {% if params.lastReview %}Page last reviewed: {{ params.lastReview }}<br>{% endif %}
+      {% if params.nextReview %}Next review due: {{ params.nextReview }}{% endif %}
     </p>
   </div>
 {%- endif %}


### PR DESCRIPTION
Removed the <time> element around the review dates because it fails
validation without a datetime attribute, which cannot be automatically
generated (yet) from the date value. Even though datetime attribute is
not strictly necessary, this can only be the case if the review date
entered is a valid date or time string, which cannot be guaranteed.

More info here:
https://www.w3.org/TR/2011/WD-html5-author-20110705/the-time-element.html

## Description

## Checklist

- [ ] SCSS
- [x] Nunjucks macro
- [ ] A standalone example
- [x] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
