### PR TITLE
accommodate longer service names on the service header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Give the Action link icon sufficient contrast when used in the Care card immediate variant ([Issue 588](https://github.com/nhsuk/nhsuk-frontend/issues/588))
 - Fix the insufficient colour contrast ratio for the Search placeholder text ([Issue 687](https://github.com/nhsuk/nhsuk-frontend/issues/687))
 - Remove `max-width` from service header with a logo only ([PR 705](https://github.com/nhsuk/nhsuk-frontend/pull/705))
+- Add a `max-width` to the service header with service name to accommodate longer service names ([Issue 708](https://github.com/nhsuk/nhsuk-frontend/issues/708))
 
 :boom: **Breaking changes**
 

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -759,6 +759,10 @@
     padding-left: nhsuk-spacing(3);
   }
 
+  @include mq($until: large-desktop) {
+    max-width: 220px;
+  }
+
 }
 
 .nhsuk-header__logo--only {


### PR DESCRIPTION
## Description

accommodate longer service names on the service header by applying a max width

[refs #708] 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
