### PR TITLE
prevent additional padding on care card headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Breadcrumb - fix the text hover colour for visited links
 - Pagination - fix the pagination arrow colour on active and visited links
 - Header - remove random margin from the Menu button on Safari ([PR 581](https://github.com/nhsuk/nhsuk-frontend/pull/581))
+- Care card - prevent additional padding on care card headings
 
 ## 3.0.2 - 11 November 2019
 

--- a/packages/components/care-card/_care-card.scss
+++ b/packages/components/care-card/_care-card.scss
@@ -15,6 +15,7 @@
  * 4. 'Random number' for the heading triangle positioning.
  * 5. 'Random number' used for spacing to compensate for the triangle.
  * 6. Needed to enable the triangle to show correctly in high contrast mode.
+ * 7. Prevent additional padding on headings
  */
 
 .nhsuk-care-card {
@@ -59,6 +60,7 @@
   @include print-color($nhsuk-print-text-color);
 
   margin: 0;
+  padding-top: 0; /* [7] */
 }
 
 .nhsuk-care-card__content {


### PR DESCRIPTION
## Description

Prevent additional padding on care card headings. This helps if the care card is nested within multiple sections or divs and the general padding removal doesn't apply.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
