### PR TITLE
Added focus-text-color to the breadcrumb on :focus:hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 3.0.4 - Unreleased
+
+:wrench: **Fixes**
+
+- Breadcrumb - fix the text colour on :focus:hover ([Issue 589](https://github.com/nhsuk/nhsuk-frontend/issues/589))
+
 ## 3.0.3 - 17 February 2020
 
 :wrench: **Fixes**
@@ -149,7 +155,7 @@
 
   [Preview the header organisational component](https://nhsuk.github.io/nhsuk-frontend/components/header/header-org.html)
 
-  Organisation names can be edited as text in the `nhsuk-organisation-name` span element. 
+  Organisation names can be edited as text in the `nhsuk-organisation-name` span element.
   Longer organisation names can be split onto multiple lines with `nhsuk-organisation-name-split` span. (The NHS England brand guidelines explain when this must be done.)
   The organisation descriptor can be used with the `nhsuk-organisation-descriptor` class name span.
 

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -75,6 +75,12 @@
 }
 
 .nhsuk-breadcrumb__link {
+  &:focus {
+    &:hover {
+      color: $nhsuk-focus-text-color;
+    }
+  }
+
   &:visited {
     color: $nhsuk-link-color;
 
@@ -82,7 +88,6 @@
       color: $nhsuk-link-hover-color;
     }
   }
-
 }
 
 .nhsuk-breadcrumb__back {


### PR DESCRIPTION
## Description

Resolves: #589 

Following the instructions on issue #589, added a `:focus:hover` state and made it `$nhsuk-focus-text-color`.

I wasn't sure what format would be preferred. I went with the latter, and both seemed to pass the linting checks.

```scss
:focus:hover {

}
// or 
:focus {
  :hover {

  }
}
```

There didn't seem to be a new release planned in the CHANGELOG, and I didn't want to presume what type of release and the date, so happy to take advice on this.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
