### PR TITLE
fix issue where focus and hover states overlay content if link text is long.

### DIFF
--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -14,7 +14,6 @@
   @include nhsuk-responsive-margin(7, 'bottom');
 }
 
-
 .nhsuk-pagination__list {
   @include clearfix();
 }
@@ -31,7 +30,6 @@
   .nhsuk-pagination__title {
     padding-left: nhsuk-spacing(5); /* [1] */
   }
-
 }
 
 .nhsuk-pagination-item--next {
@@ -46,7 +44,6 @@
   .nhsuk-pagination__title {
     padding-right: nhsuk-spacing(5); /* [1] */
   }
-
 }
 
 .nhsuk-pagination__link {
@@ -54,6 +51,10 @@
   position: relative;
   text-decoration: none;
   width: 100%;
+
+  @include mq($media-type: print) {
+    color: $color_nhsuk-black;
+  }
 
   @include mq($media-type: print) {
     color: $color_nhsuk-black;
@@ -67,41 +68,59 @@
       color: $color_nhsuk-black;
       margin-top: 0;
     }
-
   }
 
-  &:focus {
-    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-focus-background-color;
-    outline: $nhsuk-focus-width solid $nhsuk-link-focus-background-color;
-  }
+  &--prev {
+    margin-right: nhsuk-spacing(3);
 
-  &:hover {
-    box-shadow: 0 0 0 $nhsuk-box-shadow-pagination $nhsuk-link-hover-background-color;
-    outline: $nhsuk-focus-width solid $nhsuk-link-hover-background-color;
-
-    .nhsuk-pagination__page {
-      text-decoration: none;
+    &:focus {
+      box-shadow: -12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-focus-background-color, -12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-focus-background-color;
     }
 
+    &:hover {
+      box-shadow: -12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-hover-background-color, -12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-hover-background-color;
+    }
+  }
+
+  &--next {
+    margin-left: nhsuk-spacing(3);
+
+    &:focus {
+      box-shadow: 12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-focus-background-color, 12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-focus-background-color;
+    }
+
+    &:hover {
+      box-shadow: 12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-hover-background-color, 12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-hover-background-color;
+    }
+  }
+
+  &--prev,
+  &--next {
+    @include mq($until: desktop) {
+      margin: 0;
+    }
   }
 
   &:hover,
   &:focus {
-
     .nhsuk-icon {
       fill: $color_nhsuk-black;
     }
+  }
 
+  &:hover {
+    outline: $nhsuk-focus-width solid $nhsuk-link-hover-background-color;
+  }
+
+  &:focus {
+    outline: $nhsuk-focus-width solid $nhsuk-link-focus-background-color;
   }
 
   &:visited {
-
     .nhsuk-icon {
       fill: $nhsuk-link-visited-color;
     }
-
   }
-
 }
 
 .nhsuk-pagination__title {
@@ -113,7 +132,6 @@
       content: ' page'; /* [2] */
     }
   }
-
 }
 
 .nhsuk-pagination__page {

--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -74,11 +74,11 @@
     margin-right: nhsuk-spacing(3);
 
     &:focus {
-      box-shadow: -12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-focus-background-color, -12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-focus-background-color;
+      box-shadow: -12px $nhsuk-box-shadow-pagination 0 20px $nhsuk-link-focus-background-color, -12px (-$nhsuk-box-shadow-pagination) 0 20px $nhsuk-link-focus-background-color;
     }
 
     &:hover {
-      box-shadow: -12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-hover-background-color, -12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-hover-background-color;
+      box-shadow: -12px $nhsuk-box-shadow-pagination 0 20px $nhsuk-link-hover-background-color, -12px (-$nhsuk-box-shadow-pagination) 0 20px $nhsuk-link-hover-background-color;
     }
   }
 
@@ -86,11 +86,11 @@
     margin-left: nhsuk-spacing(3);
 
     &:focus {
-      box-shadow: 12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-focus-background-color, 12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-focus-background-color;
+      box-shadow: 12px $nhsuk-box-shadow-pagination 0 20px $nhsuk-link-focus-background-color, 12px (-$nhsuk-box-shadow-pagination) 0 20px $nhsuk-link-focus-background-color;
     }
 
     &:hover {
-      box-shadow: 12px $nhsuk-box-shadow-pagination 0px 20px $nhsuk-link-hover-background-color, 12px (-$nhsuk-box-shadow-pagination) 0px 20px $nhsuk-link-hover-background-color;
+      box-shadow: 12px $nhsuk-box-shadow-pagination 0 20px $nhsuk-link-hover-background-color, 12px (-$nhsuk-box-shadow-pagination) 0 20px $nhsuk-link-hover-background-color;
     }
   }
 


### PR DESCRIPTION
## Description
If links in the pagination were too long the foxus and hover states would cover the text.
from issue #448

## Checklist

- [x] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
