### PR TITLE
Update warning callout template.njk

### DIFF
--- a/app/components/warning-callout/custom-heading.njk
+++ b/app/components/warning-callout/custom-heading.njk
@@ -11,7 +11,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
           {{ warningCallout({
-            "heading": "School, nursery or work",
+            "heading": "This is important",
             "HTML": "<p>Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>"
           }) }}
         </div>

--- a/app/components/warning-callout/custom-heading.njk
+++ b/app/components/warning-callout/custom-heading.njk
@@ -11,7 +11,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
           {{ warningCallout({
-            "heading": "This is important",
+            "heading": "School, nursery or work",
             "HTML": "<p>Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>"
           }) }}
         </div>

--- a/packages/components/warning-callout/template.njk
+++ b/packages/components/warning-callout/template.njk
@@ -3,7 +3,7 @@
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <h{{ headingLevel }} class="nhsuk-warning-callout__label">
-    {%- if "Important" in params.heading %}
+    {%- if "Important" or "important" in params.heading %}
     {{ params.heading | safe }}
     {%- else %}
     <span role="text">

--- a/packages/components/warning-callout/template.njk
+++ b/packages/components/warning-callout/template.njk
@@ -3,13 +3,13 @@
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <h{{ headingLevel }} class="nhsuk-warning-callout__label">
-    {%- if params.heading != "Important" %}
+    {%- if "Important" in params.heading %}
+    {{ params.heading | safe }}
+    {%- else %}
     <span role="text">
       <span class="nhsuk-u-visually-hidden">Important: </span>
       {{ params.heading | safe }}
     </span>
-    {%- else %}
-    {{ params.heading | safe }}
     {%- endif %}
   </h{{ headingLevel }}>
   {{ params.HTML | safe }}

--- a/packages/components/warning-callout/template.njk
+++ b/packages/components/warning-callout/template.njk
@@ -3,7 +3,7 @@
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <h{{ headingLevel }} class="nhsuk-warning-callout__label">
-    {%- if "Important" or "important" in params.heading %}
+    {%- if "Important" in params.heading or "important" in params.heading %}
     {{ params.heading | safe }}
     {%- else %}
     <span role="text">


### PR DESCRIPTION
## Description
Change the `{%- if params.heading != "Important" %}` to `{%- if "Important" in params.heading %}` so the hidden text of 'Important' does not show if a custom header includes the word important, for example 'Important Coronavirus update'

For example:

![image](https://user-images.githubusercontent.com/14331000/93899066-d76d4c80-fceb-11ea-9930-ac22e9992ed8.png)

