### PR TITLE
Fix Install, Examples and About footer link URLs

### DIFF
--- a/app/_templates/layout.njk
+++ b/app/_templates/layout.njk
@@ -17,26 +17,26 @@
     <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2" rel="preload" as="font" crossorigin>
     <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff2" rel="preload" as="font" crossorigin>
 
-    <link href="{{ baseUrl }}/assets/nhsuk.css" rel="stylesheet">
+    <link href="{{ baseUrl }}assets/nhsuk.css" rel="stylesheet">
 
-    <script src="{{ baseUrl }}/assets/nhsuk.js" defer></script>
+    <script src="{{ baseUrl }}assets/nhsuk.js" defer></script>
 
-    <link rel="shortcut icon" href="{{ baseUrl }}/assets/favicons/favicon.ico" type="image/x-icon">
-    <link rel="apple-touch-icon" href="{{ baseUrl }}/assets/favicons/apple-touch-icon-180x180.png">
-    <link rel="mask-icon" href="{{ baseUrl }}/assets/favicon.svg" color="#005eb8">
-    <link rel="icon" sizes="192x192" href="{{ baseUrl }}/assets/favicon-192x192.png">
-    <meta name="msapplication-TileImage" content="{{ baseUrl }}/assets/mediumtile-144x144.png">
+    <link rel="shortcut icon" href="{{ baseUrl }}assets/favicons/favicon.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="{{ baseUrl }}assets/favicons/apple-touch-icon-180x180.png">
+    <link rel="mask-icon" href="{{ baseUrl }}assets/favicon.svg" color="#005eb8">
+    <link rel="icon" sizes="192x192" href="{{ baseUrl }}assets/favicon-192x192.png">
+    <meta name="msapplication-TileImage" content="{{ baseUrl }}assets/mediumtile-144x144.png">
     <meta name="msapplication-TileColor" content="#005eb8">
-    <meta name="msapplication-square70x70logo" content="{{ baseUrl }}/assets/smalltile-70x70.png">
-    <meta name="msapplication-square150x150logo" content="{{ baseUrl }}/assets/mediumtile-150x150.png">
-    <meta name="msapplication-wide310x150logo" content="{{ baseUrl }}/assets/favicons/widetile-310x150.png">
-    <meta name="msapplication-square310x310logo" content="{{ baseUrl }}/assets/favicons/largetile-310x310.png">
+    <meta name="msapplication-square70x70logo" content="{{ baseUrl }}assets/smalltile-70x70.png">
+    <meta name="msapplication-square150x150logo" content="{{ baseUrl }}assets/mediumtile-150x150.png">
+    <meta name="msapplication-wide310x150logo" content="{{ baseUrl }}assets/favicons/widetile-310x150.png">
+    <meta name="msapplication-square310x310logo" content="{{ baseUrl }}assets/favicons/largetile-310x310.png">
 
     <meta property="og:url" content="https://nhsuk.github.io/nhsuk-frontend/">
     <meta property="og:title" content="NHS.UK frontend library">
     <meta property="og:description" content="Code you need to start building accessible user interfaces for NHS websites and services.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="{{ baseUrl }}/assets/logos/open-graph.png">
+    <meta property="og:image" content="{{ baseUrl }}assets/logos/open-graph.png">
     <meta property="og:image:alt" content="NHS">
 
     <meta name="twitter:card" content="summary_large_image">

--- a/app/_templates/page.njk
+++ b/app/_templates/page.njk
@@ -46,7 +46,7 @@
   {{ header({
     "showNav": "false",
     "showSearch": "false",
-    "homeHref": "/nhsuk-frontend/"
+    "homeHref": baseUrl
     })
   }}
 {% endblock %}
@@ -87,19 +87,19 @@
   {{ footer({
     "links": [
       {
-        "URL": "/nhsuk-frontend/",
+        "URL": baseUrl,
         "label": "NHS.UK frontend"
       },
       {
-        "URL": "/nhsuk-frontend/pages/install.html",
+        "URL": baseUrl + "pages/install.html",
         "label": "Install"
       },
       {
-        "URL": "/nhsuk-frontend/pages/examples.html",
+        "URL": baseUrl + "pages/examples.html",
         "label": "Examples"
       },
       {
-        "URL": "/nhsuk-frontend/pages/about.html",
+        "URL": baseUrl + "pages/about.html",
         "label": "About"
       },
       {

--- a/app/_templates/page.njk
+++ b/app/_templates/page.njk
@@ -91,15 +91,15 @@
         "label": "NHS.UK frontend"
       },
       {
-        "URL": "/pages/install.html",
+        "URL": "/nhsuk-frontend/pages/install.html",
         "label": "Install"
       },
       {
-        "URL": "/pages/examples.html",
+        "URL": "/nhsuk-frontend/pages/examples.html",
         "label": "Examples"
       },
       {
-        "URL": "/pages/about.html",
+        "URL": "/nhsuk-frontend/pages/about.html",
         "label": "About"
       },
       {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "backstop:ci": "start-server-and-test start http://0.0.0.0:3000 backstop:test",
     "backstop:approve": "backstop --config=./tests/backstop/backstop.js approve",
     "backstop:clean": "rm -rf tests/backstop/bitmaps_test/*",
-    "build-gh-pages": "gulp bundle && BASE_URL='/nhsuk-frontend' gulp docs:build",
+    "build-gh-pages": "gulp bundle && BASE_URL='/nhsuk-frontend/' gulp docs:build",
     "build-gh-release": "gulp zip",
     "jest:dev": "jest --watch",
     "jest:ci": "jest"

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -5,7 +5,7 @@ const nunjucks = require('nunjucks');
 const connect = require('gulp-connect');
 
 const config = {
-  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : '',
+  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : '/',
   dest: 'dist/app',
   templates: ['app/_templates', 'packages'],
 };


### PR DESCRIPTION
## Description
Fix the URLs that "Install", "Examples" and "About" footer links direct to.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
