### PR TITLE
Multi-line hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@
 
 :wrench: **Fixes**
 
+- Hints - changed hints to be div instead of span to allow multi-line elements ([Issue 620](https://github.com/nhsuk/nhsuk-frontend/issues/620))
 - Details - fix the left alignment of the details text and summary ([Issue 615](https://github.com/nhsuk/nhsuk-frontend/issues/615))
 - Focus styling - Fixing issues with focus state on input and text area which caused resizing ([Issue 600](https://github.com/nhsuk/nhsuk-frontend/issues/600) and [Issue 613](https://github.com/nhsuk/nhsuk-frontend/issues/613))
 - Fix styles for the `nhsuk-link-style-white`

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -18,9 +18,9 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
     <legend class="nhsuk-fieldset__legend">
       What is your nationality?
     </legend>
-    <span class="nhsuk-hint" id="nationality-hint">
+    <div class="nhsuk-hint" id="nationality-hint">
     If you have more than 1 nationality, select all options that are relevant to you.
-    </span>
+    </div>
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
         <input class="nhsuk-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
@@ -100,18 +100,18 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
         <label class="nhsuk-label nhsuk-checkboxes__label" for="government-gateway">
         Sign in with Government Gateway
         </label>
-        <span class="nhsuk-hint nhsuk-checkboxes__hint" id="government-gateway-item-hint">
+        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="government-gateway-item-hint">
         You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
-        </span>
+        </div>
       </div>
       <div class="nhsuk-checkboxes__item">
         <input class="nhsuk-checkboxes__input" id="nhsuk-login" name="verify" type="checkbox" value="nhsuk-verify" aria-describedby="nhsuk-login-item-hint">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="nhsuk-login">
         Sign in with NHS.UK login
         </label>
-        <span class="nhsuk-hint nhsuk-checkboxes__hint" id="nhsuk-login-item-hint">
+        <div class="nhsuk-hint nhsuk-checkboxes__hint" id="nhsuk-login-item-hint">
         You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
-        </span>
+        </div>
       </div>
     </div>
   </fieldset>
@@ -227,9 +227,9 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
         Which types of waste do you transport regularly?
       </h1>
     </legend>
-    <span class="nhsuk-hint" id="waste-hint">
+    <div class="nhsuk-hint" id="waste-hint">
     Select all that apply
-    </span>
+    </div>
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
         <input class="nhsuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
@@ -377,9 +377,9 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
         How would you prefer to be contacted?
       </h1>
     </legend>
-    <span class="nhsuk-hint" id="contact-hint">
+    <div class="nhsuk-hint" id="contact-hint">
       Select all options that are relevant to you.
-    </span>
+    </div>
     <div class="nhsuk-checkboxes nhsuk-checkboxes--conditional">
       <div class="nhsuk-checkboxes__item">
         <input class="nhsuk-checkboxes__input" id="contact-1" name="contact" type="checkbox" value="email" aria-controls="conditional-contact-1" aria-expanded="false">

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -20,9 +20,9 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
     <legend class="nhsuk-fieldset__legend">
       What is your date of birth?
     </legend>
-    <span class="nhsuk-hint" id="dob-hint">
+    <div class="nhsuk-hint" id="dob-hint">
     For example, 31 3 1980
-    </span>
+    </div>
     <div class="nhsuk-date-input" id="dob">
       <div class="nhsuk-date-input__item">
         <div class="nhsuk-form-group">
@@ -104,9 +104,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <legend class="nhsuk-fieldset__legend">
       What is your date of birth?
     </legend>
-    <span class="nhsuk-hint" id="dob-with-autocomplete-attribute-hint">
+    <div class="nhsuk-hint" id="dob-with-autocomplete-attribute-hint">
     For example, 31 3 1980
-    </span>
+    </div>
     <div class="nhsuk-date-input" id="dob-with-autocomplete-attribute">
       <div class="nhsuk-date-input__item">
         <div class="nhsuk-form-group">
@@ -187,9 +187,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <legend class="nhsuk-fieldset__legend">
       What is your date of birth?
     </legend>
-    <span class="nhsuk-hint" id="dob-errors-hint">
+    <div class="nhsuk-hint" id="dob-errors-hint">
     For example, 31 3 1980
-    </span>
+    </div>
     <span id="dob-errors-error" class="nhsuk-error-message">
     Error message goes here
     </span>
@@ -272,9 +272,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
     <legend class="nhsuk-fieldset__legend">
       What is your date of birth?
     </legend>
-    <span class="nhsuk-hint" id="dob-day-error-hint">
+    <div class="nhsuk-hint" id="dob-day-error-hint">
     For example, 31 3 1980
-    </span>
+    </div>
     <span id="dob-day-error-error" class="nhsuk-error-message">
     Error message goes here
     </span>

--- a/packages/components/hint/README.md
+++ b/packages/components/hint/README.md
@@ -11,9 +11,9 @@ Find out more about the hint component and when to use it in the [NHS digital se
 ### HTML markup
 
 ```html
-<span class="nhsuk-hint">
+<div class="nhsuk-hint">
   It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-</span>
+</div>
 ```
 
 ### Nunjucks macro
@@ -33,8 +33,8 @@ The hint Nunjucks macro takes the following arguments:
 | Name                    | Type     | Required  | Description             |
 | ------------------------|----------|-----------|-------------------------|
 | **text or (html) html** | string   | Yes       | Text or HTML to use within the hint. If `html` is provided, the `text` argument will be ignored. |
-| **id**                  | string   | Yes       | Optional id attribute to add to the hint span tag. |
-| **classes**             | string   | No        | Optional additional classes to add to the hint span tag. Separate each class with a space. |
+| **id**                  | string   | Yes       | Optional id attribute to add to the hint div tag. |
+| **classes**             | string   | No        | Optional additional classes to add to the hint div tag. Separate each class with a space. |
 | **attributes**          | object   | No        | Any extra HTML attributes (for example data attributes) to add to the input component. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/components/hint/template.njk
+++ b/packages/components/hint/template.njk
@@ -1,6 +1,6 @@
-<span class="nhsuk-hint
+<div class="nhsuk-hint
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- if params.id %} id="{{ params.id }}"{% endif %}
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {{ params.html | safe if params.html else params.text }}
-</span>
+</div>

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -84,9 +84,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
   <label class="nhsuk-label" for="input-with-hint-text">
   National insurance number
   </label>
-  <span class="nhsuk-hint" id="input-with-hint-text-hint">
+  <div class="nhsuk-hint" id="input-with-hint-text-hint">
   It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-  </span>
+  </div>
   <input class="nhsuk-input" id="input-with-hint-text" name="test-name-2" type="text" aria-describedby="input-with-hint-text-hint">
 </div>
 ```
@@ -121,9 +121,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
   <label class="nhsuk-label" for="input-with-error-message">
   National Insurance number
   </label>
-  <span class="nhsuk-hint" id="input-with-error-message-hint">
+  <div class="nhsuk-hint" id="input-with-error-message-hint">
   It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-  </span>
+  </div>
   <span id="input-with-error-message-error" class="nhsuk-error-message">
   Error message goes here
   </span>
@@ -164,9 +164,9 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
   <label class="nhsuk-label" for="input-width-10">
   National insurance number
   </label>
-  <span class="nhsuk-hint" id="input-width-10-hint">
+  <div class="nhsuk-hint" id="input-width-10-hint">
   It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-  </span>
+  </div>
   <input class="nhsuk-input nhsuk-input--width-10" id="input-width-10" name="test-width-10" type="text" aria-describedby="input-width-10-hint">
 </div>
 ```

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -18,9 +18,9 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <legend class="nhsuk-fieldset__legend">
       Have you changed your name?
     </legend>
-    <span class="nhsuk-hint" id="example-hint">
+    <div class="nhsuk-hint" id="example-hint">
     This includes changing your last name or spelling your name differently.
-    </span>
+    </div>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
         <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -83,9 +83,9 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <legend class="nhsuk-fieldset__legend">
       Have you changed your name?
     </legend>
-    <span class="nhsuk-hint" id="example-hint">
+    <div class="nhsuk-hint" id="example-hint">
     This includes changing your last name or spelling your name differently.
-    </span>
+    </div>
     <div class="nhsuk-radios nhsuk-radios--inline">
       <div class="nhsuk-radios__item">
         <input class="nhsuk-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -149,9 +149,9 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <legend class="nhsuk-fieldset__legend">
       Have you changed your name?
     </legend>
-    <span class="nhsuk-hint" id="example-disabled-hint">
+    <div class="nhsuk-hint" id="example-disabled-hint">
     This includes changing your last name or spelling your name differently.
-    </span>
+    </div>
     <div class="nhsuk-radios">
       <div class="nhsuk-radios__item">
         <input class="nhsuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
@@ -295,18 +295,18 @@ Find out more about the radios component and when to use it in the [NHS digital 
         <label class="nhsuk-label nhsuk-radios__label" for="gov-1">
         Sign in with Government Gateway
         </label>
-        <span class="nhsuk-hint nhsuk-radios__hint" id="gov-1-item-hint">
+        <div class="nhsuk-hint nhsuk-radios__hint" id="gov-1-item-hint">
         You&#39;ll have a user ID if you've registered for self-assessment or filed a tax return online before.
-        </span>
+        </div>
       </div>
       <div class="nhsuk-radios__item">
         <input class="nhsuk-radios__input" id="gov-2" name="gov" type="radio" value="verify" aria-describedby="gov-2-item-hint">
         <label class="nhsuk-label nhsuk-radios__label" for="gov-2">
         Sign in with NHS.UK login
         </label>
-        <span class="nhsuk-hint nhsuk-radios__hint" id="gov-2-item-hint">
+        <div class="nhsuk-hint nhsuk-radios__hint" id="gov-2-item-hint">
         You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
-        </span>
+        </div>
       </div>
     </div>
   </fieldset>
@@ -417,9 +417,9 @@ Find out more about the radios component and when to use it in the [NHS digital 
     <legend class="nhsuk-fieldset__legend">
       Have you changed your name?
     </legend>
-    <span class="nhsuk-hint" id="example-hint">
+    <div class="nhsuk-hint" id="example-hint">
     This includes changing your last name or spelling your name differently.
-    </span>
+    </div>
     <span id="example-error" class="nhsuk-error-message">
     Please select an option
     </span>
@@ -495,9 +495,9 @@ Find out more about the radios component and when to use it in the [NHS digital 
         How would you prefer to be contacted?
       </h1>
     </legend>
-    <span class="nhsuk-hint" id="contact-hint">
+    <div class="nhsuk-hint" id="contact-hint">
       Select one option.
-    </span>
+    </div>
     <div class="nhsuk-radios nhsuk-radios--conditional">
       <div class="nhsuk-radios__item">
         <input class="nhsuk-radios__input" id="contact-1" name="contact" type="radio" value="email" aria-controls="conditional-contact-1" aria-expanded="false">

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -68,9 +68,9 @@ Find out more about the select component and when to use it in the [NHS digital 
   <label class="nhsuk-label" for="select-2">
   Label text goes here
   </label>
-  <span class="nhsuk-hint" id="select-2-hint">
+  <div class="nhsuk-hint" id="select-2-hint">
   Hint text goes here
-  </span>
+  </div>
   <span id="select-2-error" class="nhsuk-error-message">
   Error message goes here
   </span>

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -17,9 +17,9 @@ Find out more about the textarea component and when to use it in the [NHS digita
   <label class="nhsuk-label" for="more-detail">
   Can you provide more detail?
   </label>
-  <span class="nhsuk-hint" id="more-detail-hint">
+  <div class="nhsuk-hint" id="more-detail-hint">
   Don&#39;t include personal or financial information, eg your National Insurance number or credit card details.
-  </span>
+  </div>
   <textarea class="nhsuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
 </div>
 ```


### PR DESCRIPTION
## Description
Changed Hint component to use div rather than span to allow for multi-line elements within hints. Updated docs and changelog.
## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
