### PR TITLE
Android Chrome search suggestions bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Transactional header - changed service name link style to include an underline on hover ([Issue 653](https://github.com/nhsuk/nhsuk-frontend/issues/653))
 - Switch from Travis CI to GitHub actions - Due to slow and inconsistent builds we have moved our CI to GitHub actions
+- Android search suggestions bug - when selecting an option from the suggestions in Chrome the form didn't populate and submit, this is now fixed.
 
 ## 4.0.0 - 26 October 2020
 
@@ -16,12 +17,12 @@
   If you are using the current responsive table class `nhsuk-table-responsive` you will need to rename the `nhsuk-table-responsive` class to `nhsuk-table-container`.
 
   [Preview the responsive table component](https://nhsuk.github.io/nhsuk-frontend/components/tables/responsive-table.html)
-  
+
 - Remove Panel and Promo components
 
   The panel and promo were two components in the NHS.UK frontend that did not have guidance in the service manual. They both also shared a lot of the same structure and design. This confused users of the design system, with people not knowing when and how to use the components.
 
-  There was also an accessibility issue with the content of the promo component being all contained within a link (anchor tag) causing a difficult experience for screenreader users. We have fixed this issue and combined the two components into one new component, a card component. 
+  There was also an accessibility issue with the content of the promo component being all contained within a link (anchor tag) causing a difficult experience for screenreader users. We have fixed this issue and combined the two components into one new component, a card component.
 
   <details>
     <summary>If you are using a panel component</summary>
@@ -61,7 +62,7 @@
       "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
     }) }}
     ```
-    
+
     ##### Changing the heading size
 
     ```
@@ -73,9 +74,9 @@
       "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a>.</p>"
     }) }}
     ```
-    
+
     ### For HTML
-    
+
     You need to:
     - replace all `nhsuk-panel` classes to `nhsuk-card`
 
@@ -142,7 +143,7 @@
       "description": "Please register today. Donating blood is easy, and saves lives."
     }) }
     ```
-    
+
     ##### Changing the heading size
 
     ```
@@ -155,9 +156,9 @@
       "description": "Please register today. Donating blood is easy, and saves lives."
     }) }
     ```
-    
+
     ### For HTML
-    
+
     You need to:
     - replace all `nhsuk-promo` classes to `nhsuk-card`
     - remove surrounding `<a class="nhsuk-promo__link-wrapper" href="#">` and add `<a class="nhsuk-card__link" href="#">` within `<h3 class="nhsuk-card__heading">`
@@ -200,13 +201,13 @@
 
 - Add Card component
 
