### PR TITLE
Fix javascript error with when header search is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK frontend Changelog
 
-## 2.3.2 - TBA
+## 2.3.2 - 30th September 2019
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 2.3.2 - TBA
+
+:wrench: **Fixes**
+
+- Header search - Fix javascript error when header search autocomplete is not present on the page ([Issue 531](https://github.com/nhsuk/nhsuk-frontend/issues/531)), add linting to all component JavaScript files, exclude linting from details polyfill, fix linting errors in autocomplete JavaScript, remove unnecessary JavaScript and CSS from autocomplete.
+
 ## 2.3.1 - 10th September 2019
 
 :wrench: **Fixes**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "scripts": {
     "prepare": "gulp bundle",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "gulp",
     "test": "npm run lint",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:html",
-    "lint:js": "eslint -c ./tests/linters/.eslintrc.js **/header/header.js **/skip-link/skip-link.js **/feedback-banner/feedback-banner.js",
+    "lint:js": "eslint -c ./tests/linters/.eslintrc.js packages/components/**/*.js",
     "lint:css": "sass-lint -c ./tests/linters/.sass-lint.yml 'packages/**/*.scss' -v -q",
     "lint:html": "htmlhint --config ./tests/linters/.htmlhintrc ./dist/app/components/**/*.html",
     "backstop:ref": "backstop --config=tests/backstop/backstop.js reference --docker",

--- a/packages/components/details/details.polyfill.js
+++ b/packages/components/details/details.polyfill.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 // Details
 
 // FF Support for HTML5's <details> and <summary>

--- a/packages/components/header/_autocomplete.scss
+++ b/packages/components/header/_autocomplete.scss
@@ -9,10 +9,8 @@
    * 4. Custom height and width of svg icons
    * 5. Custom spacing to position the search icon
    * 6. Drop shadow on search suggestions dopdown box, custom spread and blur
-   * 7. Needs !important because autocomplete js adds inline styling so need to
-   *    override
-   * 8. Z-index to bring the dropdown to the front
-   * 9. No current spacing at 12px so using this value
+   * 7. Z-index to bring the dropdown to the front
+   * 8. No current spacing at 12px so using this value
 */
 
 .autocomplete-container {
@@ -22,10 +20,6 @@
     display: inline;
     width: 100%;
   }
-}
-
-.autocomplete__wrapper {
-  position: relative;
 }
 
 @include mq($until: tablet) {
@@ -66,7 +60,7 @@
     border-top-right-radius: 0;
     font-size: $nhsuk-base-font-size;
     height: 40px; /* [3] */
-    padding: 0 12px; /* [9] */
+    padding: 0 12px; /* [8] */
     width: 235px; /* [3] */
 
     &:focus {
@@ -100,7 +94,8 @@
   padding: nhsuk-spacing(3);
   position: absolute;
   top: 100%;
-  z-index: 1; /* [8] */
+  width: 100%;
+  z-index: 1; /* [7] */
 
   @include mq($until: tablet) {
     border: 0;
@@ -109,8 +104,6 @@
     padding-left: 0;
     padding-right: 0;
     position: relative;
-    top: auto !important; // sass-lint:disable-line no-important /* [7] */
-    width: 100% !important; // sass-lint:disable-line no-important /* [7] */
   }
 }
 
@@ -127,7 +120,7 @@
   color: $color_nhsuk-blue;
   cursor: pointer;
   font-size: $nhsuk-base-font-size;
-  padding-bottom: 12px; /* [9] */
+  padding-bottom: 12px; /* [8] */
   text-align: left;
   text-decoration: underline;
 

--- a/packages/components/header/autocomplete.js
+++ b/packages/components/header/autocomplete.js
@@ -1,17 +1,5 @@
 import accessibleAutocomplete from 'accessible-autocomplete';
 
-function positionsAndWidths() {
-  // Get width and position for desktop sizes to position the dropdown.
-  // For smaller viewports, doesn't need to be positioned so styling is overridden by CSS
-  const wrap = document.getElementById('wrap-search');
-
-  if (wrap) {
-    const wrapRect = wrap.getBoundingClientRect();
-    const listBox = document.getElementById('search-field__listbox');
-    listBox.style.width = wrapRect.width + 'px';
-  }
-}
-
 function getFunnelbackQueryUrl(query) {
   const FUNNELBACK_QUERY_PATH = 'https://nhs.funnelback.co.uk/s/suggest.json';
   const FUNNELBACK_MAX_RESULTS = 10;
@@ -22,12 +10,10 @@ function getFunnelbackResults(query, populateResults) {
   const url = getFunnelbackQueryUrl(query);
   const xhr = new XMLHttpRequest();
   xhr.open('GET', url);
-  xhr.onload = function () {
+  xhr.onload = () => {
     if (xhr.status === 200) {
       const data = JSON.parse(xhr.responseText);
-      const results = data.map(item => {
-        return item.disp;
-      });
+      const results = data.map(item => item.disp);
       populateResults(results);
     } else {
       // TODO: nice error messaging here
@@ -51,21 +37,21 @@ function autocomplete(config) {
     const dots = result.length > truncateLength ? '...' : '';
     const resultTruncated = result.substring(0, truncateLength) + dots;
     const svgIcon = '<svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>';
-    const resultsHref = '<a href="https://www.nhs.uk/search?collection=nhs-meta&query=' + result + '">' + resultTruncated + '</a>';
+    const resultsHref = `<a href="https://www.nhs.uk/search?collection=nhs-meta&query=${result}">${resultTruncated}</a>`;
 
     return svgIcon + resultsHref;
   }
 
   const defaultConfig = {
-    element: document.querySelector('#autocomplete-container'),
-    id: id,
-    minLength: 2,
-    placeholder: fallbackInputElement.placeholder,
-    name: fallbackInputElement.name,
     confirmOnBlur: false,
+    element: document.querySelector('#autocomplete-container'),
+    id,
+    minLength: 2,
+    name: fallbackInputElement.name,
     onConfirm: (SelectedContent) => {
-      window.open('https://www.nhs.uk/search?collection=nhs-meta&query=' + SelectedContent, '_self');
+      window.open(`https://www.nhs.uk/search?collection=nhs-meta&query=${SelectedContent}`, '_self');
     },
+    placeholder: fallbackInputElement.placeholder,
     source: getFunnelbackResults,
     templates: {
       suggestion: suggestionTemplate,
@@ -80,44 +66,18 @@ function autocomplete(config) {
   const idToremove = document.getElementById(id);
   idToremove.parentNode.removeChild(idToremove);
   accessibleAutocomplete(accessibleAutocompleteConfig);
-
 }
 
-window.addEventListener("load", function (event) {
-  const wrap = document.querySelector('#wrap-search');
-
-  if (wrap) {
-    positionsAndWidths();
-    // To deal with window resizing, need to reset positioning of search results dropdown
-    // Use setTimeout on resize so as not to kill CPU
-    // https://developer.mozilla.org/en-US/docs/Web/Events/resize
-    window.addEventListener("resize", resizeThrottler, false);
-
-    let resizeTimeout;
-
-    function resizeThrottler() {
-      // ignore resize events as long as an actualResizeHandler execution is in the queue
-      if (!resizeTimeout) {
-        resizeTimeout = setTimeout(function () {
-          resizeTimeout = null;
-          actualResizeHandler();
-          // The actualResizeHandler will execute at a rate of 15fps
-        }, 66);
-      }
-    }
-
-    function actualResizeHandler() {
-      positionsAndWidths();
-    }
-
-  }
+window.addEventListener('load', () => {
   // Handle the enter keydown event to perform search
   const input = document.getElementById('search');
-  input.addEventListener("keyup", function (event) {
-    if (event.keyCode === 13) {
-      document.querySelector(".nhsuk-search__submit").click();
-    }
-  });
+  if (input) {
+    input.addEventListener('keyup', (event) => {
+      if (event.keyCode === 13) {
+        document.querySelector('.nhsuk-search__submit').click();
+      }
+    });
+  }
 });
 
 export default autocomplete;


### PR DESCRIPTION
## Description
Added linting to all JavaScript files under `packages/components`
Removed linting from details polyfill as it isn't our code... this will be fixed soon with ES6 refactor
Fixed linting errors in autocomplete
Added check for header search element to prevent JS error when adding and event listener
Removed unnecessary JavaScript which positioned the autocomplete on resize
Refactored CSS to position the autocomplete without the need for JavaScript

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
