### PR TITLE
update panel group nunjuck macro

### DIFF
--- a/packages/components/panel/README.md
+++ b/packages/components/panel/README.md
@@ -136,6 +136,8 @@ To discuss or contribute to this component, visit the [GitHub issue for this com
       "HTML": "<h3>Healthy weight</h3> <p>Check your BMI using our healthy weight calculator and find out if you're a healthy weight</p>"
     }) }}
   </div>
+ </div>
+ <div class="nhsuk-grid-row nhsuk-panel-group">
   <div class="nhsuk-grid-column-one-half nhsuk-panel-group__item">
     {{ panel({
       "HTML": "<h3>Excercise</h3> <p>Programmes, workouts and tips to get you moving and improve your fitness and wellbeing</p>"


### PR DESCRIPTION
fixed the panel group to contain 2 panels within the nhsuk-grid-row nhsuk-panel-group div and not 4.

## Description

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
