### PR TITLE
Vendor in Sass-MQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Vendor in Sass-MQ
+
 ## 4.1.0 - Unreleased
 
 :new: **New features**
@@ -36,171 +42,178 @@
     <summary>If you are using a panel component</summary>
 
     You will need to replace the panel component with a card component.
+  You will need to replace the panel component with a card component.
 
-    ### For Nunjucks macro
+  ### For Nunjucks macro
 
-    You need to:
-    - replace `{% from 'components/panel/macro.njk' import panel %}` with `{% from 'components/card/macro.njk' import card %}`
-    - replace `{{ panel({` with `{{ card({`
-    - replace `"html"` with the relevant arguments - for example: `"heading"` and `"descriptionHtml"`
-    - declare the heading level size and heading sizes (with helper classes) because the default heading level is now 2 instead of 3
+  You need to:
 
-    For example:
+  - replace `{% from 'components/panel/macro.njk' import panel %}` with `{% from 'components/card/macro.njk' import card %}`
+  - replace `{{ panel({` with `{{ card({`
+  - replace `"html"` with the relevant arguments - for example: `"heading"` and `"descriptionHtml"`
+  - declare the heading level size and heading sizes (with helper classes) because the default heading level is now 2 instead of 3
 
-    #### Old Nunjucks macro (Panel)
+  For example:
 
-    ```
-    {% from 'components/panel/macro.njk' import panel %}
+  #### Old Nunjucks macro (Panel)
 
-    {{ panel({
-      "html": "<h3>If you need help now, but it’s not an emergency</h3> <p>Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
-    }) }}
-    ```
+  ```
+  {% from 'components/panel/macro.njk' import panel %}
 
-    #### New Nunjucks macro (Card)
+  {{ panel({
+    "html": "<h3>If you need help now, but it’s not an emergency</h3> <p>Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
+  }) }}
+  ```
 
-    ##### Changing the heading level
+  #### New Nunjucks macro (Card)
 
-    ```
-    {% from 'components/card/macro.njk' import card %}
+  ##### Changing the heading level
 
-    {{ card({
-      "heading": "If you need help now, but it’s not an emergency",
-      "headingLevel": "3",
-      "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
-    }) }}
-    ```
+  ```
+  {% from 'components/card/macro.njk' import card %}
 
-    ##### Changing the heading size
+  {{ card({
+    "heading": "If you need help now, but it’s not an emergency",
+    "headingLevel": "3",
+    "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
+  }) }}
+  ```
 
-    ```
-    {% from 'components/card/macro.njk' import card %}
+  ##### Changing the heading size
 
-    {{ card({
-      "heading": "If you need help now, but it’s not an emergency",
-      "headingClasses": "nhsuk-heading-m",
-      "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
-    }) }}
-    ```
+  ```
+  {% from 'components/card/macro.njk' import card %}
 
-    ### For HTML
+  {{ card({
+    "heading": "If you need help now, but it’s not an emergency",
+    "headingClasses": "nhsuk-heading-m",
+    "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
+  }) }}
+  ```
 
-    You need to:
-    - replace all `nhsuk-panel` classes to `nhsuk-card`
+  ### For HTML
 
-    For example:
+  You need to:
 
-    #### Old HTML (Panel)
+  - replace all `nhsuk-panel` classes to `nhsuk-card`
 
-    ```
-    <div class="nhsuk-panel nhsuk-panel--grey">
-      <h3>If you need help now, but it’s not an emergency</h3>
-      <p>Go to <a href="#">111.nhs.uk</a> or <a href="tel: 111">call 111</a>.</p>
+  For example:
+
+  #### Old HTML (Panel)
+
+  ```
+  <div class="nhsuk-panel nhsuk-panel--grey">
+    <h3>If you need help now, but it’s not an emergency</h3>
+    <p>Go to <a href="#">111.nhs.uk</a> or <a href="tel: 111">call 111</a>.</p>
+  </div>
+  ```
+
+  #### New HTML (Card)
+
+  ```
+  <div class="nhsuk-card>
+    <div class="nhsuk-card__content">
+      <h3 class="nhsuk-card__heading">If you need help now, but it’s not an emergency</h3>
+      <p>Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
     </div>
-    ```
+  </div>
+  ```
 
