### PR TITLE
Removing overflow hidden hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Images - Add `size` and `srcset` attributes to the images component for responsive loading of images. ([Issue 422](https://github.com/nhsuk/nhsuk-frontend/issues/422))
+- Jaws/NVDA not reading fieldset heading - removing old `overflow: hidden` hack for hint text in legend
 
 ## 2.3.2 - 30th September 2019
 

--- a/packages/components/fieldset/_fieldset.scss
+++ b/packages/components/fieldset/_fieldset.scss
@@ -28,7 +28,6 @@
   display: table; /* 2 */
   margin-bottom: nhsuk-spacing(2);
   max-width: 100%; /* 1 */
-  overflow: hidden;
   padding: 0;
   white-space: normal;    /* 4 */
 }


### PR DESCRIPTION
## Description
Removing `overflow: hidden` hack for hint text in fieldsets

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [X] CHANGELOG entry
