### PR TITLE
fixed transactional header layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # NHS.UK frontend Changelog
 
+## 3.1.0 - Unreleased
+
+:boom: **Breaking changes**
+
+- Fixed [Issue 563](https://github.com/nhsuk/nhsuk-frontend/issues/563)
+  - `transactionalService` parameter now deprecated. To set transactional service header, use normal service with the transactional flag. e.g:
+  ```
+  {{ header({
+      "transactional": "true",
+      "service": {
+        "name": "Register with a GP"
+      },
+      "showNav": "false",
+      "showSearch": "false"
+    })
+  }}
+  ```
+
 ## 3.0.2 - 11 November 2019
 
 :wrench: **Fixes**
@@ -136,7 +154,7 @@
 
   [Preview the header organisational component](https://nhsuk.github.io/nhsuk-frontend/components/header/header-org.html)
 
-  Organisation names can be edited as text in the `nhsuk-organisation-name` span element. 
+  Organisation names can be edited as text in the `nhsuk-organisation-name` span element.
   Longer organisation names can be split onto multiple lines with `nhsuk-organisation-name-split` span. (The NHS England brand guidelines explain when this must be done.)
   The organisation descriptor can be used with the `nhsuk-organisation-descriptor` class name span.
 

--- a/app/components/header/header-transactional-long-service-name.njk
+++ b/app/components/header/header-transactional-long-service-name.njk
@@ -6,7 +6,8 @@
 {% block body %}
 
   {{ header({
-      "transactionalService": {
+      "transactional": "true",
+      "service": {
         "name": "Find out why your NHS data matters",
         "longName": "true"
       },

--- a/app/components/header/header-transactional-service-name.njk
+++ b/app/components/header/header-transactional-service-name.njk
@@ -6,7 +6,8 @@
 {% block body %}
 
   {{ header({
-      "transactionalService": {
+      "transactional": "true",
+      "service": {
         "name": "Register with a GP"
       },
       "showNav": "false",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,7 +1770,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -453,7 +453,8 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-  "transactionalService": {
+    "transactional": "true",
+    "service": {
       "name": "Register with a GP",
       "href": "https://beta.nhs.uk/book-a-gp-appointment/"
     },
@@ -492,7 +493,8 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 ```
 {{ header({
-    "transactionalService": {
+    "transactional": "true",
+    "service": {
       "name": "Find out why your NHS data matters",
       "longName": "true"
     },
@@ -819,7 +821,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 [Preview the header organisational with white header and navigation component](https://nhsuk.github.io/nhsuk-frontend/components/header/header-org-white-nav.html)
 
-#### HTML markup 
+#### HTML markup
 
 ```html
 <header class="nhsuk-header nhsuk-header--organisation nhsuk-header--white nhsuk-header--white-nav" role="banner">
@@ -990,7 +992,6 @@ The header Nunjucks macro takes the following arguments:
 | **primaryLinks[].url**     | string   | No        | The href of a navigation item in the header. |
 | **primaryLinks[].label**   | string   | No        | The label of a navigation item in the header. |
 | **transactional**          | string   | No        | Set to "true" if this is a transactional header (with smaller logo). |
-| **transactionalService**   | object   | No        | Object containing the *name* and *href* and optional boolean *longName* of the transactional service. Set this to "true" if the transactional service name is longer than 22 characters. |
 | **service**                | object   | No        | Object containing the *name* and optional boolean *longName* of the service. Set this to "true" if the service name is longer than 22 characters. |
 | **classes**                | string   | No        | Optional additional classes to add to the header container. Separate each class with a space. |
 | **attributes**             | object   | No        | Any extra HTML attributes (for example data attributes) to add to the header container. |

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -1,9 +1,10 @@
 {# Define some defaults #}
 {% set showNav = params.showNav if params.showNav else "false" %}
 {% set showSearch = params.showSearch if params.showSearch else "false" %}
+{% set showTransactional = "true" if params.transactional and showNav == 'false' and showSearch == 'false' else "false"  %}
 
 <header class="nhsuk-header
-{%- if params.transactional or params.transactionalService %} nhsuk-header--transactional{% endif %}
+{%- if showTransactional == 'true' %} nhsuk-header--transactional{% endif %}
 {%- if params.organisation and params.organisation.name %} nhsuk-header--organisation{% endif %}
 {%- if params.classes %} {{ params.classes }}{% endif %}" role="banner"
 {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
@@ -24,13 +25,13 @@
         {%- endif %}
       </a>
       {%- else -%}
-      <a class="nhsuk-header__link{% if params.service %} nhsuk-header__link--service {% endif %}" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}" aria-label="{% if params.ariaLabel %}{{ params.ariaLabel }}{% else %}NHS homepage{% endif %}">
+      <a class="nhsuk-header__link{% if params.service and showTransactional == 'false' %} nhsuk-header__link--service {% endif %}" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}" aria-label="{% if params.ariaLabel %}{{ params.ariaLabel }}{% else %}NHS homepage{% endif %}">
         <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
           <path class="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
           <path class="nhsuk-logo__text" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
           <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
         </svg>
-        {%- if params.service %}
+        {%- if params.service and showTransactional == 'false' %}
         <span class="nhsuk-header__service-name">
           {{ params.service.name }}
         </span>
@@ -41,9 +42,9 @@
 
     {%- if showNav == "false" and showSearch == "false"%}
 
-      {%- if params.transactionalService%}
-        <div class="nhsuk-header__transactional-service-name{% if params.transactionalService.longName %} nhsuk-header__transactional-service-name--long{% endif %}">
-          <a class="nhsuk-header__transactional-service-name--link" href="{% if params.transactionalService.href %}{{ params.transactionalService.href }}{% else %}/{% endif %}">{{ params.transactionalService.name }}</a>
+      {%- if params.transactional%}
+        <div class="nhsuk-header__transactional-service-name{% if params.service.longName %} nhsuk-header__transactional-service-name--long{% endif %}">
+          <a class="nhsuk-header__transactional-service-name--link" href="{% if params.service.href %}{{ params.service.href }}{% else %}/{% endif %}">{{ params.service.name }}</a>
         </div>
       {%- endif %}
 


### PR DESCRIPTION
## Description

Fixed layout issue. `service` flag now controls both transactional and normal service names/href/longname etc.
Header will become transactional if `transactional` is set while `showNav` and `showSearch` are both false

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)

- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
