### PR TITLE
Call click event on keydown event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 3.0.2 - 11 November 2019
+
+:wrench: **Fixes**
+
+- Details keydown - following the details polyfill refactor, we've fixed an issue with keydown events not opening or closing the component
+
 ## 3.0.1 - 8 November 2019
 
 :wrench: **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "scripts": {
     "prepare": "gulp bundle",

--- a/packages/components/details/details.js
+++ b/packages/components/details/details.js
@@ -61,7 +61,7 @@ export default () => {
     summary.addEventListener('keydown', (event) => {
       if (event.keyCode === 13 || event.keyCode === 32) {
         event.preventDefault();
-        toggleDetails();
+        summary.click();
       }
     });
   };


### PR DESCRIPTION
## Description
Keydown events for space and enter were not opening or closing the details component. They now call the click event which works as expected.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
