### PR TITLE
Fix link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 :wrench: **Fixes**
 
 - Expander - fix the Expander plus and minus icon sizing on IE11 ([Issue 564](https://github.com/nhsuk/nhsuk-frontend/issues/564))
+- Button - fix the active state text colour for button as a link
+- Back button - fix the text hover colour for visited links
+- Breadcrumb - fix the text hover colour for visited links
 
 ## 3.0.2 - 11 November 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Button - fix the active state text colour for button as a link
 - Back button - fix the text hover colour for visited links
 - Breadcrumb - fix the text hover colour for visited links
+- Pagination - fix the pagination arrow colour on active and visited links
 
 ## 3.0.2 - 11 November 2019
 

--- a/packages/components/back-link/_back-link.scss
+++ b/packages/components/back-link/_back-link.scss
@@ -33,6 +33,7 @@
   }
 
   &:hover {
+    color: $nhsuk-link-hover-color;
     text-decoration: underline;
 
     .nhsuk-icon__chevron-left {

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -74,6 +74,17 @@
 
 }
 
+.nhsuk-breadcrumb__link {
+  &:visited {
+    color: $nhsuk-link-color;
+
+    &:hover {
+      color: $nhsuk-link-hover-color;
+    }
+  }
+
+}
+
 .nhsuk-breadcrumb__back {
   @include nhsuk-font(16); /* [4] */
   background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-left' xmlns='http://www.w3.org/2000/svg' fill='%23005eb8' height='24' width='24' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z'%3E%3C/path%3E%3C/svg%3E") -8px center no-repeat; // sass-lint:disable-line quotes
@@ -89,8 +100,15 @@
 .nhsuk-breadcrumb__backlink {
   left: -8px; /* [6] */
   position: relative;
-}
 
+  &:visited {
+    color: $nhsuk-link-color;
+
+    &:hover {
+      color: $nhsuk-link-hover-color;
+    }
+  }
+}
 
 /**
  * IE8 fixes

--- a/packages/components/button/_button.scss
+++ b/packages/components/button/_button.scss
@@ -63,6 +63,10 @@ $button-shadow-size: 4px;
     box-shadow: 0 $button-shadow-size 0 $nhsuk-focus-text-color;
     color: $nhsuk-focus-text-color;
     outline: $nhsuk-focus-width solid transparent;
+
+    &:visited {
+      color: $nhsuk-button-text-color;
+    }
   }
 
   &:active {
@@ -159,6 +163,10 @@ $button-shadow-size: 4px;
 
   &:link {
     color: $nhsuk-reverse-button-text-color;
+
+    &:active {
+      color: $color_nhsuk-white;
+    }
   }
 
   &.nhsuk-button--disabled {

--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -112,6 +112,12 @@
       }
     }
 
+    &:focus {
+      .nhsuk-icon {
+        fill: $nhsuk-focus-text-color;
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
## Description

Fix some pseudo link styles for the:
- button as a link (text colour for the active state)
- back link (text colour for the visited/hover state)
- breadcrumb (text colour for the visited/hover state)
- pagination (icon colour for the visited/hover state)

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
