### PR TITLE
Service name header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 - Updated browser and assistive technology support documentation - remove support for IE8-10.  Read the blog post ([Changing our testing requirements for Internet Explorer 8, 9 and 10](https://technology.blog.gov.uk/2018/06/26/changing-our-testing-requirements-for-internet-explorer-8-9-and-10/)) by GOV.UK for more information why we have done this now.
 - add ability to not display the 'do not' prefix on list items that have the type 'cross' for the do and don't list component
+- Add helper class `nhsuk-header--service-name-inline` to make a service name inline with the NHS logo on smaller screens
 
 :wrench: **Fixes**
 
 - Removing support for IE8-10 and updating the NHS logo SVG html means the `xlink:href` is no longer an issue ([PR 657](https://github.com/nhsuk/nhsuk-frontend/pull/657), [PR 673](https://github.com/nhsuk/nhsuk-frontend/pull/673)). This also fixes the issue of not being able to select or focus on the NHS logo when using VoiceOver on iOS ([PR 631](https://github.com/nhsuk/nhsuk-frontend/pull/631))
 - Fix Create release GitHub Action which wasn't publishing to NPM ([Issue 691](https://github.com/nhsuk/nhsuk-frontend/issues/691))
 - Modifying the Card JavaScript to reference Card rather than the old Panel and adding Card to the NPM docs.
+- Remove `max-width` from service header with a logo only 
 
 :boom: **Breaking changes**
 

--- a/app/components/header/header-service-name-search-and-nav.njk
+++ b/app/components/header/header-service-name-search-and-nav.njk
@@ -1,0 +1,39 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Header transactional with service name' %}
+{% from 'components/header/macro.njk' import header %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+
+  {{ header({
+    "service": {
+      "name": "Digital service manual"
+    },
+    "showNav": "true",
+    "showSearch": "true",
+    "primaryLinks": [
+        {
+          "url"  : "#",
+          "label" : "NHS service standard"
+        },
+        {
+          'url' : '#',
+          'label' : 'Design system'
+        },
+        {
+          'url'  : '#',
+          'label' : 'Content style guide'
+        },
+        {
+          'url'  : '#',
+          'label' : 'Accessibility'
+        },
+        {
+          'url' : '#',
+          'label' : 'Community'
+        }
+      ]
+    })
+  }}
+
+{% endblock %}

--- a/app/components/header/header-service-name.njk
+++ b/app/components/header/header-service-name.njk
@@ -7,32 +7,11 @@
 
   {{ header({
     "service": {
-      "name": "Digital service manual"
+      "name": "Prototype kit"
     },
-    "showNav": "true",
-    "showSearch": "true",
-    "primaryLinks": [
-        {
-          "url"  : "#",
-          "label" : "NHS service standard"
-        },
-        {
-          'url' : '#',
-          'label' : 'Design system'
-        },
-        {
-          'url'  : '#',
-          'label' : 'Content style guide'
-        },
-        {
-          'url'  : '#',
-          'label' : 'Accessibility'
-        },
-        {
-          'url' : '#',
-          'label' : 'Community'
-        }
-      ]
+    "classes": "nhsuk-header--service-name-inline",
+    "showNav": "false",
+    "showSearch": "false"
     })
   }}
 

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -61,7 +61,8 @@
     <li><a href="../components/header/header-navigation.html">Header with navigation</a></li>
     <li><a href="../components/header/header-search.html">Header with search</a></li>
     <li><a href="../components/header/header-logo.html">Header with logo only</a></li>
-    <li><a href="../components/header/header-service-name.html">Header with a service name, search and navigation</a></li>
+    <li><a href="../components/header/header-service-name.html">Header with a service name</a></li>
+    <li><a href="../components/header/header-service-name-search-and-nav.html">Header with a service name, search and navigation</a></li>
     <li><a href="../components/header/header-transactional.html">Header transactional</a></li>
     <li><a href="../components/header/header-transactional-service-name.html">Header transactional with service name</a></li>
     <li><a href="../components/header/header-transactional-long-service-name.html">Header transactional with a long service name</a></li>

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -747,6 +747,26 @@
 
 }
 
+.nhsuk-header--service-name-inline {
+  .nhsuk-header__link--service {
+    -ms-flex-align: center;
+    align-items: center;
+    display: flex;
+    height: auto;
+    margin-bottom: 0;
+    text-decoration: none;
+    width: auto;
+  }
+
+  .nhsuk-header__service-name {
+    @include mq($until: large-desktop) {
+      font-size: 19px;
+      line-height: 20px;
+      padding-left: nhsuk-spacing(3);
+    }
+  }
+}
+
 .nhsuk-header__service-name {
   @include nhsuk-font(19);
 
@@ -771,7 +791,6 @@
       align-items: center;
       display: flex;
       margin-bottom: 0;
-      max-width: 270px;
       width: auto;
     }
 


### PR DESCRIPTION
## Description

- Add helper class `nhsuk-header--service-name-inline` to make a service name inline with the NHS lozenge on smaller screens
- Remove `max-width` from service header with a logo only 

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