-    #### New HTML (Card)
-
-    ```
-    <div class="nhsuk-card>
-      <div class="nhsuk-card__content">
-        <h3 class="nhsuk-card__heading">If you need help now, but it’s not an emergency</h3>
-        <p>Go to <a href="#">111.nhs.uk</a> or <a href="#">call 111</a>.</p>
-      </div>
-    </div>
-    ```
   </details>
 
   <details>
     <summary>If you are using a promo component</summary>
 
-    You will need to replace the promo component with a card component.
+  You will need to replace the promo component with a card component.
 
-    ### For Nunjucks macro
+  ### For Nunjucks macro
 
-    You need to:
-    - replace `{% from 'components/promo/macro.njk' import promo %}` with `{% from 'components/card/macro.njk' import card %}`
-    - replace `{{ promo({` with `{{ card({`
-    - declare the heading level size and heading sizes (with helper classes) because the default heading level is now 2 instead of 3
+  You need to:
 
-    For example:
+  - replace `{% from 'components/promo/macro.njk' import promo %}` with `{% from 'components/card/macro.njk' import card %}`
+  - replace `{{ promo({` with `{{ card({`
+  - declare the heading level size and heading sizes (with helper classes) because the default heading level is now 2 instead of 3
 
-    #### Old Nunjucks macro (Promo)
+  For example:
 
-    ```
-    {% from 'components/promo/macro.njk' import promo %}
+  #### Old Nunjucks macro (Promo)
 
-    {{ promo({
-      "href": "https://www.nhs.uk",
-      "heading": "Save a life: give blood",
-      "description": "Please register today. Donating blood is easy, and saves lives."
-    }) }}
-    ```
+  ```
+  {% from 'components/promo/macro.njk' import promo %}
 
-    #### New Nunjucks macro (Card)
+  {{ promo({
+    "href": "https://www.nhs.uk",
+    "heading": "Save a life: give blood",
+    "description": "Please register today. Donating blood is easy, and saves lives."
+  }) }}
+  ```
 
-    ##### Changing the heading level
+  #### New Nunjucks macro (Card)
 
-    ```
-    {% from 'components/card/macro.njk' import card %}
+  ##### Changing the heading level
 
-    {{ card({
-      "href": "https://www.nhs.uk",
-      "heading": "Save a life: give blood",
-      "headingLevel": "3",
-      "description": "Please register today. Donating blood is easy, and saves lives."
-    }) }
-    ```
+  ```
+  {% from 'components/card/macro.njk' import card %}
 
-    ##### Changing the heading size
+  {{ card({
+    "href": "https://www.nhs.uk",
+    "heading": "Save a life: give blood",
+    "headingLevel": "3",
+    "description": "Please register today. Donating blood is easy, and saves lives."
+  }) }
+  ```
 
-    ```
-    {% from 'components/card/macro.njk' import card %}
+  ##### Changing the heading size
 
-    {{ card({
-      "href": "https://www.nhs.uk",
-      "heading": "Save a life: give blood",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Please register today. Donating blood is easy, and saves lives."
-    }) }
-    ```
+  ```
+  {% from 'components/card/macro.njk' import card %}
 
-    ### For HTML
+  {{ card({
+    "href": "https://www.nhs.uk",
+    "heading": "Save a life: give blood",
+    "headingClasses": "nhsuk-heading-m",
+    "description": "Please register today. Donating blood is easy, and saves lives."
+  }) }
+  ```
 
-    You need to:
-    - replace all `nhsuk-promo` classes to `nhsuk-card`
-    - remove surrounding `<a class="nhsuk-promo__link-wrapper" href="#">` and add `<a class="nhsuk-card__link" href="#">` within `<h3 class="nhsuk-card__heading">`
-    - add `nhsuk-card--clickable` class to make entire card clickable
+  ### For HTML
 
-    For example:
+  You need to:
 
-    #### Old HTML (Promo)
+  - replace all `nhsuk-promo` classes to `nhsuk-card`
+  - remove surrounding `<a class="nhsuk-promo__link-wrapper" href="#">` and add `<a class="nhsuk-card__link" href="#">` within `<h3 class="nhsuk-card__heading">`
+  - add `nhsuk-card--clickable` class to make entire card clickable
 
