### PR TITLE
[refs #416] Extend the page layout to include a fluid-width container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # NHS.UK frontend Changelog
 
+## 2.1.0 - TBC, 2019
+
+:new: **New features**
+
+- Fluid width container - Extend the page layout to include a fluid-width container, which spans the entire width of the viewport.
+Use `.nhsuk-width-container-fluid` for a full width container. Documentation and an example of the fluid-width container can be found on the Layout page in the NHS digital service manual. 
+([Issue 416](https://github.com/nhsuk/nhsuk-frontend/issues/416))
+
 ## 2.0.0 - Mar 11, 2019
 
 :boom: **Breaking changes**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "scripts": {
     "prepare": "gulp bundle",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,8 +6,20 @@ Core also is the home of powerful `sass` features such as variables, mixins, fun
 
 ## Page layout
 
+### Fixed-width container
+
 ```html
 <div class="nhsuk-width-container">
+  <main class="nhsuk-main-wrapper" id="maincontent">
+    <!-- Grid items -->
+  </main>
+</div>
+```
+
+### Fluid-width container
+
+```html
+<div class="nhsuk-width-container-fluid">
   <main class="nhsuk-main-wrapper" id="maincontent">
     <!-- Grid items -->
   </main>

--- a/packages/core/objects/_width-container.scss
+++ b/packages/core/objects/_width-container.scss
@@ -13,6 +13,7 @@
  * 3. From desktop, add full width gutters
  * 4. As soon as the viewport is greater than the width of the page plus the
  *    gutters, just centre the content instead of adding gutters.
+ * 5. Full width container, spanning the entire width of the viewport
  */
 
 @mixin govuk-width-container {
@@ -24,13 +25,22 @@
     margin: 0 $nhsuk-gutter; /* [3] */
   }
 
+  /* [4] */
   @include govuk-media-query($and: '(min-width: #{($nhsuk-page-width + $nhsuk-gutter * 2)})') {
     margin: 0 auto;
   }
 }
 
+@mixin nhsuk-width-container-fluid {
+  margin: 0 $nhsuk-gutter-half;
+  max-width: 100%; /* [5] */
+}
+
 @include govuk-exports('govuk/objects/width-container') {
   .nhsuk-width-container {
     @include govuk-width-container;
+  }
+  .nhsuk-width-container-fluid {
+    @include nhsuk-width-container-fluid;
   }
 }

--- a/packages/core/objects/_width-container.scss
+++ b/packages/core/objects/_width-container.scss
@@ -34,6 +34,10 @@
 @mixin nhsuk-width-container-fluid {
   margin: 0 $nhsuk-gutter-half;
   max-width: 100%; /* [5] */
+
+  @include govuk-media-query($from: desktop) {
+    margin: 0 $nhsuk-gutter; /* [3] */
+  }
 }
 
 @include govuk-exports('govuk/objects/width-container') {


### PR DESCRIPTION
## Description

The current nhsuk-width-container is restricted to a max width of 960px. A new container has been added (nhsuk-width-container-fluid), which which spans the entire width of the viewport and allows for full-screen layouts.

**To Do:**
Just in process of writing up the documentation for the service manual, should be ready before we release 2.10.