### PR TITLE
use the latest version of backstopjs in the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         # Usually the `backstop test --docker` command would be used to run the tests,
         # but in travis we need to add a --network="host" flag to the docker-run command
         # so we compose our own docker-run command.
-        - docker run --rm -it --network="host" --mount type=bind,source="/home/travis/build/nhsuk/nhsuk-frontend",target=/src backstopjs/backstopjs:3.8.5 test --config=tests/backstop/backstop.js --moby --testhost=http://127.0.0.1:3000
+        - docker run --rm -it --network="host" --mount type=bind,source="/home/travis/build/nhsuk/nhsuk-frontend",target=/src backstopjs/backstopjs:latest test --config=tests/backstop/backstop.js --moby --testhost=http://127.0.0.1:3000
 
     - stage: master
       name: github pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,3 @@ jobs:
         on:
           tags: true
         skip_cleanup: true
-
-
-notifications:
-  slack: nhsuk:$SLACK_TOKEN#frontend


### PR DESCRIPTION
## Description

- unpin the specific version of the BackstopJS docker image in Travis CI config 
- remove the Slack notification in the Travis CI config
