### PR TITLE
Fix breadcrumb link focus colour when link has been visited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Details - fix the left alignment of the details text and summary ([Issue 615](https://github.com/nhsuk/nhsuk-frontend/issues/615))
 - Fix styles for the `nhsuk-link-style-white`
+- Fix breadcrumb link color when `:visited` and `:focus`
 
 ## 3.1.0 - 24 April 2020
 

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -75,17 +75,18 @@
 }
 
 .nhsuk-breadcrumb__link {
-  &:focus {
-    &:hover {
-      color: $nhsuk-focus-text-color;
-    }
-  }
 
   &:visited {
     color: $nhsuk-link-color;
 
     &:hover {
       color: $nhsuk-link-hover-color;
+    }
+  }
+
+  &:focus {
+    &:hover {
+      color: $nhsuk-focus-text-color;
     }
   }
 }


### PR DESCRIPTION
## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
