### PR TITLE
Action link icon contrast in the immediate Care card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removing support for IE8-10 and updating the NHS logo SVG html means the `xlink:href` is no longer an issue ([PR 657](https://github.com/nhsuk/nhsuk-frontend/pull/657), [PR 673](https://github.com/nhsuk/nhsuk-frontend/pull/673)). This also fixes the issue of not being able to select or focus on the NHS logo when using VoiceOver on iOS ([PR 631](https://github.com/nhsuk/nhsuk-frontend/pull/631))
 - Fix Create release GitHub Action which wasn't publishing to NPM ([Issue 691](https://github.com/nhsuk/nhsuk-frontend/issues/691))
 - Modifying the Card JavaScript to reference Card rather than the old Panel and adding Card to the NPM docs.
+- Give the Action link icon sufficient contrast when used in the Care card immediate variant ([Issue 588](https://github.com/nhsuk/nhsuk-frontend/issues/588))
 
 :boom: **Breaking changes**
 

--- a/packages/components/care-card/_care-card.scss
+++ b/packages/components/care-card/_care-card.scss
@@ -16,6 +16,7 @@
  * 5. 'Random number' used for spacing to compensate for the triangle.
  * 6. Needed to enable the triangle to show correctly in high contrast mode.
  * 7. Prevent additional padding on headings
+ * 8. Give the action link icon sufficient contrast when used in the immediate variant
  */
 
 .nhsuk-care-card {
@@ -146,6 +147,12 @@
     }
     &:focus {
       color: $color_nhsuk-black;
+    }
+  }
+
+  .nhsuk-action-link__link {
+    .nhsuk-icon__arrow-right-circle {
+      fill: $color_nhsuk-white; /* [8] */
     }
   }
 


### PR DESCRIPTION
## Description

Give the Action link icon sufficient contrast when used in the Care card immediate variant

fixes #588 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
