### PR TITLE
h2 additional padding top after details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Open Graph image and meta data - use the latest Open Graph image and meta data from the NHS website. You can find this asset in the `packages/assets/logos` directory and the recommended meta data for Open Graph cards in the [Installing using compiled files - HTML template](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-compiled.md#html-template)
 
+- Details component - Additional top padding for a h2 / nhsuk-heading-l which is placed after the details component. [Issue 486](https://github.com/nhsuk/nhsuk-frontend/issues/486)
+
 ## 2.2.0 - 24th June 2019
 
 :new: **New features**

--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -171,3 +171,7 @@
 
   @include nhsuk-responsive-margin(4, 'bottom');
 }
+
+.nhsuk-details  + %nhsuk-heading-l {
+  @include nhsuk-responsive-padding(4, 'top');
+}


### PR DESCRIPTION
This is for Issue #486

## Description
After a details component the next h2 / nhsuk-heading-l  has additional padding

## Checklist

- [x] SCSS
- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
