### PR TITLE
Button - fix the text colour on :focus :visited states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Breadcrumb - fix the text colour on :focus:hover ([Issue 589](https://github.com/nhsuk/nhsuk-frontend/issues/589))
 - Transactional Header - fix the text colour on :focus:hover for non visited links ([Issue 592](https://github.com/nhsuk/nhsuk-frontend/issues/592))
+- Button - fix the text colour on :focus :visited states and remove the role="button" from button as a link example ([Issue 593](https://github.com/nhsuk/nhsuk-frontend/issues/593)) ([Issue 425](https://github.com/nhsuk/nhsuk-frontend/issues/425))
 
 ## 3.0.3 - 17 February 2020
 

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -37,7 +37,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 #### HTML markup
 
 ```html
-<a href="/" role="button" draggable="false" class="nhsuk-button">
+<a href="/" class="nhsuk-button" draggable="false">
   Link button
 </a>
 ```

--- a/packages/components/button/_button.scss
+++ b/packages/components/button/_button.scss
@@ -65,7 +65,12 @@ $button-shadow-size: 4px;
     outline: $nhsuk-focus-width solid transparent;
 
     &:visited {
-      color: $nhsuk-button-text-color;
+      color: $nhsuk-focus-text-color;
+
+      &:active {
+        color: $color_nhsuk-white;
+      }
+
     }
   }
 

--- a/packages/components/button/template.njk
+++ b/packages/components/button/template.njk
@@ -23,8 +23,7 @@
  {%- endset -%}
 
 {% if element == 'a' %}
-<a{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" role="button" draggable="false"
-  {%- if params.disabled %} aria-disabled="true"{% endif %}>
+<a{{ commonAttributes | safe }} href="{{ params.href if params.href else '#' }}" draggable="false"{%- if params.disabled %} aria-disabled="true"{% endif %}>
   {{ params.html | safe if params.html else params.text }}
 </a>
 


### PR DESCRIPTION
## Description

Button - fix the text colour on :focus :visited states and remove the role="button" from button as a link example ([Issue 593](https://github.com/nhsuk/nhsuk-frontend/issues/593)) ([Issue 425](https://github.com/nhsuk/nhsuk-frontend/issues/425))

Resolves #593 & #425 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
