### PR TITLE
Search api update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,7 @@
 
 - Custom search API endpoint – Improving the search experience it's now possible to define a custom API endpoint in the HTML. The JavaScript will check the window object to look for a new API reference, if nothing is found it will default to the standard NHS reference. 
 
-  Add the below code to a base HTML file or any pages that will use search.
+  Add the below code to a base HTML file or any pages that use search.
 
 ```HTML
     <script>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,18 @@
 
 - Add `nhsuk-link--no-visited-state` mixin - for where it is not helpful to distinguish between visited and non-visited links.
 
+- Custom search API endpoint – Improving the search experience it's now possible to define a custom API endpoint in the HTML. The JavaScript will check the window object to look for a new API reference, if nothing is found it will default to the standard NHS reference. 
+
+  Add the below code to a base HTML file or any pages that will use search.
+
+```HTML
+    <script>
+      window.NHSUK_SETTINGS = {};
+      window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST = "[CUSTOM API ENDPOINT]";
+      window.NHSUK_SETTINGS.SEARCH_TEST_HOST = "[CUSTOM SEARCH PAGE URL]";
+    </script>
+```
+
 :wrench: **Fixes**
 
 - Details - fix the left alignment of the details text and summary ([Issue 615](https://github.com/nhsuk/nhsuk-frontend/issues/615))
@@ -237,7 +249,7 @@
   ```
 
   If you are importing component JavaScript with ES6 imports, you will need to update your imports to include the JavaScript:
-  
+
   ```javascript
   // Components
   import Header from '../node_modules/nhsuk-frontend/packages/components/header/header';

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,8 @@ module.exports = {
   collectCoverageFrom: [
     'packages/**/*.js',
   ],
+  globals: {
+    window: true,
+  },
   verbose: true,
 };

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -1,12 +1,11 @@
 import AutoComplete from './autoCompleteConfig';
 
-// Check if search URLs are set as globals on window object
-const overwriteSearchApiUrl = window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST;
-const overwriteSearchPageUrl = window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST;
-
-// Use URL from global or default to live URLs
-const searchApiUrl = overwriteSearchApiUrl ? window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST : 'https://www.nhs.uk/s/suggest.json';
-const searchPageUrl = overwriteSearchPageUrl ? window.NHSUK_SETTINGS.SEARCH_TEST_HOST : 'https://www.nhs.uk/search/';
+/**
+ * Check if search URLs are set as globals on window object,
+ * Use URL from global or default to live URLs
+*/
+const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://www.nhs.uk/s/suggest.json';
+const searchPageUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SEARCH_TEST_HOST) || 'https://www.nhs.uk/search/';
 
 /**
  * Function to build truncated result with svg for search autocomplete

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -1,8 +1,12 @@
 import AutoComplete from './autoCompleteConfig';
 
-// Search variables which can be set from HTML
-const searchApiUrl = window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST || 'https://www.nhs.uk/s/suggest.json';
-const searchPageUrl = window.NHSUK_SETTINGS.SEARCH_TEST_HOST || 'https://www.nhs.uk/search/';
+// Check if search URLs are set as globals on window object
+const overwriteSearchApiUrl = window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST;
+const overwriteSearchPageUrl = window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST;
+
+// Use URL from global or default to live URLs
+const searchApiUrl = overwriteSearchApiUrl ? window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST : 'https://www.nhs.uk/s/suggest.json';
+const searchPageUrl = overwriteSearchPageUrl ? window.NHSUK_SETTINGS.SEARCH_TEST_HOST : 'https://www.nhs.uk/search/';
 
 /**
  * Function to build truncated result with svg for search autocomplete

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -32,7 +32,9 @@ const source = (query, populateResults) => {
   // Build URL for search endpoint
   // const rootUrl = 'https://nhs.funnelback.co.uk/s/suggest.json';
   // const maxResults = 10;
-  // const fullUrl = `${rootUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}`;
+  // const fullUrl =
+  // `${rootUrl}?collection=nhs-meta&partial_query=
+  // ${query}&sort=0&fmt=json++&profile=&show=${maxResults}`;
   // const maxResults = 10;
   const rootUrl = 'https://nhsuk-apim-dev-uks.azure-api.net/site-search/Autocomplete';
   const fullUrl = `${rootUrl}?q=${query}&api-version=1`;

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -3,6 +3,7 @@ import AutoComplete from './autoCompleteConfig';
 // Search variables which can be set from HTML
 const searchApiUrl = window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST || 'https://www.nhs.uk/s/suggest.json';
 const searchPageUrl = window.NHSUK_SETTINGS.SEARCH_TEST_HOST || 'https://www.nhs.uk/search/';
