### PR TITLE
remove references to the NuGet and PyPi packages until they are finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Visit the [NHS digital service manual](https://beta.nhs.uk/service-manual) for e
 
 We recommend that you [install NHS.UK frontend using node package manager (npm)](/docs/installation/installing-with-npm.md).
 
-Other package managers will become available in early 2019, such as NuGet and Python Package Index (PyPi).
-
 ### 2. Install by using compiled files
 
 You can also [install NHS.UK frontend using our compiled files](/docs/installation/installing-compiled.md), if you are not currently using a package manager.


### PR DESCRIPTION
## Description

Priorities with the NuGet and PyPi packages for the NHS.UK frontend have changed, they are currently in development but aren't ready so removing the reference to them to avoid confusion.