### PR TITLE
Made distinction between heading and caption

### DIFF
--- a/app/components/tables/tables-panel.njk
+++ b/app/components/tables/tables-panel.njk
@@ -12,12 +12,12 @@
         <div class="nhsuk-grid-column-two-thirds">
           {{ table({
             panel: true,
-            heading: "Skin symptoms and possible causes",
-            caption: "Skin symptoms and possible causes",
+            heading: "Conditions similar to impetigo",
+            caption: "Other possible causes of your symptoms",
             firstCellIsHeader: false,
             head: [
               {
-                text: "Skin symptoms"
+                text: "Symptoms"
               },
               {
                 text: "Possible cause"


### PR DESCRIPTION
## Description

Changed heading to "Conditions similar to impetigo", caption to "Other possible causes of your symptoms" and first column to "Symptoms".

Previously, screenreaders will have read out the same line "Skin symptoms and possible causes" twice (as heading and caption).