+
 /**
  * Function to build truncated result with svg for search autocomplete
  * @param {string} result String containing individual result from autocomplete source function

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -1,5 +1,12 @@
 import AutoComplete from './autoCompleteConfig';
 
+// Standard search variables
+// const searchApiUrl = 'https://www.nhs.uk/s/suggest.json';
+// const searchPageUrl = 'https://www.nhs.uk/search/?q=';
+// IA test search variables
+const searchApiUrl = 'https://nhsuk-site-search-dev-uks.azurewebsites.net/site-search/Autocomplete';
+const searchPageUrl = 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search/?q=';
+
 /**
  * Function to build truncated result with svg for search autocomplete
  * @param {string} result String containing individual result from autocomplete source function
@@ -9,15 +16,9 @@ const suggestion = (result) => {
   const truncateLength = 36;
   const dots = result.length > truncateLength ? '...' : '';
   const resultTruncated = result.substring(0, truncateLength) + dots;
-  // return `
-  //   <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
-  //   <a href="https://www.nhs.uk/search?collection=nhs-meta&query=${result}">
-  //     ${resultTruncated}
-  //   </a>
-  // `;
   return `
     <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
-    <a href="https://nhsuk-site-search-dev-uks.azurewebsites.net/search/?q=${result}">
+    <a href="${searchPageUrl}${result}">
       ${resultTruncated}
     </a>
   `;
@@ -30,14 +31,8 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  // const rootUrl = 'https://nhs.funnelback.co.uk/s/suggest.json';
-  // const maxResults = 10;
-  // const fullUrl =
-  // `${rootUrl}?collection=nhs-meta&partial_query=
-  // ${query}&sort=0&fmt=json++&profile=&show=${maxResults}`;
-  // const maxResults = 10;
-  const rootUrl = 'https://nhsuk-apim-dev-uks.azure-api.net/site-search/Autocomplete';
-  const fullUrl = `${rootUrl}?q=${query}&api-version=1`;
+  const maxResults = 10;
+  const fullUrl = `${searchApiUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}&q=${query}&api-version=1`;
 
   // Async request for results based on query param
   const xhr = new XMLHttpRequest();
@@ -46,7 +41,8 @@ const source = (query, populateResults) => {
     if (xhr.status === 200) {
       // Array of display values from json
       const results = JSON.parse(xhr.responseText)
-        .map(({ disp }) => disp);
+        // Handle new search API or Funnelback
+        .map((result) => result.query || result.disp);
 
       // Fire callback from autoComplete plugin
       populateResults(results);

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -9,9 +9,15 @@ const suggestion = (result) => {
   const truncateLength = 36;
   const dots = result.length > truncateLength ? '...' : '';
   const resultTruncated = result.substring(0, truncateLength) + dots;
+  // return `
+  //   <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
+  //   <a href="https://www.nhs.uk/search?collection=nhs-meta&query=${result}">
+  //     ${resultTruncated}
+  //   </a>
+  // `;
   return `
     <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
-    <a href="https://www.nhs.uk/search?collection=nhs-meta&query=${result}">
+    <a href="https://nhsuk-site-search-dev-uks.azurewebsites.net/search/?q=${result}">
       ${resultTruncated}
     </a>
   `;
@@ -24,9 +30,12 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  const rootUrl = 'https://nhs.funnelback.co.uk/s/suggest.json';
-  const maxResults = 10;
-  const fullUrl = `${rootUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}`;
+  // const rootUrl = 'https://nhs.funnelback.co.uk/s/suggest.json';
+  // const maxResults = 10;
+  // const fullUrl = `${rootUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}`;
+  // const maxResults = 10;
+  const rootUrl = 'https://nhsuk-apim-dev-uks.azure-api.net/site-search/Autocomplete';
+  const fullUrl = `${rootUrl}?q=${query}&api-version=1`;
 
   // Async request for results based on query param
   const xhr = new XMLHttpRequest();

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -1,12 +1,8 @@
 import AutoComplete from './autoCompleteConfig';
 
-// Standard search variables
-// const searchApiUrl = 'https://www.nhs.uk/s/suggest.json';
-// const searchPageUrl = 'https://www.nhs.uk/search/?q=';
-// IA test search variables
-const searchApiUrl = 'https://nhsuk-site-search-dev-uks.azurewebsites.net/site-search/Autocomplete';
-const searchPageUrl = 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search/?q=';
-
+// Search variables which can be set from HTML
+const searchApiUrl = window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST || 'https://www.nhs.uk/s/suggest.json';
+const searchPageUrl = window.NHSUK_SETTINGS.SEARCH_TEST_HOST || 'https://www.nhs.uk/search/';
 /**
  * Function to build truncated result with svg for search autocomplete
  * @param {string} result String containing individual result from autocomplete source function
@@ -18,7 +14,7 @@ const suggestion = (result) => {
   const resultTruncated = result.substring(0, truncateLength) + dots;
   return `
     <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
-    <a href="${searchPageUrl}${result}">
+    <a href="${searchPageUrl}?q=${result}">
       ${resultTruncated}
     </a>
   `;

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -67,7 +67,7 @@
             <span class="nhsuk-u-visually-hidden">Search</span>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
-            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search' }}" method="get" role="search">
+            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
               <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
               <div class="autocomplete-container" id="autocomplete-container"></div>
               <input class="nhsuk-search__input" id="search-field" name="{{ params.searchInputName if params.searchInputName else 'q' }}" type="search" placeholder="Search" autocomplete="off">
@@ -138,7 +138,7 @@
             <span class="nhsuk-u-visually-hidden">Search</span>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
-            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search' }}" method="get" role="search">
+            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
               <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
               <div class="autocomplete-container" id="autocomplete-container"></div>
               <input class="nhsuk-search__input" id="search-field" name="{{ params.searchInputName if params.searchInputName else 'q' }}" type="search" placeholder="Search" autocomplete="off">

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -67,7 +67,7 @@
             <span class="nhsuk-u-visually-hidden">Search</span>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
-            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
+            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search' }}" method="get" role="search">
               <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
               <div class="autocomplete-container" id="autocomplete-container"></div>
               <input class="nhsuk-search__input" id="search-field" name="{{ params.searchInputName if params.searchInputName else 'q' }}" type="search" placeholder="Search" autocomplete="off">
@@ -138,7 +138,7 @@
             <span class="nhsuk-u-visually-hidden">Search</span>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
-            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
+            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://nhsuk-site-search-dev-uks.azurewebsites.net/search' }}" method="get" role="search">
               <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
               <div class="autocomplete-container" id="autocomplete-container"></div>
               <input class="nhsuk-search__input" id="search-field" name="{{ params.searchInputName if params.searchInputName else 'q' }}" type="search" placeholder="Search" autocomplete="off">


### PR DESCRIPTION
## Description
Adding in the ability to set search URLs as variables on the window to override the hardcoded variables defined in headerAutoComplete.js. This looks for an override and if there's nothing there will default to use the funnelback URL.


## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