-    ```
-    <div class="nhsuk-promo">
-      <a class="nhsuk-promo__link-wrapper" href="#">
-        <img class="nhsuk-promo__img" src="https://assets.nhs.uk/prod/images/020720_PHE_Barrington_5426_TRL3_CL.2e16d0ba.fill-720x405.jpg" alt="">
-        <div class="nhsuk-promo__content">
-          <h3 class="nhsuk-promo__heading">Kickstart your health</h3>
-          <p class="nhsuk-promo__description">It's never too late to get your health back on track. Eat well, move more and start losing weight with Better Health. Try our NHS weight loss plan to get you started.</p>
-        </div>
-      </a>
-    </div>
-    ```
+  For example:
 
-    #### New HTML (Card)
+  #### Old HTML (Promo)
 
-    ```
-    <div class="nhsuk-card nhsuk-card--clickable">
-      <img class="nhsuk-card__img" src="https://assets.nhs.uk/prod/images/020720_PHE_Barrington_5426_TRL3_CL.2e16d0ba.fill-720x405.jpg" alt="">
-      <div class="nhsuk-card__content">
-        <h3 class="nhsuk-card__heading">
-          <a class="nhsuk-card__link" href="#">Kickstart your health</a>
-        </h3>
-        <p class="nhsuk-card__description">It's never too late to get your health back on track. Eat well, move more and start losing weight with Better Health. Try our NHS weight loss plan to get you started.</p>
+  ```
+  <div class="nhsuk-promo">
+    <a class="nhsuk-promo__link-wrapper" href="#">
+      <img class="nhsuk-promo__img" src="https://assets.nhs.uk/prod/images/020720_PHE_Barrington_5426_TRL3_CL.2e16d0ba.fill-720x405.jpg" alt="">
+      <div class="nhsuk-promo__content">
+        <h3 class="nhsuk-promo__heading">Kickstart your health</h3>
+        <p class="nhsuk-promo__description">It's never too late to get your health back on track. Eat well, move more and start losing weight with Better Health. Try our NHS weight loss plan to get you started.</p>
       </div>
+    </a>
+  </div>
+  ```
+
+  #### New HTML (Card)
+
+  ```
+  <div class="nhsuk-card nhsuk-card--clickable">
+    <img class="nhsuk-card__img" src="https://assets.nhs.uk/prod/images/020720_PHE_Barrington_5426_TRL3_CL.2e16d0ba.fill-720x405.jpg" alt="">
+    <div class="nhsuk-card__content">
+      <h3 class="nhsuk-card__heading">
+        <a class="nhsuk-card__link" href="#">Kickstart your health</a>
+      </h3>
+      <p class="nhsuk-card__description">It's never too late to get your health back on track. Eat well, move more and start losing weight with Better Health. Try our NHS weight loss plan to get you started.</p>
     </div>
