### PR TITLE
Update release action to fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
       - name: Install dependencies
         run: npm install
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 4.1.1 - TBC
+
+:wrench: **Fixes**
+
+- Fix Create release GitHub Action which wasn't publishing to NPM ([Issue 691](https://github.com/nhsuk/nhsuk-frontend/issues/691))
+
 ## 4.1.0 - 21 January 2021
 
 :new: **New features**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "start-server-and-test": "^1.11.7",
     "webpack-stream": "^5.2.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "eslintConfig": {
     "extends": "./tests/linters/.eslintrc.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "scripts": {
     "prepare": "gulp bundle",


### PR DESCRIPTION
## Description
Fix for ([Issue 691](https://github.com/nhsuk/nhsuk-frontend/issues/691))
Update Release GitHub Action to use Node environment and set NPM registry
Ensure publishConfig is set to `public` in `package.json`

Tested on a fork with different package name and version so I could publish to my own NPM.
Diff of the fork here: https://github.com/nhsuk/nhsuk-frontend/compare/master...tomdoughty:master
Github action succeeding here: https://github.com/tomdoughty/nhsuk-frontend/runs/1762708040?check_suite_focus=true

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
