### PR TITLE
remove random margin-top from the Menu button on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Back button - fix the text hover colour for visited links
 - Breadcrumb - fix the text hover colour for visited links
 - Pagination - fix the pagination arrow colour on active and visited links
+- Header - remove random margin from the Menu button on Safari ([PR 581](https://github.com/nhsuk/nhsuk-frontend/pull/581))
 
 ## 3.0.2 - 11 November 2019
 

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -37,6 +37,7 @@
  * 15. IE 9 alternative for flexbox
  * 16. Use non variable colour to follow NHS England guidelines on logo colour
  * 17. On print stylesheets remove the header link
+ * 18. Remove random top margin in Safari
  */
 
 @import 'autocomplete';
@@ -461,6 +462,10 @@
 
   @include mq($until: tablet) {
     right: 48px;
+  }
+
+  @include mq($from: tablet, $until: large-desktop) {
+    margin-top: 0; /* [18] */
   }
 
   &:focus {


### PR DESCRIPTION
## Description

On screen sizes between the table and large-desktop breakpoints, there is a random 1 pixel margin-top on the Menu button in Safari. This makes the button unaligned with the search bar.

This isn't an issue on Chrome or Firefox

<img width="946" alt="Screenshot 2020-01-24 at 09 43 56" src="https://user-images.githubusercontent.com/11615501/73059655-1b266280-3e8e-11ea-98be-7091dd640e0f.png">

Setting margin-top to 0 between the table and large-desktop breakpoints fixes the issue on Safari and has no affect on other browsers.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