-    ```
+  </div>
+  ```
+
   </details>
 
   ([PR 627](https://github.com/nhsuk/nhsuk-frontend/pull/627))
@@ -221,7 +234,7 @@
 
 - Add `nhsuk-link--no-visited-state` mixin - for where it is not helpful to distinguish between visited and non-visited links.
 
-- Custom search API endpoint – Improving the search experience it's now possible to define a custom API endpoint in the HTML. The JavaScript will check the window object to look for a new API reference, if nothing is found it will default to the standard NHS reference. 
+- Custom search API endpoint – Improving the search experience it's now possible to define a custom API endpoint in the HTML. The JavaScript will check the window object to look for a new API reference, if nothing is found it will default to the standard NHS reference.
 
   Add the below code to a base HTML file or any pages that use search.
 
@@ -244,6 +257,7 @@
 - Style updates to a few components so that they render properly on a range of quality monitors and devices found in use in the NHS.
 
   Including adding a 1px border to:
+
   - care cards (non-urgent and urgent)
   - do and don't list
   - expander
@@ -269,17 +283,17 @@
 
   ```javascript
   // Components
-  import Header from '../node_modules/nhsuk-frontend/packages/components/header/header';
-  import SkipLink from '../node_modules/nhsuk-frontend/packages/components/skip-link/skip-link';
-  import Details from '../node_modules/nhsuk-frontend/packages/components/details/details';
-  import Radios from '../node_modules/nhsuk-frontend/packages/components/radios/radios';
-  import Checkboxes from '../node_modules/nhsuk-frontend/packages/components/checkboxes/checkboxes';
+  import Header from "../node_modules/nhsuk-frontend/packages/components/header/header";
+  import SkipLink from "../node_modules/nhsuk-frontend/packages/components/skip-link/skip-link";
+  import Details from "../node_modules/nhsuk-frontend/packages/components/details/details";
+  import Radios from "../node_modules/nhsuk-frontend/packages/components/radios/radios";
+  import Checkboxes from "../node_modules/nhsuk-frontend/packages/components/checkboxes/checkboxes";
 
   // Polyfills
-  import '../node_modules/nhsuk-frontend/packages/polyfills';
+  import "../node_modules/nhsuk-frontend/packages/polyfills";
 
   // Initialize components
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener("DOMContentLoaded", () => {
     Details();
     Header();
     SkipLink();
@@ -357,34 +371,35 @@
   <details>
     <summary>View the colour variables that have been replaced</summary>
 
-  | Colour variable removed  | Suggested replacement |
-  | ------------- | ------------- |
-  | $color_tint_nhsuk-warm-yellow-30  | $color_nhsuk-warm-yellow  |
-  | $color_tint_nhsuk-warm-yellow-10  | $color_nhsuk-warm-yellow  |
-  | $nhsuk-link-focus-color | $nhsuk-focus-text-color |
-  | $nhsuk-link-hover-background-color | $nhsuk-focus-color |
-  | $nhsuk-link-focus-background-color | $nhsuk-focus-color |
-  | $nhsuk-link-active-background-color | $nhsuk-focus-color |
-  | $nhsuk-button-text-colour | $nhsuk-button-text-color |
-  | $nhsuk-button-hover-colour | $nhsuk-button-hover-color |
-  | $nhsuk-reverse-button-text-colour | $nhsuk-reverse-button-text-color |
-  | $nhsuk-button-shadow-colour | $nhsuk-button-shadow-color |
-  | $nhsuk-secondary-button-colour | $nhsuk-secondary-button-color |
-  | $nhsuk-secondary-button-hover-colour | $nhsuk-secondary-button-hover-color |
+  | Colour variable removed               | Suggested replacement                |
+  | ------------------------------------- | ------------------------------------ |
+  | $color_tint_nhsuk-warm-yellow-30      | $color_nhsuk-warm-yellow             |
+  | $color_tint_nhsuk-warm-yellow-10      | $color_nhsuk-warm-yellow             |
+  | $nhsuk-link-focus-color               | $nhsuk-focus-text-color              |
+  | $nhsuk-link-hover-background-color    | $nhsuk-focus-color                   |
+  | $nhsuk-link-focus-background-color    | $nhsuk-focus-color                   |
+  | $nhsuk-link-active-background-color   | $nhsuk-focus-color                   |
+  | $nhsuk-button-text-colour             | $nhsuk-button-text-color             |
+  | $nhsuk-button-hover-colour            | $nhsuk-button-hover-color            |
+  | $nhsuk-reverse-button-text-colour     | $nhsuk-reverse-button-text-color     |
+  | $nhsuk-button-shadow-colour           | $nhsuk-button-shadow-color           |
+  | $nhsuk-secondary-button-colour        | $nhsuk-secondary-button-color        |
+  | $nhsuk-secondary-button-hover-colour  | $nhsuk-secondary-button-hover-color  |
   | $nhsuk-secondary-button-shadow-colour | $nhsuk-secondary-button-shadow-color |
-  | $nhsuk-reverse-button-colour | $nhsuk-reverse-button-color |
-  | $nhsuk-reverse-button-hover-colour | $nhsuk-reverse-button-hover-color |
-  | $nhsuk-button-colour | $nhsuk-button-color |
-  | $nhsuk-button-hover-colour | $nhsuk-button-hover-color |
-  | $nhsuk-secondary-button-colour | $nhsuk-secondary-button-color |
-  | $nhsuk-secondary-button-hover-colour | $nhsuk-secondary-button-hover-color |
+  | $nhsuk-reverse-button-colour          | $nhsuk-reverse-button-color          |
+  | $nhsuk-reverse-button-hover-colour    | $nhsuk-reverse-button-hover-color    |
+  | $nhsuk-button-colour                  | $nhsuk-button-color                  |
+  | $nhsuk-button-hover-colour            | $nhsuk-button-hover-color            |
+  | $nhsuk-secondary-button-colour        | $nhsuk-secondary-button-color        |
+  | $nhsuk-secondary-button-hover-colour  | $nhsuk-secondary-button-hover-color  |
   | $nhsuk-secondary-button-shadow-colour | $nhsuk-secondary-button-shadow-color |
-  | $nhsuk-reverse-button-colour | $nhsuk-reverse-button-color |
-  | $nhsuk-reverse-button-hover-colour | $nhsuk-reverse-button-hover-color |
-  | $nhsuk-reverse-button-shadow-colour | $nhsuk-reverse-button-shadow-color |
-  | $nhsuk-focus-colour | $nhsuk-focus-color |
-  | $nhsuk-focus-text-colour | $nhsuk-focus-text-color |
-  | $nhsuk-button-shadow-colour | $nhsuk-button-shadow-color |
+  | $nhsuk-reverse-button-colour          | $nhsuk-reverse-button-color          |
+  | $nhsuk-reverse-button-hover-colour    | $nhsuk-reverse-button-hover-color    |
+  | $nhsuk-reverse-button-shadow-colour   | $nhsuk-reverse-button-shadow-color   |
+  | $nhsuk-focus-colour                   | $nhsuk-focus-color                   |
+  | $nhsuk-focus-text-colour              | $nhsuk-focus-text-color              |
+  | $nhsuk-button-shadow-colour           | $nhsuk-button-shadow-color           |
+
   </details>
 
   <hr>
@@ -393,17 +408,18 @@
 
 - Deprecation of the [Feedback banner](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/151) and [Emergency alert](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/149) components.
 
-   If you are using Sass and JavaScript (ES6) imports, you will need to remove the imports for these components. You will also no longer be able to use the Nunjucks macros.
+  If you are using Sass and JavaScript (ES6) imports, you will need to remove the imports for these components. You will also no longer be able to use the Nunjucks macros.
 
   **Sass**
 
   If you are importing component styles individually, you will need to remove the imports for the emergency alert and feedback banner:
 
   ```scss
-  @import 'node_modules/nhsuk-frontend/packages/components/emergency-alert/emergency-alert';
+  @import "node_modules/nhsuk-frontend/packages/components/emergency-alert/emergency-alert";
   ```
+
   ```scss
-  @import 'node_modules/nhsuk-frontend/packages/components/feedback-banner/feedback-banner';
+  @import "node_modules/nhsuk-frontend/packages/components/feedback-banner/feedback-banner";
   ```
 
   If you import all the component styles with `@import 'node_modules/nhsuk-frontend/packages/core/all';`, you don't need to update your Sass imports.
@@ -413,8 +429,9 @@
   If you are importing component JavaScript with ES6 imports, you will need to remove the imports and initialisation for the feedback banner:
 
   ```js
-  import nhsuk_feedbackBanner from 'node_modules/nhsuk-frontend/packages/components/feedback-banner/feedback-banner';
+  import nhsuk_feedbackBanner from "node_modules/nhsuk-frontend/packages/components/feedback-banner/feedback-banner";
   ```
+
   ```js
   nhsuk_feedbackBanner(3000);
   ```
@@ -431,12 +448,12 @@
 
   ```js
   // Components
-  import Header from './components/header/header';
-  import SkipLink from './components/skip-link/skip-link';
-  import Details from './components/details/details';
+  import Header from "./components/header/header";
+  import SkipLink from "./components/skip-link/skip-link";
+  import Details from "./components/details/details";
 
   // Initialize components
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener("DOMContentLoaded", () => {
     Details();
     Header();
     SkipLink();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14206,11 +14206,6 @@
         }
       }
     },
-    "sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "jest:ci": "jest"
   },
   "dependencies": {
-    "accessible-autocomplete": "^2.0.3",
-    "sass-mq": "^5.0.1"
+    "accessible-autocomplete": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/packages/core/tools/_sass-mq.scss
+++ b/packages/core/tools/_sass-mq.scss
@@ -14,7 +14,7 @@ $sass-mq-already-included: false !default;
   $mq-show-breakpoints: ();
 }
 
