### PR TITLE
Updating card JS to use card rather than panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Removing support for IE8-10 and updating the NHS logo SVG html means the `xlink:href` is no longer an issue ([PR 657](https://github.com/nhsuk/nhsuk-frontend/pull/657), [PR 673](https://github.com/nhsuk/nhsuk-frontend/pull/673)). This also fixes the issue of not being able to select or focus on the NHS logo when using VoiceOver on iOS ([PR 631](https://github.com/nhsuk/nhsuk-frontend/pull/631))
 - Fix Create release GitHub Action which wasn't publishing to NPM ([Issue 691](https://github.com/nhsuk/nhsuk-frontend/issues/691))
+- Modifying the Card JavaScript to reference Card rather than the old Panel and adding Card to the NPM docs.
 
 :boom: **Breaking changes**
 
@@ -62,7 +63,6 @@
 - Vendor in Sass-MQ (PR [#601](https://github.com/nhsuk/nhsuk-frontend/pull/601))
 - Update header focus styles to fix accessibility issue (PR [#684](https://github.com/nhsuk/nhsuk-frontend/pull/684))
 - Remove the full stops from the card component examples ([Issue 669](https://github.com/nhsuk/nhsuk-frontend/issues/653))
-- Modifying the Card JavaScript to reference Card rather than the old Panel and adding Card to the NPM docs.
 
 ## 4.0.0 - 26 October 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Vendor in Sass-MQ (PR [#601](https://github.com/nhsuk/nhsuk-frontend/pull/601))
 - Update header focus styles to fix accessibility issue (PR [#684](https://github.com/nhsuk/nhsuk-frontend/pull/684))
 - Remove the full stops from the card component examples ([Issue 669](https://github.com/nhsuk/nhsuk-frontend/issues/653))
+- Modifying the Card JavaScript to reference Card rather than the old Panel and adding Card to the NPM docs.
 
 ## 4.0.0 - 26 October 2020
 

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -93,6 +93,7 @@ import SkipLink from '../node_modules/nhsuk-frontend/packages/components/skip-li
 import Details from '../node_modules/nhsuk-frontend/packages/components/details/details';
 import Radios from '../node_modules/nhsuk-frontend/packages/components/radios/radios';
 import Checkboxes from '../node_modules/nhsuk-frontend/packages/components/checkboxes/checkboxes';
+import Card from '../node_modules/nhsuk-frontend/packages/components/card/card';
 
 // Polyfills
 import '../node_modules/nhsuk-frontend/packages/polyfills';
@@ -104,6 +105,7 @@ document.addEventListener('DOMContentLoaded', () => {
   SkipLink();
   Radios();
   Checkboxes();
+  Card();
 });
 ```
 

--- a/packages/components/card/card.js
+++ b/packages/components/card/card.js
@@ -1,11 +1,11 @@
 export default () => {
   // Loops through dom and finds all elements with nhsuk-card--clickable class
-  document.querySelectorAll('.nhsuk-card--clickable').forEach((panel) => {
-    // Check if panel has a link within it
-    if (panel.querySelector('a') !== null) {
+  document.querySelectorAll('.nhsuk-card--clickable').forEach((card) => {
+    // Check if card has a link within it
+    if (card.querySelector('a') !== null) {
       // Clicks the link within the heading to navigate to desired page
-      panel.addEventListener('click', () => {
-        panel.querySelector('a').click();
+      card.addEventListener('click', () => {
+        card.querySelector('a').click();
       });
     }
   });


### PR DESCRIPTION
## Description
The JS for the card component current references the old `panel` name. Updating JS to now use `card`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
