### PR TITLE
Prefix error messages with hidden "Error:"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 Use `.nhsuk-width-container-fluid` for a full width container. Documentation and an example of the fluid-width container can be found on the Layout page in the NHS digital service manual. 
 ([Issue 416](https://github.com/nhsuk/nhsuk-frontend/issues/416))
 
+- Prefix error messages with a visually hidden "Error:", to make it clearer to
+  users of assistive technologies.
+
 ## 2.0.0 - Mar 11, 2019
 
 :boom: **Breaking changes**

--- a/packages/components/error-message/README.md
+++ b/packages/components/error-message/README.md
@@ -13,6 +13,7 @@ Find out more about the error message component and when to use it in the [NHS d
 
 ```html
 <span class="nhsuk-error-message">
+  <span class="nhsuk-u-visually-hidden">Error:</span> 
   Error message about full name goes here
 </span>
 ```
@@ -33,10 +34,11 @@ The error message Nunjucks macro takes the following arguments:
 
 | Name                      | Type     | Required  | Description             |
 | --------------------------|----------|-----------|-------------------------|
-| **text (or) html**        | string   | No        | Text to use within the error message. If `html` is provided, the `text` argument will be ignored. |
+| **text (or) html**        | string   | Yes       | Text to use within the error message. If `html` is provided, the `text` argument will be ignored. |
 | **id**                    | string   | No        | Optional id attribute to add to the error message span tag. |
 | **classes**               | string   | No        | Optional additional classes to add to the error message span tag. Separate each class with a space. |
 | **attributes**            | object   | No        | Any extra HTML attributes (for example data attributes) to add to the error message span tag. |
+| **visuallyHiddenText**    | string   | No        | A visually hidden prefix used before the error message. Defaults to "Error" |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
 

--- a/packages/components/error-message/template.njk
+++ b/packages/components/error-message/template.njk
@@ -1,6 +1,9 @@
+{% set visuallyHiddenText = params.visuallyHiddenText | default("Error") -%}
+
 <span class="nhsuk-error-message
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- if params.id %} id="{{ params.id }}"{% endif %}
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% if visuallyHiddenText %}<span class="nhsuk-u-visually-hidden">{{ visuallyHiddenText }}:</span> {% endif -%}
   {{ params.html | safe if params.html else params.text }}
 </span>


### PR DESCRIPTION
## Description

Prefix error messages with a visually hidden "Error:", to make it clearer to users of assistive technologies.