### PR TITLE
add eslint and sass lint configuration path for code editors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "sass-lint": "^1.13.1",
     "webpack-stream": "^5.2.1"
   },
+  "eslintConfig": {
+    "extends": "./tests/linters/.eslintrc.js"
+  },
+  "sasslintConfig": "./tests/linters/.sass-lint.yml",
   "files": [
     "dist",
     "packages"


### PR DESCRIPTION
## Description

Code editors weren't automatically picking up the configuration file for the eslint, added to package.json so that they know where to look.