### PR TITLE
Fix link style white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Details - fix the left alignment of the details text and summary ([Issue 615](https://github.com/nhsuk/nhsuk-frontend/issues/615))
+- Fix styles for the `nhsuk-link-style-white`
 
 ## 3.1.0 - 24 April 2020
 

--- a/packages/core/tools/_links.scss
+++ b/packages/core/tools/_links.scss
@@ -54,19 +54,19 @@
   color: $color_nhsuk-white;
 
   &:visited {
-    color: $color_nhsuk-grey-5;
+    color: $color_nhsuk-white;
+  }
+
+  &:hover {
+    color: $color_nhsuk-white;
+    text-decoration: none;
   }
 
   &:focus {
     color: $nhsuk-focus-text-color;
     outline: $nhsuk-focus-width solid transparent;
     outline-offset: $nhsuk-focus-width;
-    text-decoration: underline;
-  }
-
-  &:hover {
-    color: $nhsuk-link-hover-color;
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   &:active {


### PR DESCRIPTION
## Description
Fix the styles for the `nhsuk-link-style-white`

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
