### PR TITLE
[refs #676] Move icons using background into ::before to simplify automated testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 5.0.1 - Unreleased
+
+:wrench: **Fixes**
+
+- Fix aXe accessibility warning on breadcrumb and expander components ([PR 718](https://github.com/nhsuk/nhsuk-frontend/pull/718))
+
 ## 5.0.0 - 26 March 2021
 
 :boom: **Breaking changes**

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -58,20 +58,18 @@
 
 .nhsuk-breadcrumb__item {
   @include nhsuk-font(16); /* [4] */
-  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-right' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' height='18' width='18' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z'%3E%3C/path%3E%3C/svg%3E") right -1px top 4px no-repeat; // sass-lint:disable-line quotes
   display: inline-block;
   margin-bottom: 0;
-  padding-left: 3px; /* [7] */
-  padding-right: 27px; /* [7] */
 
-  &:first-child {
-    padding-left: 0;
+  &:not(:last-child):after {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-right' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' height='18' width='18' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z'%3E%3C/path%3E%3C/svg%3E") right 0 top 4px no-repeat; // sass-lint:disable-line quotes
+    content: '';
+    display: inline-block;
+    height: 18px;
+    margin-left: 10px;
+    margin-right: 2px;
+    width: 18px;
   }
-
-  &:last-child {
-    background: none;
-  }
-
 }
 
 .nhsuk-breadcrumb__link {
@@ -93,20 +91,27 @@
 
 .nhsuk-breadcrumb__back {
   @include nhsuk-font(16); /* [4] */
-  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-left' xmlns='http://www.w3.org/2000/svg' fill='%23005eb8' height='24' width='24' viewBox='0 0 24 24' aria-hidden='true'%3E%3Cpath d='M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z'%3E%3C/path%3E%3C/svg%3E") -8px center no-repeat; // sass-lint:disable-line quotes
   margin: 0;
-  padding-left: nhsuk-spacing(4);
+  padding-left: nhsuk-spacing(3);
+  position: relative;
 
   @include mq($from: tablet) {
     display: none; /* [5] */
   }
 
+  &:before {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-left' xmlns='http://www.w3.org/2000/svg' fill='%23005eb8' height='24' width='24' viewBox='8 0 24 24' aria-hidden='true'%3E%3Cpath d='M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z'%3E%3C/path%3E%3C/svg%3E") no-repeat; // sass-lint:disable-line quotes
+    content: '';
+    display: inline-block;
+    height: 18px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 10px;
+  }
 }
 
 .nhsuk-breadcrumb__backlink {
-  left: -8px; /* [6] */
-  position: relative;
-
   &:visited {
     color: $nhsuk-link-color;
 

--- a/packages/components/details/_details.scss
+++ b/packages/components/details/_details.scss
@@ -136,21 +136,30 @@ $expander-border-hover-color: $color_nhsuk-grey-3;
       .nhsuk-details__summary-text {
         @include nhsuk-focused-text();
 
-        background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
-        background-size: 32px 32px;
+        &:before {
+          background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
+        }
       }
     }
-
   }
 
   .nhsuk-details__summary-text {
-    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
-    background-size: 32px 32px;
     color: $color_nhsuk-blue;
     cursor: pointer;
     display: inline-block;
     padding: nhsuk-spacing(1) nhsuk-spacing(1) nhsuk-spacing(1) 38px;
     position: relative;
+
+    &:before {
+      background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; // sass-lint:disable-line quotes
+      content: '';
+      display: inline-block;
+      height: 32px;
+      left: 0;
+      position: absolute;
+      top: calc(50% - 16px);
+      width: 32px;
+    }
   }
 
   .nhsuk-details__text {
@@ -163,7 +172,6 @@ $expander-border-hover-color: $color_nhsuk-grey-3;
     margin-left: 0;
     margin-top: 0;
   }
-
 }
 
 .nhsuk-expander[open] {
@@ -172,25 +180,21 @@ $expander-border-hover-color: $color_nhsuk-grey-3;
   .nhsuk-details__summary {
 
     &:focus {
-
-      .nhsuk-details__summary-text {
-        background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
-        background-size: 32px 32px;
-      }
-
       &:hover {
         .nhsuk-details__summary-text {
           text-decoration: none;
         }
       }
+
+      .nhsuk-details__summary-text::before {
+        background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
+      }
     }
   }
 
-  .nhsuk-details__summary-text {
+  .nhsuk-details__summary-text::before {
     background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat; /* [3] */ // sass-lint:disable-line quotes
-    background-size: 32px 32px;
   }
-
 }
 
 .nhsuk-expander-group { /* [4] */


### PR DESCRIPTION
## Description
Resolving https://github.com/nhsuk/nhsuk-frontend/issues/676 - this updates the expander and breadcrumb components to prevent aXe from seeing accessibility violations due to the use of background images on elements that contain text. This fixes the `elements must have sufficient color contrast` warning.

They look pixel-perfect identical across all resolutions.

![Screenshot 2021-03-16 at 11 19 19](https://user-images.githubusercontent.com/23333247/111300949-8c544680-8649-11eb-8eac-288a66b639e8.png)

![Screenshot 2021-03-16 at 11 19 28](https://user-images.githubusercontent.com/23333247/111300932-88c0bf80-8649-11eb-8cea-a7d80f0cfa45.png)


## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
