### PR TITLE
[refs #465] secondary text colour utility class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Lede text - Lede text styling for use after the `<h1>` element, often used as intro text for the page immediately following the page header. You can see an example of Lede text on the [NHS website Live Well page](https://www.nhs.uk/live-well/), you can find the HTML code for Lede text in the [Typography section in the README](https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/core#lede-text). ([Issue 106](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/106))
 
+- Secondary text colour utility class - a new utility class to be able to use the secondary text colour within elements (`$nhsuk-secondary-text-color` - `#425563`) You can find the HTML code for secondary text colour utility class in the [Utilities section in the README](https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/core#secondary-text-colour) ([Issue 465](https://github.com/nhsuk/nhsuk-frontend/issues/465))
+
 :wrench: **Fixes**
 
 - Care card (immediate) - Fix colour contrast issue when using the Details component within the Care card (immediate) ([Issue 475](https://github.com/nhsuk/nhsuk-frontend/issues/475))

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,6 +158,12 @@ nhsuk-u-[grid-size]
 <p class="nhsuk-u-font-weight-normal"></p>
 ```
 
+### Secondary text colour
+
+```html
+<p class="nhsuk-u-secondary-text-color"></p>
+```
+
 ### Reading width
 
 Add a maximum width to large pieces of content, to improve readability. 

--- a/packages/core/utilities/_typography.scss
+++ b/packages/core/utilities/_typography.scss
@@ -2,6 +2,10 @@
    UTILITIES / #TYPOGRAPHY
    ========================================================================== */
 
+// Utility classes are allowed to use !important;
+// so we disable the sass-lint for that rule
+// sass-lint:disable no-important
+
 /**
  * Font size and line height
  *
@@ -32,4 +36,16 @@
 
 .nhsuk-u-font-weight-bold {
   @include nhsuk-typography-weight-bold($important: true);
+}
+
+/* Colours
+   ========================================================================== */
+
+/**
+ * Secondary text colour $nhsuk-secondary-text-color
+ * eg <p class="nhsuk-u-secondary-text-color">Published on: 15 March 2018</p>
+ */
+
+.nhsuk-u-secondary-text-color {
+  color: $nhsuk-secondary-text-color !important;
 }


### PR DESCRIPTION
## Description

Secondary text colour utility class - a new utility class to be able to use the secondary text colour within elements (`$nhsuk-secondary-text-color` - `#425563`) 

You can find the HTML code for secondary text colour utility class in the [Utilities section in the README](https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/core#secondary-text-colour) ([Issue 465](https://github.com/nhsuk/nhsuk-frontend/issues/465))

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
