### PR TITLE
Feature/do dont prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :new: **New features**
 
 - Updated browser and assistive technology support documentation - remove support for IE8-10.  Read the blog post ([Changing our testing requirements for Internet Explorer 8, 9 and 10](https://technology.blog.gov.uk/2018/06/26/changing-our-testing-requirements-for-internet-explorer-8-9-and-10/)) by GOV.UK for more information why we have done this now.
+- add ability to not display the 'do not' prefix on list items that have the type 'cross' for the do and don't list component
 
 :wrench: **Fixes**
 

--- a/app/components/do-dont-list/index.njk
+++ b/app/components/do-dont-list/index.njk
@@ -29,6 +29,7 @@
         {{ list({
           "title": "Don't",
           "type": "cross",
+          "showPrefix": true,
           "items": [
             {
               "item": "burst a blister yourself"

--- a/app/components/do-dont-list/index.njk
+++ b/app/components/do-dont-list/index.njk
@@ -29,7 +29,6 @@
         {{ list({
           "title": "Don't",
           "type": "cross",
-          "showPrefix": true,
           "items": [
             {
               "item": "burst a blister yourself"

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -118,7 +118,7 @@ The do and don't list Nunjucks macro takes the following arguments:
 | **title**         | string   | Yes       | Title to be displayed on the do and don't list component. |
 | **type**          | string   | Yes       | Type of do and don't list component, "cross", "tick" |
 | **items**         | array    | Yes       | Items to be displayed within the do and don't list component |
-| **showprefix**    | boolean  | No        | If set to true when type is "cross", then adds the "do not" text prefix to each item |
+| **showPrefix**    | boolean  | No        | If set to true when type is "cross", then adds the "do not" text prefix to each item |
 | **headingLevel**  | integer  | No        | Optional heading level for the title heading. Default: 3 |
 | **classes**       | string   | No        | Optional additional classes to add to the do and don't list container. Separate each class with a space. |
 | **attributes**    | object   | No        | Any extra HTML attributes (for example data attributes) to add to the do and don't list container. |

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -118,7 +118,7 @@ The do and don't list Nunjucks macro takes the following arguments:
 | **title**         | string   | Yes       | Title to be displayed on the do and don't list component. |
 | **type**          | string   | Yes       | Type of do and don't list component, "cross", "tick" |
 | **items**         | array    | Yes       | Items to be displayed within the do and don't list component |
-| **showPrefix**    | boolean  | No        | If set to true when type is "cross", then adds the "do not" text prefix to each item |
+| **hidePrefix**    | boolean  | No        | If set to true when type is "cross", then removes the default "do not" text prefix to each item |
 | **headingLevel**  | integer  | No        | Optional heading level for the title heading. Default: 3 |
 | **classes**       | string   | No        | Optional additional classes to add to the do and don't list container. Separate each class with a space. |
 | **attributes**    | object   | No        | Any extra HTML attributes (for example data attributes) to add to the do and don't list container. |

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -118,6 +118,7 @@ The do and don't list Nunjucks macro takes the following arguments:
 | **title**         | string   | Yes       | Title to be displayed on the do and don't list component. |
 | **type**          | string   | Yes       | Type of do and don't list component, "cross", "tick" |
 | **items**         | array    | Yes       | Items to be displayed within the do and don't list component |
+| **showprefix**    | boolean  | No        | If set to true when type is "cross", then adds the "do not" text prefix to each item |
 | **headingLevel**  | integer  | No        | Optional heading level for the title heading. Default: 3 |
 | **classes**       | string   | No        | Optional additional classes to add to the do and don't list container. Separate each class with a space. |
 | **attributes**    | object   | No        | Any extra HTML attributes (for example data attributes) to add to the do and don't list container. |

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -16,7 +16,7 @@
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
     {%- endif %}
-      {% if params.type == 'cross' %}{% if params.showPrefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
+      {% if params.type == 'cross' %}{% if not params.hidePrefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
     </li>
     {%- endfor %}
   </ul>

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -16,7 +16,7 @@
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
     {%- endif %}
-      {% if params.type == 'cross' %}do not {% endif %}{{ data.item | safe}}
+      {% if params.type == 'cross' %}{% if params.showprefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
     </li>
     {%- endfor %}
   </ul>

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -16,7 +16,7 @@
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
     {%- endif %}
-      {% if params.type == 'cross' %}{% if params.showprefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
+      {% if params.type == 'cross' %}{% if params.showPrefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
     </li>
     {%- endfor %}
   </ul>

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -16,7 +16,7 @@
         <path stroke-width="4" stroke-linecap="round" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
       </svg>
     {%- endif %}
-      {% if params.type == 'cross' %}{% if not params.hidePrefix %}do not {% endif %}{% endif %} {{ data.item | safe}}
+      {% if params.type == 'cross' %}{% if not params.hidePrefix %}do not {% endif %}{% endif %}{{ data.item | safe}}
     </li>
     {%- endfor %}
   </ul>


### PR DESCRIPTION
## Description
Suggested fix for https://github.com/nhsuk/nhsuk-frontend/issues/539 - allow the option to not show the prefix of "do not" on items if the type is "cross". An alternative solution is to either remove the prefix altogether so you just enter the required text for each item. Or another solution is to have another argument of, say, "prefix" which prepends the value for each list item, for either type. But then I feel that is moving away from the 'do or don't' list idea.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
