### PR TITLE
Add npm script to approve BackstopJS screenshot changes

### DIFF
--- a/docs/contributing/automated-testing.md
+++ b/docs/contributing/automated-testing.md
@@ -61,8 +61,10 @@ BackstopJS creates a set of test bitmaps each time tests are run and compares th
 
 If you have made intentional visual changes, the reference bitmaps need to be updated for the tests (and future tests) to pass.
 
+After running the tests (`npm run backstop:test`) you can update the reference screenshots with:
+
 ```
-npm run backstop:ref
+npm run backstop:approve
 ```
 
 #### Add new tests scenarios

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:html": "htmlhint --config ./tests/linters/.htmlhintrc ./dist/app/components/**/*.html",
     "backstop:ref": "backstop --config=tests/backstop/backstop.js reference --docker",
     "backstop:test": "backstop --config=tests/backstop/backstop.js test --docker",
+    "backstop:approve": "backstop --config=tests/backstop/backstop.js approve",
     "backstop:clean": "rm -rf tests/backstop/bitmaps_test/*",
     "build-gh-pages": "gulp bundle && BASE_URL='/nhsuk-frontend' gulp docs:build",
     "build-gh-release": "gulp zip"


### PR DESCRIPTION
## Description

Add npm script to approve BackstopJS reference screenshots. After running BackstopJS tests you can update the screenshots with `npm run backstop:approve` opposed to having to run the tests again.

Change log not required as its doesn't affect the package.
