### PR TITLE
Enable autocomplete attributes for input components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Use `.nhsuk-width-container-fluid` for a full width container. Documentation and
   
 - Add example and code snippets for a Button as a link and remove the multiple examples for the disabled Button. The Button as a link includes the attribute `draggable="false"` to stop links that are styled as button from being dragged.
 
+- Enable `autocomplete` attributes for input components. The `autocomplete` attribute can now be enabled on input, date input and textarea components using the component macros parameters.
+  
+  This was already possible to do with the `attributes` option but this change highlights the new WCAG 2.1 success criteria [Identify Input Purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html) which "is to ensure that the purpose of a form input collecting information about the user can be programmatically determined, so that user agents can extract and present this purpose to users using different modalities".
+
+  See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
+
 ## 2.0.0 - Mar 11, 2019
 
 :boom: **Breaking changes**

--- a/app/components/date-input/autocomplete.njk
+++ b/app/components/date-input/autocomplete.njk
@@ -1,0 +1,48 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Date input with autocomplete attribute' %}
+{% from 'components/date-input/macro.njk' import dateInput %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="maincontent">
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          {{ dateInput({
+            "id": "dob-with-autocomplete-attribute",
+            "namePrefix": "dob-with-autocomplete",
+            "fieldset": {
+              "legend": {
+                "text": "What is your date of birth?"
+              }
+            },
+            "hint": {
+              "text": "For example, 31 3 1980"
+            },
+            "items": [
+              {
+                "name": "day",
+                "classes": "nhsuk-input--width-2",
+                "autocomplete": "bday-day"
+              },
+              {
+                "name": "month",
+                "classes": "nhsuk-input--width-2",
+                "autocomplete": "bday-month"
+              },
+              {
+                "name": "year",
+                "classes": "nhsuk-input--width-4",
+                "autocomplete": "bday-year"
+              }
+            ]
+          }) }}
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/app/components/input/autocomplete.njk
+++ b/app/components/input/autocomplete.njk
@@ -1,0 +1,27 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Input with autocomplete attribute' %}
+{% from 'components/input/macro.njk' import input %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="maincontent">
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          {{ input({
+            "label": {
+              "text": "Postcode"
+            },
+            "id": "input-with-autocomplete-attribute",
+            "name": "postcode",
+            "autocomplete": "postal-code"
+          }) }}
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/app/components/textarea/autocomplete.njk
+++ b/app/components/textarea/autocomplete.njk
@@ -1,0 +1,27 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Textarea with autocomplete attribute' %}
+{% from 'components/textarea/macro.njk' import textarea %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="maincontent">
+
+      <div class="nhsuk-grid-row">
+        <div class="nhsuk-grid-column-two-thirds">
+          {{ textarea({
+            "name": "address",
+            "id": "textarea-with-autocomplete-attribute",
+            "label": {
+              "text": "Full address"
+            },
+            "autocomplete": "street-address"
+          }) }}
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -39,6 +39,7 @@
     <li><a href="../components/checkboxes/error.html">Checkboxes with error message</a></li>
     <li><a href="../components/contents-list/index.html">Contents list</a></li>
     <li><a href="../components/date-input/index.html">Date input</a></li>
+    <li><a href="../components/date-input/autocomplete.html">Date input with autocomplete attribute</a></li>
     <li><a href="../components/date-input/error.html">Date input with error</a></li>
     <li><a href="../components/date-input/multiple-errors.html">Date input with multiple errors</a></li>
     <li><a href="../components/details/index.html">Details</a></li>
@@ -67,6 +68,7 @@
     <li><a href="../components/hint/index.html">Hint</a></li>
     <li><a href="../components/images/index.html">Images</a></li>
     <li><a href="../components/input/index.html">Input</a></li>
+    <li><a href="../components/input/autocomplete.html">Input with autocomplete attribute</a></li>
     <li><a href="../components/input/hint.html">Input with hint text</a></li>
     <li><a href="../components/input/error.html">Input with error message</a></li>
     <li><a href="../components/input/custom-width.html">Input with width modifier</a></li>
@@ -103,6 +105,7 @@
     <li><a href="../components/tables/index.html">Table</a></li>
     <li><a href="../components/tables/tables-panel.html">Table as a panel</a></li>
     <li><a href="../components/textarea/index.html">Textarea</a></li>
+    <li><a href="../components/textarea/autocomplete.html">Textarea with autocomplete attribute</a></li>
     <li><a href="../components/textarea/error.html">Textarea with error message</a></li>
     <li><a href="../components/warning-callout/index.html">Warning callout</a></li>
   </ul>

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -6,6 +6,8 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
 
 Find out more about the date input component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/date-input).
 
+Note: The `pattern` attribute is not valid HTML for inputs where the type attribute is number. It is added deliberately to [force numeric keypads on iOS devices](http://bradfrost.com/blog/post/better-numerical-inputs-for-mobile-forms/). See also [presenting iOS keyboards](https://stackoverflow.com/questions/25425181/iphone-ios-presenting-html-5-keyboard-for-postal-codes) for visual examples of iOS keyboards and attributes.
+
 ## Quick start examples
 
 ### Date input

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -88,9 +88,96 @@ Find out more about the date input component and when to use it in the [NHS digi
 
 ---
 
+### Date input with autocomplete attribute
+
+[Preview the date input with autocomplete attribute component](https://nhsuk.github.io/nhsuk-frontend/components/date-input/autocomplete.html)
+
+#### HTML markup
+
+```html
+<div class="nhsuk-form-group">
+  <fieldset class="nhsuk-fieldset" aria-describedby="dob-with-autocomplete-attribute-hint" role="group">
+    <legend class="nhsuk-fieldset__legend">
+      What is your date of birth?
+    </legend>
+    <span class="nhsuk-hint" id="dob-with-autocomplete-attribute-hint">
+    For example, 31 3 1980
+    </span>
+    <div class="nhsuk-date-input" id="dob-with-autocomplete-attribute">
+      <div class="nhsuk-date-input__item">
+        <div class="nhsuk-form-group">
+          <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-day">
+          Day
+          </label>
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" type="number" autocomplete="bday-day" pattern="[0-9]*">
+        </div>
+      </div>
+      <div class="nhsuk-date-input__item">
+        <div class="nhsuk-form-group">
+          <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-month">
+          Month
+          </label>
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-month" name="dob-with-autocomplete-month" type="number" autocomplete="bday-month" pattern="[0-9]*">
+        </div>
+      </div>
+      <div class="nhsuk-date-input__item">
+        <div class="nhsuk-form-group">
+          <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-year">
+          Year
+          </label>
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-with-autocomplete-attribute-year" name="dob-with-autocomplete-year" type="number" autocomplete="bday-year" pattern="[0-9]*">
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>
+```
+
+#### Nunjucks macro
+
+```
+{% from 'components/date-input/macro.njk' import dateInput %}
+
+{{ dateInput({
+  "id": "dob-with-autocomplete-attribute",
+  "namePrefix": "dob-with-autocomplete",
+  "fieldset": {
+    "legend": {
+      "text": "What is your date of birth?"
+    }
+  },
+  "hint": {
+    "text": "For example, 31 3 1980"
+  },
+  "items": [
+    {
+      "name": "day",
+      "classes": "nhsuk-input--width-2",
+      "autocomplete": "bday-day"
+    },
+    {
+      "name": "month",
+      "classes": "nhsuk-input--width-2",
+      "autocomplete": "bday-month"
+    },
+    {
+      "name": "year",
+      "classes": "nhsuk-input--width-4",
+      "autocomplete": "bday-year"
+    }
+  ]
+}) }}
+```
+
+---
+
 ### Date input with errors
 
 [Preview the date input with errors component](https://nhsuk.github.io/nhsuk-frontend/components/date-input/multiple-errors.html)
+
+#### Guidance
+
+See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
 
 #### HTML markup
 
@@ -275,6 +362,7 @@ The date input Nunjucks macro takes the following arguments:
 | **hint**                  | object   | No        | Arguments for the hint component (e.g. text). See [hint](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/hint) component. |
 | **errorMessage**          | object   | No        | Arguments for the error message component (e.g. text). See [error message](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/error-message) component. |
 | **fieldset**              | object   | No        | Arguments for the fieldset component (e.g. legend). See [fieldset](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/fieldset) component. |
+| **autocomplete**          | string   | No        | Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used. |
 | **classes**               | string   | No        | Optional additional classes to add to the date-input container. Separate each class with a space. |
 | **attributes**            | object   | No        | Any extra HTML attributes (for example data attributes) to add to the date-input container. |
 

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -94,6 +94,10 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
 
 [Preview the date input with autocomplete attribute component](https://nhsuk.github.io/nhsuk-frontend/components/date-input/autocomplete.html)
 
+#### Guidance
+
+See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
+
 #### HTML markup
 
 ```html
@@ -176,10 +180,6 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
 ### Date input with errors
 
 [Preview the date input with errors component](https://nhsuk.github.io/nhsuk-frontend/components/date-input/multiple-errors.html)
-
-#### Guidance
-
-See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
 
 #### HTML markup
 

--- a/packages/components/date-input/template.njk
+++ b/packages/components/date-input/template.njk
@@ -66,6 +66,7 @@
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
         type: "number",
+        autocomplete: item.autocomplete,
         attributes: {
           pattern: "[0-9]*"
         }

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -39,6 +39,42 @@ Find out more about the input component and when to use it in the [NHS digital s
 
 ---
 
+### Input with autocomplete attribute
+
+[Preview the input with autocomplete attribute component](https://nhsuk.github.io/nhsuk-frontend/components/input/autocomplete.html)
+
+#### Guidance
+
+See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
+
+#### HTML markup
+
+```html
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="input-with-autocomplete-attribute">
+  Postcode
+  </label>
+  <input class="nhsuk-input" id="input-with-autocomplete-attribute" name="postcode" type="text" autocomplete="postal-code">
+</div>
+```
+
+#### Nunjucks macro
+
+```
+{% from 'components/input/macro.njk' import input %}
+
+{{ input({
+  "label": {
+    "text": "Postcode"
+  },
+  "id": "input-with-autocomplete-attribute",
+  "name": "postcode",
+  "autocomplete": "postal-code"
+}) }}
+```
+
+---
+
 ### Input with hint text
 
 [Preview the input with hint text component](https://nhsuk.github.io/nhsuk-frontend/components/input/hint.html)
@@ -171,6 +207,7 @@ The input macro takes the following arguments:
 | **hint**            | object   | No        | Arguments for the hint component (e.g. text). See [hint](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/hint) component. |
 | **errorMessage**    | object   | No        | Arguments for the error message component (e.g. text). See [error message](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/error-message) component. |
 | **classes**         | string   | No        | Optional additional classes add to the input component. Separate each class with a space. |
+| **autocomplete**          | string   | No        | Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used. |
 | **attributes**      | object   | No        | Any extra HTML attributes (for example data attributes) to add to the input component. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/components/input/template.njk
+++ b/packages/components/input/template.njk
@@ -42,5 +42,6 @@
   {%- if params.errorMessage %} nhsuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
 </div>

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -45,6 +45,42 @@ Find out more about the textarea component and when to use it in the [NHS digita
 
 ---
 
+### Textarea with autocomplete attribute
+
+[Preview the textarea with autocomplete attribute component](https://nhsuk.github.io/nhsuk-frontend/components/textarea/autocomplete.html)
+
+#### Guidance
+
+See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.
+
+#### HTML markup
+
+```html
+<div class="nhsuk-form-group">
+  <label class="nhsuk-label" for="textarea-with-autocomplete-attribute">
+  Full address
+  </label>
+  <textarea class="nhsuk-textarea" id="textarea-with-autocomplete-attribute" name="address" rows="5" autocomplete="street-address"></textarea>
+</div>
+```
+
+#### Nunjucks macro
+
+```
+{% from 'components/textarea/macro.njk' import textarea %}
+
+{{ textarea({
+  "name": "address",
+  "id": "textarea-with-autocomplete-attribute",
+  "label": {
+    "text": "Full address"
+  },
+  "autocomplete": "street-address"
+}) }}
+```
+
+---
+
 ### Textarea with error message
 
 [Preview the textarea with error message component](https://nhsuk.github.io/nhsuk-frontend/components/textarea/error.html)
@@ -97,6 +133,7 @@ The textarea Nunjucks macro takes the following arguments:
 | **hint**            | object   | No        | Arguments for the hint component (e.g. text). See [hint](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/hint) component. |
 | **errorMessage**    | object   | No        | Arguments for the error message component (e.g. text). See [error message](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/error-message) component. |
 | **classes**         | string   | No        | Optional additional classes to add to the textarea tag. Separate each class with a space. |
+| **autocomplete**          | string   | No        | Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used. |
 | **attributes**      | object   | No        | Any extra HTML attributes (for example data attributes) to add to the textarea tag. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/components/textarea/template.njk
+++ b/packages/components/textarea/template.njk
@@ -40,5 +40,6 @@
   {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="
   {%- if params.rows %} {{ params.rows }} {% else %}5{%endif %}"
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
 </div>


### PR DESCRIPTION
## Description

This was already possible to do with the `attributes` option but this change highlights the new WCAG 2.1 success criteria (Identify Input Purpose) which "is to ensure that the purpose of a form input collecting information about the user can be programmatically determined, so that user agents can extract and present this purpose to users using different modalities".

See [autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used.

Added a note about the `pattern` attribute being used alongside `type="number"` due to invalid HTML being used.

## Checklist

- [ ] SCSS
- [x] Nunjucks macro
- [x] A standalone example
- [x] README/Documentation with HTML snippet
- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [x] CHANGELOG entry
