### PR TITLE
Search input focus state style fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Switch from Travis CI to GitHub actions - Due to slow and inconsistent builds we have moved our CI to GitHub actions
 - Android search suggestions bug - when selecting an option from the suggestions in Chrome the form didn't populate and submit, this is now fixed.
 - Expander - Set width and height on expander SVG images to avoid squashed display in IE10 ([PR 668](https://github.com/nhsuk/nhsuk-frontend/pull/668))
+- Search input focus state style fix (mobile) - adjust padding to prevent the text from jumping when the field receives focus ([Issue 675](https://github.com/nhsuk/nhsuk-frontend/issues/675), [PR 678](https://github.com/nhsuk/nhsuk-frontend/pull/678))
 
 ## 4.0.0 - 26 October 2020
 

--- a/packages/components/header/_autocomplete.scss
+++ b/packages/components/header/_autocomplete.scss
@@ -48,6 +48,7 @@
       box-shadow: inset 0 0 0 $nhsuk-focus-width $nhsuk-focus-text-color;
       outline: $nhsuk-focus-width solid transparent;
       outline-offset: $nhsuk-focus-width;
+      padding: 0 13px;
     }
   }
 }

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -1086,6 +1086,7 @@
 
       @include mq($until: tablet) {
         border: $nhsuk-focus-width solid $nhsuk-focus-color;
+        padding: 0 13px;
       }
     }
   }


### PR DESCRIPTION
Adjust padding of `.autocomplete__input:focus` on mobile.

Closes https://github.com/nhsuk/nhsuk-frontend/issues/675.
