### PR TITLE
Remove light version of the font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # NHS.UK frontend Changelog
 
-## 2.1.1 - Unreleased
+## 2.2.0 - Unreleased
+
+:boom: **Breaking changes**
+
+- Remove light font version - The light version of the Frutiger font has been removed as it was only been used in one place. If you are referencing this by either using the SASS `$nhsuk-font-light` variable, or using a font weight of `300` then please make the appropriate style changes. ([PR 460](https://github.com/nhsuk/nhsuk-frontend/pull/460))
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # NHS.UK frontend Changelog
 
-## 2.2.0 - Unreleased
-
-:boom: **Breaking changes**
-
-- Remove light font version - The light version of the Frutiger font has been removed as it was only been used in one place. If you are referencing this by either using the SASS `$nhsuk-font-light` variable, or using a font weight of `300` then please make the appropriate style changes. ([PR 460](https://github.com/nhsuk/nhsuk-frontend/pull/460))
+## 2.1.1 - Unreleased
 
 :wrench: **Fixes**
+
+- Remove light font version - The light version of the Frutiger font has been removed as it was only been used in one place. The SASS `$nhsuk-font-light` variable has been remapped to use the `$nhsuk-font-normal` value as a defensive measure for now until it is decided to remove the `$nhsuk-font-light` variable completely. ([PR 460](https://github.com/nhsuk/nhsuk-frontend/pull/460))
 
 - Expander group component - Fixed expander group spacing issues when used with components with no top margin ([Issue 439](https://github.com/nhsuk/nhsuk-frontend/issues/439))
 

--- a/packages/components/header/_autocomplete.scss
+++ b/packages/components/header/_autocomplete.scss
@@ -126,7 +126,6 @@
   color: $color_nhsuk-blue;
   cursor: pointer;
   font-size: $nhsuk-base-font-size;
-  font-weight: $nhsuk-font-light;
   padding-bottom: 12px; /* [9] */
   text-align: left;
   text-decoration: underline;

--- a/packages/core/generic/_font-face.scss
+++ b/packages/core/generic/_font-face.scss
@@ -12,19 +12,6 @@
   font-family: 'Frutiger W01';
   font-display: swap;
   font-style: normal;
-  font-weight: 300;
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.eot?#iefix');
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.eot?#iefix') format('eot'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.woff2') format('woff2'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.woff') format('woff'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.ttf') format('truetype'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-45Light.svg#29f3ff8a-1719-4e25-a757-53ee1a1114a5') format('svg');
-}
-
-@font-face {
-  font-family: 'Frutiger W01';
-  font-display: swap;
-  font-style: normal;
   font-weight: 400;
   src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.eot?#iefix');
   src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.eot?#iefix') format('eot'),

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -13,6 +13,7 @@ $nhsuk-font-fallback: Helvetica, Arial, Sans-serif; // [1] //
 $nhsuk-font-family-print: sans-serif !default;
 $nhsuk-font-bold: 600;
 $nhsuk-font-normal: 400;
+$nhsuk-font-light: $nhsuk-font-normal;
 
 //
 // Font sizing and spacing

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -13,7 +13,6 @@ $nhsuk-font-fallback: Helvetica, Arial, Sans-serif; // [1] //
 $nhsuk-font-family-print: sans-serif !default;
 $nhsuk-font-bold: 600;
 $nhsuk-font-normal: 400;
-$nhsuk-font-light: 300;
 
 //
 // Font sizing and spacing


### PR DESCRIPTION
The Frutiger light font was only being referenced in the header
autocomplete dropdown, so we've decided to remove it and save a request
to get it.

## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [x] CHANGELOG entry
