### PR TITLE
Swap input type number with inputmode numeric - Text and Date input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # NHS.UK frontend Changelog
 
-## 4.0.1 - Unreleased
+## 4.1.0 - Unreleased
+
+:new: **New features**
+
+- Add `inputmode` and `spellcheck` options to the text input component Nunjucks macro
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 :new: **New features**
 
-- Add `inputmode` and `spellcheck` options to the text input component Nunjucks macro
+- Text input component - add `inputmode` and `spellcheck` options to the Nunjucks macro
+- Date input component - change `type="number"` to `inputmode="numeric"`
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 :new: **New features**
 
-- Text input component - add `inputmode` and `spellcheck` options to the Nunjucks macro
-- Date input component - change `type="number"` to `inputmode="numeric"`
+- Add `inputmode` and `spellcheck` options to the text input Nunjucks macro
+- Change `type="number"` to `inputmode="numeric"` for the date input component
 
 :wrench: **Fixes**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5855,7 +5855,7 @@
     },
     "file-type": {
       "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
       "dev": true
     },
@@ -6125,7 +6125,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -29,7 +29,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day" name="dob-day" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -37,7 +37,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-month" name="dob-month" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -45,7 +45,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-year" name="dob-year" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -113,7 +113,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" type="number" autocomplete="bday-day" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" inputmode="numeric" autocomplete="bday-day" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -121,7 +121,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-month" name="dob-with-autocomplete-month" type="number" autocomplete="bday-month" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-month" name="dob-with-autocomplete-month" inputmode="numeric" autocomplete="bday-month" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -129,7 +129,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-with-autocomplete-attribute-year" name="dob-with-autocomplete-year" type="number" autocomplete="bday-year" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-with-autocomplete-attribute-year" name="dob-with-autocomplete-year" inputmode="numeric" autocomplete="bday-year" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -199,7 +199,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-day" name="day" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-day" name="day" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -207,7 +207,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-month" name="month" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-month" name="month" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -215,7 +215,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 nhsuk-input--error" id="dob-errors-year" name="year" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 nhsuk-input--error" id="dob-errors-year" name="year" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -284,7 +284,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-day-error-day" name="dob-day-error-day" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -292,7 +292,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -300,7 +300,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" inputmode="numeric" pattern="[0-9]*">
         </div>
       </div>
     </div>

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -29,7 +29,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day" name="dob-day" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day" name="dob-day" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -37,7 +37,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-month" name="dob-month" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-month" name="dob-month" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -45,7 +45,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-year" name="dob-year" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-year" name="dob-year" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -113,7 +113,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" inputmode="numeric" autocomplete="bday-day" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-day" name="dob-with-autocomplete-day" inputmode="numeric" type="text" autocomplete="bday-day" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -121,7 +121,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-month" name="dob-with-autocomplete-month" inputmode="numeric" autocomplete="bday-month" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-with-autocomplete-attribute-month" name="dob-with-autocomplete-month" inputmode="numeric" type="text" autocomplete="bday-month" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -129,7 +129,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-with-autocomplete-attribute-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-with-autocomplete-attribute-year" name="dob-with-autocomplete-year" inputmode="numeric" autocomplete="bday-year" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-with-autocomplete-attribute-year" name="dob-with-autocomplete-year" inputmode="numeric" type="text" autocomplete="bday-year" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -199,7 +199,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-day" name="day" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-day" name="day" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -207,7 +207,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-month" name="month" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-errors-month" name="month" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -215,7 +215,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-errors-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 nhsuk-input--error" id="dob-errors-year" name="year" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4 nhsuk-input--error" id="dob-errors-year" name="year" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
     </div>
@@ -284,7 +284,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-day">
           Day
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-day-error-day" name="dob-day-error-day" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2 nhsuk-input--error" id="dob-day-error-day" name="dob-day-error-day" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -292,7 +292,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-month">
           Month
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
       <div class="nhsuk-date-input__item">
@@ -300,7 +300,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
           <label class="nhsuk-label nhsuk-date-input__label" for="dob-day-error-year">
           Year
           </label>
-          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" inputmode="numeric" pattern="[0-9]*">
+          <input class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" inputmode="numeric" type="text" pattern="[0-9]*">
         </div>
       </div>
     </div>

--- a/packages/components/date-input/template.njk
+++ b/packages/components/date-input/template.njk
@@ -65,7 +65,7 @@
         classes: "nhsuk-date-input__input " + (item.classes if item.classes),
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
-        type: "number",
+        inputmode: item.inputmode if item.inputmode else "numeric",
         autocomplete: item.autocomplete,
         pattern: item.pattern if item.pattern else "[0-9]*",
         attributes: item.attributes

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -200,13 +200,15 @@ The input macro takes the following arguments:
 | **id**              | string   | Yes       | The id of the input. |
 | **name**            | string   | Yes       | The name of the input, which is submitted with the form data. |
 | **type**            | string   | No        | Type of input control to render. Defaults to "text".|
-| **value**           | string   | No        | Optional initial value of the input.|
-| **label**           | object   | No        | Arguments for the label component. See label component.|
+| **inputmode**       | string   | No        | Optional value for [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode). |
+| **value**           | string   | No        | Optional initial value of the input. |
+| **label**           | object   | No        | Arguments for the label component. See label component. |
 | **hint**            | object   | No        | Arguments for the hint component (e.g. text). See [hint](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/hint) component. |
 | **errorMessage**    | object   | No        | Arguments for the error message component (e.g. text). See [error message](https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/error-message) component. |
 | **classes**         | string   | No        | Optional additional classes add to the input component. Separate each class with a space. |
 | **autocomplete**    | string   | No        | Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [Autofilling form controls: the autocomplete attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for the full list of attributes that can be used. |
 | **pattern**         | string   | No        | Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value. |
+| **spellcheck**      | boolean | No         | Optional field to enable or disable the spellcheck attribute on the input. |
 | **attributes**      | object   | No        | Any extra HTML attributes (for example data attributes) to add to the input component. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/components/input/template.njk
+++ b/packages/components/input/template.njk
@@ -40,9 +40,11 @@
   <input class="nhsuk-input
   {%- if params.classes %} {{ params.classes }}{% endif %}
   {%- if params.errorMessage %} nhsuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+  {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
+  {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
 </div>


### PR DESCRIPTION
## Description

Add `inputmode` and `spellcheck` options to Text input component Nunjucks macro.

Change `type="number"` to `inputmode="numeric"` on the Date input component.

## Related issues

- https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/293
- https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/223
- https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/10

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
