### PR TITLE
remove the duplicate favicons from the docs

### DIFF
--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -104,8 +104,6 @@ document.addEventListener('DOMContentLoaded', function() {
 If you want to import assets such as the NHS logo, favicons and SVG icons, you might wish to copy the files into your project folders from the `node_modules/nhsuk-frontend/assets/` directory or you can reference them straight from the `node_modules` folder.
 
 ```html
-<link rel="apple-touch-icon" href="path-to-assets/apple-touch-icon.png">
-<link rel="icon" href="path-to-assets/favicon.png">
 <link rel="shortcut icon" href="path-to-assets/favicon.ico" type="image/x-icon">
 <link rel="apple-touch-icon" href="path-to-assets/apple-touch-icon-180x180.png">
 <link rel="mask-icon" href="path-to-assets/favicon.svg" color="#005eb8">


### PR DESCRIPTION
## Description

remove duplicate favicons from the installing with npm docs.

## Checklist

- [x] SCSS
- [x] Nunjucks macro
- [x] A standalone example
- [x] README/Documentation with HTML snippet
- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [x] Print stylesheet considered
- [ ] CHANGELOG entry
