### PR TITLE
[refs #385] Document the 'call' block for fieldset

### DIFF
--- a/app/components/fieldset/with-inputs.njk
+++ b/app/components/fieldset/with-inputs.njk
@@ -1,0 +1,61 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Fieldset with input fields' %}
+{% from 'components/input/macro.njk' import input %}
+{% from 'components/fieldset/macro.njk' import fieldset %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="maincontent">
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+
+        {% call fieldset({
+          legend: {
+            text: "What is your address?",
+            "classes": "nhsuk-fieldset__legend--xl",
+            "isPageHeading": true
+          }
+        }) %}
+
+          {{ input({
+            "label": {
+              "text": "Address line 1"
+            },
+            "id": "input-address1",
+            "name": "address1"
+          }) }}
+
+          {{ input({
+            "label": {
+              "text": "Address line 2"
+            },
+            "id": "input-address2",
+            "name": "address2"
+          }) }}
+
+          {{ input({
+            "label": {
+              "text": "Town or city"
+            },
+            "id": "input-town-city",
+            "name": "town"
+          }) }}
+
+          {{ input({
+            "label": {
+              "text": "County"
+            },
+            "id": "input-county",
+            "name": "county"
+          }) }}
+
+        {% endcall %}
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -52,6 +52,7 @@
     <li><a href="../components/feedback-banner/index.html">Feedback banner</a></li>
     <li><a href="../components/fieldset/index.html">Fieldset</a></li>
     <li><a href="../components/fieldset/page-heading.html">Fieldset as page heading</a></li>
+    <li><a href="../components/fieldset/with-inputs.html">Fieldset with inputs</a></li>
     <li><a href="../components/footer/index.html">Footer</a></li>
     <li><a href="../components/header/index.html">Header</a></li>
     <li><a href="../components/header/header-logo.html">Header with logo only</a></li>

--- a/packages/components/fieldset/README.md
+++ b/packages/components/fieldset/README.md
@@ -66,6 +66,43 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 [Preview the fieldset component with input fields](https://nhsuk.github.io/nhsuk-frontend/components/fieldset/with-inputs.html)
 
 
+### HTML markup
+
+```html
+<fieldset class="nhsuk-fieldset">
+  <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--xl">
+    <h1 class="nhsuk-fieldset__heading">
+      What is your address?
+    </h1>
+  </legend>
+  <div class="nhsuk-form-group">
+    <label class="nhsuk-label" for="input-address1">
+      Address line 1
+    </label>
+    <input class="nhsuk-input" id="input-address1" name="address1" type="text">
+  </div>
+  <div class="nhsuk-form-group">
+    <label class="nhsuk-label" for="input-address2">
+      Address line 2
+    </label>
+    <input class="nhsuk-input" id="input-address2" name="address2" type="text">
+  </div>
+  <div class="nhsuk-form-group">
+    <label class="nhsuk-label" for="input-town-city">
+      Town or city
+    </label>
+    <input class="nhsuk-input" id="input-town-city" name="town" type="text">
+  </div>
+  <div class="nhsuk-form-group">
+    <label class="nhsuk-label" for="input-county">
+      County
+    </label>
+    <input class="nhsuk-input" id="input-county" name="county" type="text">
+  </div>
+</fieldset>
+
+```
+
 ### Nunjucks macro
 
 To add input fields inside the fieldset, use the `call` block.

--- a/packages/components/fieldset/README.md
+++ b/packages/components/fieldset/README.md
@@ -60,6 +60,64 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 }) }}
 ```
 
+
+### Fieldset with input fields
+
+[Preview the fieldset component with input fields](https://nhsuk.github.io/nhsuk-frontend/components/fieldset/with-inputs.html)
+
+
+### Nunjucks macro
+
+To add input fields inside the fieldset, use the `call` block.
+
+```
+{% from 'components/input/macro.njk' import input %}
+{% from 'components/fieldset/macro.njk' import fieldset %}
+
+{% call fieldset({
+  legend: {
+    text: "What is your address?",
+    "classes": "nhsuk-fieldset__legend--xl",
+    "isPageHeading": true
+  }
+}) %}
+
+  {{ input({
+    "label": {
+      "text": "Address line 1"
+    },
+    "id": "input-address1",
+    "name": "address1"
+  }) }}
+
+  {{ input({
+    "label": {
+      "text": "Address line 2"
+    },
+    "id": "input-address2",
+    "name": "address2"
+  }) }}
+
+  {{ input({
+    "label": {
+      "text": "Town or city"
+    },
+    "id": "input-town-city",
+    "name": "town"
+  }) }}
+
+  {{ input({
+    "label": {
+      "text": "County"
+    },
+    "id": "input-county",
+    "name": "county"
+  }) }}
+
+{% endcall %}
+```
+
+
 ## Nunjucks arguments
 
 If you are using Nunjucks, then macros take the following arguments:


### PR DESCRIPTION
So that input fields can be put inside the fieldset, you can use the
'call' block:
https://mozilla.github.io/nunjucks/templating.html#call

## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [x] A standalone example
- [x] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
