### PR TITLE
open graph image asset path should be an absolute url

### DIFF
--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -89,7 +89,7 @@ If you require any of this functionality, you should [install using npm](/docs/i
     <meta property="og:title" content="NHS.UK">
     <meta property="og:description" content="Helping you take control of your health and wellbeing.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="assets/logos/open-graph.png">
+    <meta property="og:image" content="[absolute url]/assets/logos/open-graph.png">
     <meta property="og:image:alt" content="nhs.uk">
 
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Description

Update the example HTML layout to be filled in with the absolute URL.

CHANGELOG entry not needed as its a fix for a previous entry.

## Checklist

- [x] SCSS
- [x] Nunjucks macro
- [x] A standalone example
- [x] README/Documentation with HTML snippet
- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [x] Print stylesheet considered
- [x] CHANGELOG entry
