### PR TITLE
@elseif unsupported in future versions of sass

### DIFF
--- a/packages/core/tools/_typography.scss
+++ b/packages/core/tools/_typography.scss
@@ -145,7 +145,7 @@
       font-size: $font-size;
       font-size: $font-size-rem;
       line-height: $line-height;
-    } @elseif $breakpoint == 'print' {
+    } @else if $breakpoint == 'print' {
       @include govuk-media-query($media-type: print) {
         font-size: $font-size;
         line-height: $line-height;


### PR DESCRIPTION
## Description
Warning about deprecated feature in sass. `@else if` is supported going forward and not `@elseif`

'DEPRECATION WARNING on line 148, column 7 of node_modules/nhsuk-frontend/packages/core/tools/_typography.scss: 
elseif is deprecated and will not be supported in future Sass versions.'
## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
Updated core/tools/_typography.css to remove use of deprecated feature.