-@import './node_modules/sass-mq/mq'; // [1] //
+@import '../vendor/sass-mq'; // [1] //
 
 $sass-mq-already-included: true;
 

--- a/packages/core/vendor/sass-mq.scss
+++ b/packages/core/vendor/sass-mq.scss
@@ -1,0 +1,351 @@
+// mq() v4.0.2
+// sass-mq/sass-mq
+
+// sass-lint:disable-all
+
+@charset "UTF-8"; // Fixes an issue where Ruby locale is not set properly
+                  // See https://github.com/sass-mq/sass-mq/pull/10
+
+/// Base font size on the `<body>` element
+/// @type Number (unit)
+$mq-base-font-size: 16px !default;
+
+/// Responsive mode
+///
+/// Set to `false` to enable support for browsers that do not support @media queries,
+/// (IE <= 8, Firefox <= 3, Opera <= 9)
+///
+/// You could create a stylesheet served exclusively to older browsers,
+/// where @media queries are rasterized
+///
+/// @example scss
+///  // old-ie.scss
+///  $mq-responsive: false;
+///  @import 'main'; // @media queries in this file will be rasterized up to $mq-static-breakpoint
+///                   // larger breakpoints will be ignored
+///
+/// @type Boolean
+/// @link https://github.com/sass-mq/sass-mq#responsive-mode-off Disabled responsive mode documentation
+$mq-responsive: true !default;
+
+/// Breakpoint list
+///
+/// Name your breakpoints in a way that creates a ubiquitous language
+/// across team members. It will improve communication between
+/// stakeholders, designers, developers, and testers.
+///
+/// @type Map
+/// @link https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint Full documentation and examples
+$mq-breakpoints: (
+    mobile:  320px,
+    tablet:  740px,
+    desktop: 980px,
+    wide:    1300px
+) !default;
+
+/// Static breakpoint (for fixed-width layouts)
+///
+/// Define the breakpoint from $mq-breakpoints that should
+/// be used as the target width for the fixed-width layout
+/// (i.e. when $mq-responsive is set to 'false') in a old-ie.scss
+///
+/// @example scss
+///  // tablet-only.scss
+///  //
+///  // Ignore all styles above tablet breakpoint,
+///  // and fix the styles (e.g. layout) at tablet width
+///  $mq-responsive: false;
+///  $mq-static-breakpoint: tablet;
+///  @import 'main'; // @media queries in this file will be rasterized up to tablet
+///                   // larger breakpoints will be ignored
+///
+/// @type String
+/// @link https://github.com/sass-mq/sass-mq#adding-custom-breakpoints Full documentation and examples
+$mq-static-breakpoint: desktop !default;
+
+/// Show breakpoints in the top right corner
+///
+/// If you want to display the currently active breakpoint in the top
+/// right corner of your site during development, add the breakpoints
+/// to this list, ordered by width, e.g. (mobile, tablet, desktop).
+///
+/// @type map
+$mq-show-breakpoints: () !default;
+
+/// Customize the media type (e.g. `@media screen` or `@media print`)
+/// By default sass-mq uses an "all" media type (`@media all and …`)
+///
+/// @type String
+/// @link https://github.com/sass-mq/sass-mq#changing-media-type Full documentation and examples
+$mq-media-type: all !default;
+
+/// Convert pixels to ems
+///
+/// @param {Number} $px - value to convert
+/// @param {Number} $base-font-size ($mq-base-font-size) - `<body>` font size
+///
+/// @example scss
+///  $font-size-in-ems: mq-px2em(16px);
+///  p { font-size: mq-px2em(16px); }
+///
+/// @requires $mq-base-font-size
+/// @returns {Number}
+@function mq-px2em($px, $base-font-size: $mq-base-font-size) {
+    @if unitless($px) {
+        @warn "Assuming #{$px} to be in pixels, attempting to convert it into pixels.";
+        @return mq-px2em($px * 1px, $base-font-size);
+    } @else if unit($px) == em {
+        @return $px;
+    }
+    @return ($px / $base-font-size) * 1em;
+}
+
+/// Get a breakpoint's width
+///
+/// @param {String} $name - Name of the breakpoint. One of $mq-breakpoints
+///
+/// @example scss
+///  $tablet-width: mq-get-breakpoint-width(tablet);
+///  @media (min-width: mq-get-breakpoint-width(desktop)) {}
+///
+/// @requires {Variable} $mq-breakpoints
+///
+/// @returns {Number} Value in pixels
+@function mq-get-breakpoint-width($name, $breakpoints: $mq-breakpoints) {
+    @if map-has-key($breakpoints, $name) {
+        @return map-get($breakpoints, $name);
+    } @else {
+        @warn "Breakpoint #{$name} wasn't found in $breakpoints.";
+    }
+}
+
+/// Media Query mixin
+///
+/// @param {String | Boolean} $from (false) - One of $mq-breakpoints
+/// @param {String | Boolean} $until (false) - One of $mq-breakpoints
+/// @param {String | Boolean} $and (false) - Additional media query parameters
+/// @param {String} $media-type ($mq-media-type) - Media type: screen, print…
+///
+/// @ignore Undocumented API, for advanced use only:
+/// @ignore @param {Map} $breakpoints ($mq-breakpoints)
+/// @ignore @param {String} $static-breakpoint ($mq-static-breakpoint)
+///
+/// @content styling rules, wrapped into a @media query when $responsive is true
+///
+/// @requires {Variable} $mq-media-type
+/// @requires {Variable} $mq-breakpoints
+/// @requires {Variable} $mq-static-breakpoint
+/// @requires {function} mq-px2em
+/// @requires {function} mq-get-breakpoint-width
+///
+/// @link https://github.com/sass-mq/sass-mq#responsive-mode-on-default Full documentation and examples
+///
+/// @example scss
+///  .element {
+///    @include mq($from: mobile) {
+///      color: red;
+///    }
+///    @include mq($until: tablet) {
+///      color: blue;
+///    }
+///    @include mq(mobile, tablet) {
+///      color: green;
+///    }
+///    @include mq($from: tablet, $and: '(orientation: landscape)') {
+///      color: teal;
+///    }
+///    @include mq(950px) {
+///      color: hotpink;
+///    }
+///    @include mq(tablet, $media-type: screen) {
+///      color: hotpink;
+///    }
+///    // Advanced use:
+///    $my-breakpoints: (L: 900px, XL: 1200px);
+///    @include mq(L, $breakpoints: $my-breakpoints, $static-breakpoint: L) {
+///      color: hotpink;
+///    }
+///  }
+@mixin mq(
+    $from: false,
+    $until: false,
+    $and: false,
+    $media-type: $mq-media-type,
+    $breakpoints: $mq-breakpoints,
+    $responsive: $mq-responsive,
+    $static-breakpoint: $mq-static-breakpoint
+) {
+    $min-width: 0;
+    $max-width: 0;
+    $media-query: '';
+
+    // From: this breakpoint (inclusive)
+    @if $from {
+        @if type-of($from) == number {
+            $min-width: mq-px2em($from);
+        } @else {
+            $min-width: mq-px2em(mq-get-breakpoint-width($from, $breakpoints));
+        }
+    }
+
+    // Until: that breakpoint (exclusive)
+    @if $until {
+        @if type-of($until) == number {
+            $max-width: mq-px2em($until);
+        } @else {
+            $max-width: mq-px2em(mq-get-breakpoint-width($until, $breakpoints)) - .01em;
+        }
+    }
+
+    // Responsive support is disabled, rasterize the output outside @media blocks
+    // The browser will rely on the cascade itself.
+    @if $responsive == false {
+        $static-breakpoint-width: mq-get-breakpoint-width($static-breakpoint, $breakpoints);
+        $target-width: mq-px2em($static-breakpoint-width);
+
+        // Output only rules that start at or span our target width
+        @if (
+            $and == false
+            and $min-width <= $target-width
+            and (
+                $until == false or $max-width >= $target-width
+            )
+            and $media-type != 'print'
+        ) {
+            @content;
+        }
+    }
+
+    // Responsive support is enabled, output rules inside @media queries
+    @else {
+        @if $min-width != 0 { $media-query: '#{$media-query} and (min-width: #{$min-width})'; }
+        @if $max-width != 0 { $media-query: '#{$media-query} and (max-width: #{$max-width})'; }
+        @if $and            { $media-query: '#{$media-query} and #{$and}'; }
+
+        // Remove unnecessary media query prefix 'all and '
+        @if ($media-type == 'all' and $media-query != '') {
+            $media-type: '';
+            $media-query: str-slice(unquote($media-query), 6);
+        }
+
+        @media #{$media-type + $media-query} {
+            @content;
+        }
+    }
+}
+
+/// Quick sort
+///
+/// @author Sam Richards
+/// @access private
+/// @param {List} $list - List to sort
+/// @returns {List} Sorted List
+@function _mq-quick-sort($list) {
+    $less:  ();
+    $equal: ();
+    $large: ();
+
+    @if length($list) > 1 {
+        $seed: nth($list, ceil(length($list) / 2));
+
+        @each $item in $list {
+            @if ($item == $seed) {
+                $equal: append($equal, $item);
+            } @else if ($item < $seed) {
+                $less: append($less, $item);
+            } @else if ($item > $seed) {
+                $large: append($large, $item);
+            }
+        }
+
+        @return join(join(_mq-quick-sort($less), $equal), _mq-quick-sort($large));
+    }
+
+    @return $list;
+}
+
+/// Sort a map by values (works with numbers only)
+///
+/// @access private
+/// @param {Map} $map - Map to sort
+/// @returns {Map} Map sorted by value
+@function _mq-map-sort-by-value($map) {
+    $map-sorted: ();
+    $map-keys: map-keys($map);
+    $map-values: map-values($map);
+    $map-values-sorted: _mq-quick-sort($map-values);
+
+    // Reorder key/value pairs based on key values
+    @each $value in $map-values-sorted {
+        $index: index($map-values, $value);
+        $key: nth($map-keys, $index);
+        $map-sorted: map-merge($map-sorted, ($key: $value));
+
+        // Unset the value in $map-values to prevent the loop
+        // from finding the same index twice
+        $map-values: set-nth($map-values, $index, 0);
+    }
+
+    @return $map-sorted;
+}
+
+/// Add a breakpoint
+///
+/// @param {String} $name - Name of the breakpoint
+/// @param {Number} $width - Width of the breakpoint
+///
+/// @requires {Variable} $mq-breakpoints
+///
+/// @example scss
+///  @include mq-add-breakpoint(tvscreen, 1920px);
+///  @include mq(tvscreen) {}
+@mixin mq-add-breakpoint($name, $width) {
+    $new-breakpoint: ($name: $width);
+    $mq-breakpoints: map-merge($mq-breakpoints, $new-breakpoint) !global;
+    $mq-breakpoints: _mq-map-sort-by-value($mq-breakpoints) !global;
+}
+
+/// Show the active breakpoint in the top right corner of the viewport
+/// @link https://github.com/sass-mq/sass-mq#seeing-the-currently-active-breakpoint
+///
+/// @param {List} $show-breakpoints ($mq-show-breakpoints) - List of breakpoints to show in the top right corner
+/// @param {Map} $breakpoints ($mq-breakpoints) - Breakpoint names and sizes
+///
+/// @requires {Variable} $mq-breakpoints
+/// @requires {Variable} $mq-show-breakpoints
+///
+/// @example scss
+///  // Show breakpoints using global settings
+///  @include mq-show-breakpoints;
+///
+///  // Show breakpoints using custom settings
+///  @include mq-show-breakpoints((L, XL), (S: 300px, L: 800px, XL: 1200px));
+@mixin mq-show-breakpoints($show-breakpoints: $mq-show-breakpoints, $breakpoints: $mq-breakpoints) {
+    body:before {
+        background-color: #FCF8E3;
+        border-bottom: 1px solid #FBEED5;
+        border-left: 1px solid #FBEED5;
+        color: #C09853;
+        font: small-caption;
+        padding: 3px 6px;
+        pointer-events: none;
+        position: fixed;
+        right: 0;
+        top: 0;
+        z-index: 100;
+
+        // Loop through the breakpoints that should be shown
+        @each $show-breakpoint in $show-breakpoints {
+            $width: mq-get-breakpoint-width($show-breakpoint, $breakpoints);
+            @include mq($show-breakpoint, $breakpoints: $breakpoints) {
+                content: "#{$show-breakpoint} ≥ #{$width} (#{mq-px2em($width)})";
+            }
+        }
+    }
+}
+
+@if length($mq-show-breakpoints) > 0 {
+    @include mq-show-breakpoints;
+}
+
+// sass-lint:enable-all


### PR DESCRIPTION
## Description

We're trying to use NHSUK Frontend on a project which has a non-standard location for `node_modules`, and as a result, we were getting the following error:

```
sass.CompileError: Error: File to import not found or unreadable: ./node_modules/sass-mq/mq.
        on line 17:1 of assets/_dev/node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss
        from line 9:1 of assets/_dev/node_modules/nhsuk-frontend/packages/core/tools/_all.scss
        from line 6:1 of assets/_dev/scss/screen.scss
>> @import './node_modules/sass-mq/mq'; // [1] //
```

After a bit of Googling, I found that govuk-frontend had a similar problem and solved this by [vendoring in SassMQ](https://github.com/alphagov/govuk-frontend/pull/657). I've attempted to replicate this approach in NHS Frontend too.

Thoughts welcome!

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