-  Use a card instead of a panel or promo to provide users with a brief summary of content or a task, often with a link to more detail. Cards are frequently displayed alongside other cards to group related content or tasks. 
+  Use a card instead of a panel or promo to provide users with a brief summary of content or a task, often with a link to more detail. Cards are frequently displayed alongside other cards to group related content or tasks.
 
   ([PR 627](https://github.com/nhsuk/nhsuk-frontend/pull/627))
 
 - Add Tag component
 
-  Use the tag component when it’s possible for something to have more than one status and it’s useful for the user to know about that status. 
+  Use the tag component when it’s possible for something to have more than one status and it’s useful for the user to know about that status.
 
   ([PR 626](https://github.com/nhsuk/nhsuk-frontend/pull/626))
 
@@ -232,7 +233,7 @@
 - Fix styles for the `nhsuk-link-style-white`
 - Fix breadcrumb link color when `:visited` and `:focus`
 - Warning callout - update Nunjucks macro template so custom headings get prefixed with `<span class="nhsuk-u-visually-hidden">Important:</span>` to convey the importance of the message to screen reader users. ([PR 630](https://github.com/nhsuk/nhsuk-frontend/pull/630))
-- Style updates to a few components so that they render properly on a range of quality monitors and devices found in use in the NHS. 
+- Style updates to a few components so that they render properly on a range of quality monitors and devices found in use in the NHS.
 
   Including adding a 1px border to:
   - care cards (non-urgent and urgent)

--- a/packages/components/header/autoCompleteConfig.js
+++ b/packages/components/header/autoCompleteConfig.js
@@ -27,9 +27,9 @@ export default (config) => {
   */
   const addFormEvents = () => {
     // Attach event to form as the original input element is cloned by autoComplete plugin
-    form.addEventListener('keyup', ({ keyCode }) => {
+    form.addEventListener('keyup', ({ key }) => {
       // Submit search using current input value if input is focused and enter is pressed
-      if (keyCode === 13 && document.activeElement.id === inputId) form.submit();
+      if (key === 'Enter' && document.activeElement.id === inputId) form.submit();
     });
   };
 

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -63,6 +63,7 @@ export default () => {
   AutoComplete({
     containerId: 'autocomplete-container',
     formId: 'search',
+    showNoOptionsFound: false,
     inputId: 'search-field',
     onConfirm,
     source,

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -29,9 +29,9 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  // const maxResults = 10;
-  const fullUrl = `${searchApiUrl}?q=${query}&api-version=1`;
-  console.log(fullUrl);
+  const maxResults = 10;
+  const fullUrl = `${searchApiUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}&q=${query}&api-version=1`;
+
   // Async request for results based on query param
   const xhr = new XMLHttpRequest();
   xhr.open('GET', fullUrl);
@@ -40,7 +40,7 @@ const source = (query, populateResults) => {
       // Array of display values from json
       const results = JSON.parse(xhr.responseText)
         // Handle new search API or Funnelback
-        .map((result) => result.query);
+        .map((result) => result.query || result.disp);
 
       // Fire callback from autoComplete plugin
       populateResults(results);

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -4,7 +4,7 @@ import AutoComplete from './autoCompleteConfig';
  * Check if search URLs are set as globals on window object,
  * Use URL from global or default to live URLs
 */
-const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://www.nhs.uk/s/suggest.json';
+const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://api.nhs.uk/site-search/autocomplete';
 const searchPageUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SEARCH_TEST_HOST) || 'https://www.nhs.uk/search/';
 
 /**
@@ -29,9 +29,9 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  const maxResults = 10;
-  const fullUrl = `${searchApiUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}&q=${query}&api-version=1`;
-
+  // const maxResults = 10;
+  const fullUrl = `${searchApiUrl}?q=${query}&api-version=1`;
+  console.log(fullUrl);
   // Async request for results based on query param
   const xhr = new XMLHttpRequest();
   xhr.open('GET', fullUrl);
@@ -40,7 +40,7 @@ const source = (query, populateResults) => {
       // Array of display values from json
       const results = JSON.parse(xhr.responseText)
         // Handle new search API or Funnelback
-        .map((result) => result.query || result.disp);
+        .map((result) => result.query);
 
       // Fire callback from autoComplete plugin
       populateResults(results);

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -38,7 +38,6 @@ const source = (query, populateResults) => {
   xhr.onload = () => {
     if (xhr.status === 200) {
       // Array of display values from json
-      console.log(fullUrl);
       const results = JSON.parse(xhr.responseText)
         // Handle new search API
         .map((result) => result.query);

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -4,7 +4,7 @@ import AutoComplete from './autoCompleteConfig';
  * Check if search URLs are set as globals on window object,
  * Use URL from global or default to live URLs
 */
-const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://nhsuk-apim-stag-uks.azure-api.net/site-search/Autocomplete';
+const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://api.nhs.uk/site-search/Autocomplete';
 const searchPageUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SEARCH_TEST_HOST) || 'https://www.nhs.uk/search/';
 
 /**

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -4,7 +4,7 @@ import AutoComplete from './autoCompleteConfig';
  * Check if search URLs are set as globals on window object,
  * Use URL from global or default to live URLs
 */
-const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://api.nhs.uk/site-search/autocomplete';
+const searchApiUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST) || 'https://nhsuk-apim-stag-uks.azure-api.net/site-search/Autocomplete';
 const searchPageUrl = (window.NHSUK_SETTINGS && window.NHSUK_SETTINGS.SEARCH_TEST_HOST) || 'https://www.nhs.uk/search/';
 
 /**
@@ -29,8 +29,8 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  const maxResults = 10;
-  const fullUrl = `${searchApiUrl}?collection=nhs-meta&partial_query=${query}&sort=0&fmt=json++&profile=&show=${maxResults}&q=${query}&api-version=1`;
+  // const maxResults = 10;
+  const fullUrl = `${searchApiUrl}?q=${query}&api-version=1`;
 
   // Async request for results based on query param
   const xhr = new XMLHttpRequest();
@@ -38,9 +38,10 @@ const source = (query, populateResults) => {
   xhr.onload = () => {
     if (xhr.status === 200) {
       // Array of display values from json
+      console.log(fullUrl);
       const results = JSON.parse(xhr.responseText)
-        // Handle new search API or Funnelback
-        .map((result) => result.query || result.disp);
+        // Handle new search API
+        .map((result) => result.query);
 
       // Fire callback from autoComplete plugin
       populateResults(results);

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -18,9 +18,7 @@ const suggestion = (result) => {
   const resultTruncated = result.substring(0, truncateLength) + dots;
   return `
     <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path></svg>
-    <a href="${searchPageUrl}?q=${result}">
-      ${resultTruncated}
-    </a>
+    ${resultTruncated}
   `;
 };
 
@@ -52,11 +50,21 @@ const source = (query, populateResults) => {
   xhr.send();
 };
 
+/**
+ * Callback function to redirect to NHS Search page when an
+ * option is selected either with click or enter.
+ * @param {string} result Query to pass to search page URL
+*/
+const onConfirm = (result) => {
+  window.location.href = `${searchPageUrl}?q=${result}`;
+};
+
 export default () => {
   AutoComplete({
     containerId: 'autocomplete-container',
     formId: 'search',
     inputId: 'search-field',
+    onConfirm,
     source,
     templates: {
       suggestion,

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -63,9 +63,9 @@ export default () => {
   AutoComplete({
     containerId: 'autocomplete-container',
     formId: 'search',
-    showNoOptionsFound: false,
     inputId: 'search-field',
     onConfirm,
+    showNoOptionsFound: false,
     source,
     templates: {
       suggestion,

--- a/packages/components/header/headerAutoComplete.js
+++ b/packages/components/header/headerAutoComplete.js
@@ -29,7 +29,6 @@ const suggestion = (result) => {
 */
 const source = (query, populateResults) => {
   // Build URL for search endpoint
-  // const maxResults = 10;
   const fullUrl = `${searchApiUrl}?q=${query}&api-version=1`;
 
   // Async request for results based on query param


### PR DESCRIPTION
## Description
On Android Chrome you cannot go to a search results page by touching a header search suggestion.

This is because of the `accessible-autocomplete` package blocking this event. They offer an `onConfirm` callback which is called on touch, click or enter on a focused option.

Dev has been completed to add this callback to our `headerAutoComplete`

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
