### PR TITLE
[refs #395] Panel component should fill the width of the grid item

### DIFF
--- a/packages/components/panel/_panel.scss
+++ b/packages/components/panel/_panel.scss
@@ -4,6 +4,7 @@
 
 .nhsuk-panel {
   @include panel($color_nhsuk-white, $nhsuk-text-color);
+  width: 100%;
 }
 
 /* Panel colour variant


### PR DESCRIPTION
## Description

When using a shorter amount of content within a panel group component, the panel does not fill the full width of the grid item. The panel should fill the width of the grid item rather than just the width of content.

https://github.com/nhsuk/nhsuk-frontend/issues/395