### PR TITLE
Patch to remove &s from the middle of selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS.UK frontend Changelog
 
+
+## 2.3.0 - Unreleased
+
+:wrench: **Fixes**
+
+- Updated details.scss, radios.scss and checkboxes.scss components to remove &s from the middle of selectors and added new selectors that don't use the &s.
+
 ## 2.2.1 - Unreleased
 
 :wrench: **Fixes**

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -126,6 +126,43 @@ BEM stands for `Block__Element--Modifier`, not `Block__Element__Element--Modifie
 
 Avoid including multiple elements when naming classes.
 
+### Using ampsersands in selectors
+
+Create separate selectors rather using an `&` in the middle of a selector.
+
+This enables the NHSUK styles to be used inside other applications, where, for example, an ID is being used to isolate a section of a page to style separately from the rest of an application; e.g. 
+```scss
+div#nhsuk-ers {
+...
+@import 'node_modules/nhsuk-frontend/packages/core/all'; 
+...
+}
+``` 
+
+Bad: 
+
+```scss
+.nhsuk-checkboxes__conditional {
+  ...
+  .js-enabled &--hidden {
+    ...
+  }
+ ...
+}
+```
+
+Good: 
+
+```scss
+.nhsuk-checkboxes__conditional {
+  ...
+}
+
+.js-enabled .nhsuk-checkboxes__conditional--hidden {
+  ...
+}
+```
+
 ### Single Responsibility Principle
 
 Each class has a single purpose, so you can be sure when making a change to a

--- a/packages/components/checkboxes/_checkboxes.scss
+++ b/packages/components/checkboxes/_checkboxes.scss
@@ -133,11 +133,11 @@ $conditional-padding-left: $conditional-border-padding + $nhsuk-checkboxes-label
   margin-left: $conditional-margin-left;
   padding-left: $conditional-padding-left;
 
-  .js-enabled &--hidden {
-    display: none;
-  }
-
   & > :last-child {
     margin-bottom: 0;
   }
+}
+
+.js-enabled .nhsuk-checkboxes__conditional--hidden {
+  display: none;
 }

--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -44,9 +44,6 @@
 
     @include govuk-shape-arrow($direction: right, $base: 14px);
 
-    .nhsuk-details[open] > & {
-      @include govuk-shape-arrow($direction: down, $base: 14px);
-    }
   }
 
   &:focus {
@@ -66,9 +63,11 @@
       color: $nhsuk-link-hover-color;
       text-decoration: none;
     }
-
   }
+}
 
+.nhsuk-details[open] > .nhsuk-details__summary:before {
+  @include govuk-shape-arrow($direction: down, $base: 14px);
 }
 
 .nhsuk-details__summary-text {

--- a/packages/components/radios/_radios.scss
+++ b/packages/components/radios/_radios.scss
@@ -166,11 +166,11 @@ $conditional-padding-left: $conditional-border-padding + $nhsuk-radios-label-pad
   margin-left: $conditional-margin-left;
   padding-left: $conditional-padding-left;
 
-  .js-enabled &--hidden {
-    display: none;
-  }
-
   & > :last-child {
     margin-bottom: 0;
   }
+}
+
+.js-enabled .nhsuk-radios__conditional--hidden {
+  display: none;
 }


### PR DESCRIPTION
## Description
There are three places in where &s are used in the middle of selectors.
These instances have been rewritten to remove these and separate them
out into separate selectors, so that the NHSUK styles can be used in
conjunction with existing external selectors.

## Checklist

- [ ] SCSS
- [ ] Nunjucks macro
- [ ] A standalone example
- [ ] README/Documentation with HTML snippet
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Visual tests ([BackstopJS](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/automated-testing.md))
- [ ] Print stylesheet considered
- [ ] CHANGELOG entry
