### PR TITLE
update README to remove specific contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ Visit our [support for browsers and assistive technology](/docs/contributing/bro
 
 Read our [contributing guidelines](CONTRIBUTING.md) to contribute to NHS.UK frontend.
 
-We created this library with help from:
-
-- [Government Digital Service (GDS)](https://github.com/alphagov/)
-- [Harry Roberts (csswizardry)](https://github.com/csswizardry)
-- [Phil Sherry](https://github.com/philsherry)
-- [Caroline Jarrett](https://twitter.com/cjforms)
-
 ## Get in touch
 
 NHS.UK frontend is maintained by NHS Digital. [Email us](mailto:service-manual@nhs.net), open a [GitHub issue](https://github.com/nhsuk/nhsuk-frontend/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).


### PR DESCRIPTION
## Description

Over the years this library has grown and has been contributed to by a number of people (both through code and non code contributions), these specific people helped us start the library, but since there have been many more who have helped build and grow it further. So it would be unfair to highlight only a select few. 

Credit to the Government Digital Service remains in code and specific documentation.