### PR TITLE
fixes backstop test not working on linux or windows

### DIFF
--- a/tests/backstop/backstop.js
+++ b/tests/backstop/backstop.js
@@ -1,6 +1,26 @@
 // Get the --testhost=... argument from the backstop command
 const arguments = require('minimist')(process.argv.slice(2));
-const TEST_HOST = arguments.testhost || "http://host.docker.internal:3000"
+var TEST_HOST = arguments.testhost || "http://host.docker.internal:3000"
+
+const childProcess = require('child_process')
+var output = ""
+try {
+  output = childProcess.execFileSync("/sbin/ip", ["route"], {encoding: "utf-8"})
+}
+catch (e) {
+  output = ""
+}
+
+const match = output.match(/default via ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) dev eth0/)
+
+let ip = undefined
+if (Array.isArray(match) && match.length >= 2) {
+  ip = match[1]
+}
+
+if (ip) {
+  TEST_HOST = arguments.testhost || `http://${ip}:3000`
+}
 
 module.exports = {
   "id": "nhsuk-frontend",

--- a/tests/backstop/backstop.js
+++ b/tests/backstop/backstop.js
@@ -1,25 +1,25 @@
 // Get the --testhost=... argument from the backstop command
 const arguments = require('minimist')(process.argv.slice(2));
-var TEST_HOST = arguments.testhost || "http://host.docker.internal:3000"
+var TEST_HOST = arguments.testhost || "http://host.docker.internal:3000";
 
-const childProcess = require('child_process')
-var output = ""
+const childProcess = require('child_process');
+var output = "";
 try {
-  output = childProcess.execFileSync("/sbin/ip", ["route"], {encoding: "utf-8"})
+  output = childProcess.execFileSync("/sbin/ip", ["route"], {encoding: "utf-8"});
 }
 catch (e) {
-  output = ""
+  output = "";
 }
 
-const match = output.match(/default via ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) dev eth0/)
+const match = output.match(/default via ((?:[0-9]{1,3}\.){3}[0-9]{1,3}) dev eth0/);
 
-let ip = undefined
+let ip = undefined;
 if (Array.isArray(match) && match.length >= 2) {
-  ip = match[1]
+  ip = match[1];
 }
 
 if (ip) {
-  TEST_HOST = arguments.testhost || `http://${ip}:3000`
+  TEST_HOST = arguments.testhost || `http://${ip}:3000`;
 }
 
 module.exports = {


### PR DESCRIPTION
## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry


Fixes backstop tests failing on linux and windows by adding a script to run `/sbin/ip route` inside the container and retrieve the docker bridge IP.