### PR TITLE
update links to the latest service manual URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NHS.UK frontend contains the code you need to start building user interfaces for
 
 ## Guidance
 
-Visit the [NHS digital service manual](https://beta.nhs.uk/service-manual) for examples of components and guidance for when to use them. If we haven’t yet published guidance on the component you want, please [email us](mailto:service-manual@nhs.net) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).
+Visit the [NHS digital service manual](https://service-manual.nhs.uk/) for examples of components and guidance for when to use them. If we haven’t yet published guidance on the component you want, please [email us](mailto:service-manual@nhs.net) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).
 
 ## How to install NHS.UK frontend
 

--- a/app/index.njk
+++ b/app/index.njk
@@ -48,7 +48,7 @@
 
   <div class="nhsuk-u-reading-width">
 
-    <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a> for guidance and examples.</p>
+    <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://service-manual.nhs.uk/">NHS digital service manual</a> for guidance and examples.</p>
 
   </div>
 

--- a/packages/components/action-link/README.md
+++ b/packages/components/action-link/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the action link component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/action-link).
+Find out more about the action link component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/action-link).
 
 ## Quick start example
 

--- a/packages/components/back-link/README.md
+++ b/packages/components/back-link/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the back link component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/back-link).
+Find out more about the back link component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/back-link).
 
 ## Quick start example
 

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the breadcrumb component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/breadcrumbs).
+Find out more about the breadcrumb component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/breadcrumbs).
 
 ## Quick start example
 

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the button component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/buttons).
+Find out more about the button component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/buttons).
 
 ## Quick start examples
 

--- a/packages/components/care-card/README.md
+++ b/packages/components/care-card/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the care card component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/care-cards).
+Find out more about the care card component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/care-cards).
 
 ## Quick start examples
 

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the checkboxes component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/checkboxes).
+Find out more about the checkboxes component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/checkboxes).
 
 ## Quick start examples
 

--- a/packages/components/contents-list/README.md
+++ b/packages/components/contents-list/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the contents list component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/contents-list).
+Find out more about the contents list component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/contents-list).
 
 ## Quick start example
 

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the date input component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/date-input).
+Find out more about the date input component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/date-input).
 
 Note: The `pattern` attribute is not valid HTML for inputs where the type attribute is number. It is added deliberately to [force numeric keypads on iOS devices](http://bradfrost.com/blog/post/better-numerical-inputs-for-mobile-forms/). See also [presenting iOS keyboards](https://stackoverflow.com/questions/25425181/iphone-ios-presenting-html-5-keyboard-for-postal-codes) for visual examples of iOS keyboards and attributes.
 

--- a/packages/components/details/README.md
+++ b/packages/components/details/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the details component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/details).
+Find out more about the details component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/details).
 
 ## Dependencies
 
@@ -68,7 +68,7 @@ For this component to be accessible and compatible with older browsers, include 
 
 #### Guidance
 
-Find out more about the expander component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/expander).
+Find out more about the expander component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/expander).
 
 #### HTML markup
 

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -1,7 +1,7 @@
 # Do and don't list
 
 ## Guidance
-Find out more about the do and don't list component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/do-and-dont-list).
+Find out more about the do and don't list component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/do-and-dont-lists).
 
 ## Quick start example
 

--- a/packages/components/error-message/README.md
+++ b/packages/components/error-message/README.md
@@ -1,7 +1,7 @@
 # Error message
 
 ## Guidance
-Find out more about the error message component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/error-message).
+Find out more about the error message component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/error-message).
 
 ## Quick start example
 

--- a/packages/components/error-summary/README.md
+++ b/packages/components/error-summary/README.md
@@ -1,7 +1,7 @@
 # Error summary
 
 ## Guidance
-Find out more about the error summary component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/error-summary).
+Find out more about the error summary component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/error-summary).
 
 ## Quick start example
 

--- a/packages/components/fieldset/README.md
+++ b/packages/components/fieldset/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the fieldset component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/fieldset).
+Find out more about the fieldset component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/fieldset).
 
 ## Quick start examples
 

--- a/packages/components/footer/README.md
+++ b/packages/components/footer/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the footer component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/footer).
+Find out more about the footer component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/footer).
 
 ## Quick start examples
 

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the header component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/header).
+Find out more about the header component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/header).
 
 ## Dependencies
 

--- a/packages/components/hint/README.md
+++ b/packages/components/hint/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the hint component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/hint-text).
+Find out more about the hint component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/hint-text).
 
 ## Quick start example
 

--- a/packages/components/images/README.md
+++ b/packages/components/images/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the images component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/images).
+Find out more about the images component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/images).
 
 ## Quick start example
 

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the input component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/text-input).
+Find out more about the input component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/text-input).
 
 ## Quick start examples
 

--- a/packages/components/inset-text/README.md
+++ b/packages/components/inset-text/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the inset text component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/inset-text).
+Find out more about the inset text component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/inset-text).
 
 ## Quick start example
 

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the pagination component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/pagination).
+Find out more about the pagination component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/pagination).
 
 ## Quick start examples
 

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the radios component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/radios).
+Find out more about the radios component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/radios).
 
 ## Quick start examples
 

--- a/packages/components/review-date/README.md
+++ b/packages/components/review-date/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the review date component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/review-date).
+Find out more about the review date component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/review-date).
 
 ## Quick start example
 

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the select component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/select).
+Find out more about the select component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/select).
 
 ## Quick start examples
 

--- a/packages/components/skip-link/README.md
+++ b/packages/components/skip-link/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the skip link component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/skip-link).
+Find out more about the skip link component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/skip-link).
 
 ## Dependencies
 

--- a/packages/components/tables/README.md
+++ b/packages/components/tables/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the table component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/table).
+Find out more about the table component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/table).
 
 ## Quick start examples
 

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the textarea component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/textarea).
+Find out more about the textarea component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/textarea).
 
 ## Quick start examples
 

--- a/packages/components/warning-callout/README.md
+++ b/packages/components/warning-callout/README.md
@@ -2,7 +2,7 @@
 
 ## Guidance
 
-Find out more about the warning callout component and when to use it in the [NHS digital service manual](https://beta.nhs.uk/service-manual/styles-components-patterns/warning-callout).
+Find out more about the warning callout component and when to use it in the [NHS digital service manual](https://service-manual.nhs.uk/design-system/components/warning-callout).
 
 ## Quick start example
 


### PR DESCRIPTION
## Description

The NHS digital service manual recently went from beta to live. This change is up date all the links to the service manual in the documentation.