### PR TITLE
fix issue with Travis CI by opting into v2 deployment tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ jobs:
       script: npm run build-gh-release
       deploy:
         provider: releases
-        api_key: $GITHUB_TOKEN
+        edge: true
+        api_token: $GITHUB_TOKEN
         file_glob: true
         file: ./dist/nhsuk-frontend-*.zip
         skip_cleanup: true
@@ -60,6 +61,7 @@ jobs:
       name: publish to npm
       deploy:
         provider: npm
+        edge: true
         email: $NPM_EMAIL
         api_key: $NPM_API_KEY
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       deploy:
         provider: releases
         edge: true
-        api_token: $GITHUB_TOKEN
+        token: $GITHUB_TOKEN
         file_glob: true
         file: ./dist/nhsuk-frontend-*.zip
         skip_cleanup: true
@@ -63,7 +63,7 @@ jobs:
         provider: npm
         edge: true
         email: $NPM_EMAIL
-        api_key: $NPM_API_KEY
+        api_token: $NPM_API_KEY
         on:
           tags: true
         skip_cleanup: true


### PR DESCRIPTION
## Description

Travis CI was having issues deploying to npm due to recently version changes in tooling on their end. This change opts in to using the latest version and relevant configuration for the new token name for API keys.

https://docs.travis-ci.com/user/deployment-v2
https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/14
