### PR TITLE
Set fallback font to Arial by removing Helvetica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 :wrench: **Fixes**
 
 - Images - Add `size` and `srcset` attributes to the images component for responsive loading of images. ([Issue 422](https://github.com/nhsuk/nhsuk-frontend/issues/422))
-- Jaws/NVDA not reading fieldset heading - removing old `overflow: hidden` hack for hint text in legend
+- Jaws/NVDA not reading fieldset heading - removing old `overflow: hidden` hack for hint text in legend ([Issue 534](https://github.com/nhsuk/nhsuk-frontend/issues/534))
 - Fallback font - Fix fallback to be Arial by removing Helvetica.
 
 ## 2.3.2 - 30th September 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Images - Add `size` and `srcset` attributes to the images component for responsive loading of images. ([Issue 422](https://github.com/nhsuk/nhsuk-frontend/issues/422))
 - Jaws/NVDA not reading fieldset heading - removing old `overflow: hidden` hack for hint text in legend
+- Fallback font - Fix fallback to be Arial by removing Helvetica.
 
 ## 2.3.2 - 30th September 2019
 

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -9,7 +9,7 @@
 //
 
 $nhsuk-font: Frutiger W01;
-$nhsuk-font-fallback: Helvetica, Arial, Sans-serif; // [1] //
+$nhsuk-font-fallback: Arial, Sans-serif; // [1] //
 $nhsuk-font-family-print: sans-serif !default;
 $nhsuk-font-bold: 600;
 $nhsuk-font-normal: 400;


### PR DESCRIPTION
## Description

Changed `$nhsuk-font-fallback: Helvetica, Arial, Sans-serif;` to `$nhsuk-font-fallback: Arial, Sans-serif;` 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
