### PR TITLE
Conditionally load fonts to avoid performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   ```
 
   Note: You may need to change the path to `node_modules` depending on your project structure.
+- Added `$nhsuk-fonts-path` and `$nhsuk-include-font-face` variables to allow for self-hosted fonts or
+disabling font altogether
 
 :wrench: **Fixes**
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -229,6 +229,14 @@ Hide elements visually but keep it in the DOM, useful for screen readers.
 <p class="nhsuk-lede-text">Advice, tips and tools to help you make the best choices about your health and wellbeing.</p>
 ```
 
+### Font
+
+The default `@font-face`, "Frutiger", is loaded from `https://assets.nhs.uk`. The host for the fonts can be
+overridden or disabled entirely.
+
+- `$nhsuk-fonts-path`: base URL to load fonts from (e.g. `/fonts/`; trailing slash required)
+- `$nhsuk-include-font-face`: set to false to disable the inclusion of the `@font-face` definition entirely
+
 ## Breakpoints
 
 ```

--- a/packages/core/elements/_page.scss
+++ b/packages/core/elements/_page.scss
@@ -16,8 +16,12 @@
 
 html {
   background-color: $color_nhsuk-grey-4;
-  font-family: $nhsuk-font, $nhsuk-font-fallback;
   overflow-y: scroll; /* [1] */
+
+  @if $nhsuk-include-font-face {
+    @include _nhsuk-font-face-frutiger;
+    font-family: $nhsuk-font, $nhsuk-font-fallback;
+  }
 }
 
 body {

--- a/packages/core/generic/_font-face.scss
+++ b/packages/core/generic/_font-face.scss
@@ -8,28 +8,36 @@
 
 // sass-lint:disable no-duplicate-properties, indentation, property-sort-order
 
-@font-face {
-  font-family: 'Frutiger W01';
-  font-display: swap;
-  font-style: normal;
-  font-weight: 400;
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.eot?#iefix');
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.eot?#iefix') format('eot'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2') format('woff2'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff') format('woff'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.ttf') format('truetype'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.svg#7def0e34-f28d-434f-b2ec-472bde847115') format('svg');
+@function nhsuk-font-url($filename) {
+  @return url($nhsuk-fonts-path + $filename);
 }
 
-@font-face {
-  font-family: 'Frutiger W01';
-  font-display: swap;
-  font-style: normal;
-  font-weight: 600;
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.eot?#iefix');
-  src: url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.eot?#iefix') format('eot'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff2') format('woff2'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff') format('woff'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.ttf') format('truetype'),
-       url('https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.svg#eae74276-dd78-47e4-9b27-dac81c3411ca') format('svg');
+@mixin _nhsuk-font-face-frutiger {
+  @at-root {
+    @font-face {
+      font-family: 'Frutiger W01';
+      font-display: swap;
+      font-style: normal;
+      font-weight: 400;
+      src: nhsuk-font-url('FrutigerLTW01-55Roman.eot?#iefix');
+      src: nhsuk-font-url('FrutigerLTW01-55Roman.eot?#iefix') format('eot'),
+           nhsuk-font-url('FrutigerLTW01-55Roman.woff2') format('woff2'),
+           nhsuk-font-url('FrutigerLTW01-55Roman.woff') format('woff'),
+           nhsuk-font-url('FrutigerLTW01-55Roman.ttf') format('truetype'),
+           nhsuk-font-url('FrutigerLTW01-55Roman.svg#7def0e34-f28d-434f-b2ec-472bde847115') format('svg');
+    }
+
+    @font-face {
+      font-family: 'Frutiger W01';
+      font-display: swap;
+      font-style: normal;
+      font-weight: $nhsuk-font-bold;
+      src: nhsuk-font-url('FrutigerLTW01-65Bold.eot?#iefix');
+      src: nhsuk-font-url('FrutigerLTW01-65Bold.eot?#iefix') format('eot'),
+           nhsuk-font-url('FrutigerLTW01-65Bold.woff2') format('woff2'),
+           nhsuk-font-url('FrutigerLTW01-65Bold.woff') format('woff'),
+           nhsuk-font-url('FrutigerLTW01-65Bold.ttf') format('truetype'),
+           nhsuk-font-url('FrutigerLTW01-65Bold.svg#eae74276-dd78-47e4-9b27-dac81c3411ca') format('svg');
+    }
+  }
 }

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -8,12 +8,14 @@
 // 1. Fallback fonts if Frutiger fails to load
 //
 
-$nhsuk-font: Frutiger W01;
-$nhsuk-font-fallback: Arial, Sans-serif; // [1] //
+$nhsuk-font: Frutiger W01 !default;
+$nhsuk-font-fallback: Arial, Sans-serif !default; // [1] //
 $nhsuk-font-family-print: sans-serif !default;
-$nhsuk-font-bold: 600;
-$nhsuk-font-normal: 400;
-$nhsuk-font-light: $nhsuk-font-normal;
+$nhsuk-font-bold: 600 !default;
+$nhsuk-font-normal: 400 !default;
+$nhsuk-font-light: $nhsuk-font-normal !default;
+$nhsuk-fonts-path: 'https://assets.nhs.uk/fonts/' !default;
+$nhsuk-include-font-face: true !default;
 
 //
 // Font sizing and spacing


### PR DESCRIPTION
## Description

Related: https://github.com/nhsuk/nhsuk-frontend/issues/728

This PR fixes the above issue by separating font loading into a separate stylesheet; disabling the font by default. If a dependent wishes to load fonts from `assets.nhs.uk` they will need to include the new `nhsuk-fonts.css` stylesheet. I've incremented the MAJOR version in `package.json` to signify this as a breaking change for those who are using `nhsuk-frontend` already.

Further reading: https://developers.google.com/web/updates/2020/10/http-cache-partitioning

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
