### PR TITLE
remove deprecated uses of SASS division operator via sass-migrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## 6.0.0 - Unreleased
+
+:wrench: **Fixes**
+
+- Address SASS deprecation warnings ([Issue 752](https://github.com/nhsuk/nhsuk-frontend/issues/752)).
+
 ## 5.1.0 - 14 May 2021
 
 :new: **New features**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "nhsuk-frontend",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.1.0",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "jest": "^26.6.3",
         "minimist": "^1.2.5",
         "nunjucks": "^3.2.2",
-        "sass": "^1.32.11",
+        "sass": "^1.33.0",
         "start-server-and-test": "^1.11.7",
         "stylelint": "^13.10.0",
         "stylelint-order": "^4.1.0",
@@ -17005,9 +17005,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.32.11",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
-      "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.2.tgz",
+      "integrity": "sha512-jhO5KAR+AMxCEwIH3v+4zbB2WB0z67V1X0jbapfVwQQdjHZUGUyukpnoM6+iCMfsIUC016w9OPKQ5jrNOS9uXw==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -35593,9 +35593,9 @@
       }
     },
     "sass": {
-      "version": "1.32.11",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
-      "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.2.tgz",
+      "integrity": "sha512-jhO5KAR+AMxCEwIH3v+4zbB2WB0z67V1X0jbapfVwQQdjHZUGUyukpnoM6+iCMfsIUC016w9OPKQ5jrNOS9uXw==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "scripts": {
     "prepare": "gulp bundle",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "^26.6.3",
     "minimist": "^1.2.5",
     "nunjucks": "^3.2.2",
-    "sass": "^1.32.11",
+    "sass": "^1.33.0",
     "start-server-and-test": "^1.11.7",
     "stylelint": "^13.10.0",
     "stylelint-order": "^4.1.0",

--- a/packages/components/checkboxes/_checkboxes.scss
+++ b/packages/components/checkboxes/_checkboxes.scss
@@ -134,7 +134,7 @@ $nhsuk-checkboxes-label-padding-left-right: 12px;
  */
 
 $conditional-border-width: $nhsuk-border-width-mobile;
-$conditional-border-padding: ($nhsuk-checkboxes-size / 2) - ($conditional-border-width / 2); /* 1 */
+$conditional-border-padding: ($nhsuk-checkboxes-size * 0.5) - ($conditional-border-width * 0.5); /* 1 */
 $conditional-margin-left: $conditional-border-padding; /* 2 */
 $conditional-padding-left: $conditional-border-padding + $nhsuk-checkboxes-label-padding-left-right; /* 3 */
 

--- a/packages/components/checkboxes/_checkboxes.scss
+++ b/packages/components/checkboxes/_checkboxes.scss
@@ -134,7 +134,7 @@ $nhsuk-checkboxes-label-padding-left-right: 12px;
  */
 
 $conditional-border-width: $nhsuk-border-width-mobile;
-$conditional-border-padding: ($nhsuk-checkboxes-size * 0.5) - ($conditional-border-width * 0.5); /* 1 */
+$conditional-border-padding: ($nhsuk-checkboxes-size * .5) - ($conditional-border-width * .5); /* 1 */
 $conditional-margin-left: $conditional-border-padding; /* 2 */
 $conditional-padding-left: $conditional-border-padding + $nhsuk-checkboxes-label-padding-left-right; /* 3 */
 

--- a/packages/components/radios/_radios.scss
+++ b/packages/components/radios/_radios.scss
@@ -152,7 +152,7 @@ $nhsuk-radios-focus-width: $nhsuk-focus-width + 1px;
 
 $conditional-border-width: $nhsuk-border-width-mobile;
 // Calculate the amount of padding needed to keep the border centered against the radios.
-$conditional-border-padding: ($nhsuk-radios-size * 0.5) - ($conditional-border-width * 0.5);
+$conditional-border-padding: ($nhsuk-radios-size * .5) - ($conditional-border-width * .5);
 // Move the border centered with the radios
 $conditional-margin-left: $conditional-border-padding;
 // Move the contents of the conditional inline with the label

--- a/packages/components/radios/_radios.scss
+++ b/packages/components/radios/_radios.scss
@@ -152,7 +152,7 @@ $nhsuk-radios-focus-width: $nhsuk-focus-width + 1px;
 
 $conditional-border-width: $nhsuk-border-width-mobile;
 // Calculate the amount of padding needed to keep the border centered against the radios.
-$conditional-border-padding: ($nhsuk-radios-size / 2) - ($conditional-border-width / 2);
+$conditional-border-padding: ($nhsuk-radios-size * 0.5) - ($conditional-border-width * 0.5);
 // Move the border centered with the radios
 $conditional-margin-left: $conditional-border-padding;
 // Move the contents of the conditional inline with the label

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -36,7 +36,7 @@ $nhsuk-icon-size: 34px !default;
 
 $nhsuk-page-width: 960px;
 $nhsuk-gutter: 32px;
-$nhsuk-gutter-half: $nhsuk-gutter / 2;
+$nhsuk-gutter-half: $nhsuk-gutter * 0.5;
 
 //
 // Border sizes

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -36,7 +36,7 @@ $nhsuk-icon-size: 34px !default;
 
 $nhsuk-page-width: 960px;
 $nhsuk-gutter: 32px;
-$nhsuk-gutter-half: $nhsuk-gutter * 0.5;
+$nhsuk-gutter-half: $nhsuk-gutter * .5;
 
 //
 // Border sizes

--- a/packages/core/tools/_functions.scss
+++ b/packages/core/tools/_functions.scss
@@ -13,6 +13,8 @@
 // https://github.com/alphagov/govuk-frontend
 //
 
+@use "sass:math";
+
 @function nhsuk-em($value, $context-font-size) {
   @if (unitless($value)) {
     $value: $value * 1px;
@@ -20,7 +22,7 @@
   @if (unitless($context-font-size)) {
     $context-font-size: $context-font-size * 1px;
   }
-  @return $value / $context-font-size * 1em;
+  @return math.div($value, $context-font-size) * 1em;
 }
 
 // Convert pixels to rem
@@ -39,5 +41,5 @@
     $value: $value * 1px;
   }
 
-  @return $value / $nhsuk-base-font-size * 1rem;
+  @return math.div($value, $nhsuk-base-font-size) * 1rem;
 }

--- a/packages/core/tools/_functions.scss
+++ b/packages/core/tools/_functions.scss
@@ -13,7 +13,7 @@
 // https://github.com/alphagov/govuk-frontend
 //
 
-@use "sass:math";
+@use 'sass:math';
 
 @function nhsuk-em($value, $context-font-size) {
   @if (unitless($value)) {

--- a/packages/core/tools/_shape-arrow.scss
+++ b/packages/core/tools/_shape-arrow.scss
@@ -19,7 +19,7 @@
 @function _govuk-equilateral-height($base) {
   $square-root-of-three: 1.732;
 
-  @return ($base / 2) * $square-root-of-three;
+  @return ($base * 0.5) * $square-root-of-three;
 }
 
 //
@@ -49,7 +49,7 @@
   border-style: solid;
   border-color: transparent; // 1
 
-  $perpendicular: $base / 2;
+  $perpendicular: $base * 0.5;
 
   @if ($height == null) {
     $height: _govuk-equilateral-height($base);

--- a/packages/core/tools/_shape-arrow.scss
+++ b/packages/core/tools/_shape-arrow.scss
@@ -19,7 +19,7 @@
 @function _govuk-equilateral-height($base) {
   $square-root-of-three: 1.732;
 
-  @return ($base * 0.5) * $square-root-of-three;
+  @return ($base * .5) * $square-root-of-three;
 }
 
 //
@@ -49,7 +49,7 @@
   border-style: solid;
   border-color: transparent; // 1
 
-  $perpendicular: $base * 0.5;
+  $perpendicular: $base * .5;
 
   @if ($height == null) {
     $height: _govuk-equilateral-height($base);

--- a/packages/core/tools/_typography.scss
+++ b/packages/core/tools/_typography.scss
@@ -17,6 +17,8 @@
 // https://github.com/alphagov/govuk-frontend
 //
 
+@use "sass:math";
+
 @mixin nhsuk-text-color {
   color: $nhsuk-text-color;
 
@@ -68,7 +70,7 @@
     // This is expanded to 10 in dart-sass and results in significant line height differences
     // Therefore by rounding it here we achieve consistent rendering across node-sass and dart-sass
     $ten-to-the-power-five: 100000;
-    $line-height: round(($line-height / $font-size) * $ten-to-the-power-five) / $ten-to-the-power-five;
+    $line-height: math.div(round(math.div($line-height, $font-size) * $ten-to-the-power-five), $ten-to-the-power-five);
   }
 
   @return $line-height;

--- a/packages/core/tools/_typography.scss
+++ b/packages/core/tools/_typography.scss
@@ -17,7 +17,7 @@
 // https://github.com/alphagov/govuk-frontend
 //
 
-@use "sass:math";
+@use 'sass:math';
 
 @mixin nhsuk-text-color {
   color: $nhsuk-text-color;

--- a/packages/core/utilities/_grid-widths.scss
+++ b/packages/core/utilities/_grid-widths.scss
@@ -15,11 +15,11 @@
 // so we disable stylelint for that rule
 /* stylelint-disable declaration-no-important */
 
-@use "sass:math";
+@use 'sass:math';
 
 .nhsuk-u-one-half {
   float: left;
-  width: percentage(1 * 0.5) !important;
+  width: percentage(1 * .5) !important;
 }
 
 .nhsuk-u-one-third {
@@ -34,12 +34,12 @@
 
 .nhsuk-u-one-quarter {
   float: left;
-  width: percentage(1 * 0.25) !important;
+  width: percentage(1 * .25) !important;
 }
 
 .nhsuk-u-three-quarters {
   float: left;
-  width: percentage(3 * 0.25) !important;
+  width: percentage(3 * .25) !important;
 }
 
 /**
@@ -58,7 +58,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(1 * 0.5) !important;
+    width: percentage(1 * .5) !important;
   }
 }
 
@@ -82,7 +82,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(1 * 0.25) !important;
+    width: percentage(1 * .25) !important;
   }
 }
 
@@ -90,6 +90,6 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(3 * 0.25) !important;
+    width: percentage(3 * .25) !important;
   }
 }

--- a/packages/core/utilities/_grid-widths.scss
+++ b/packages/core/utilities/_grid-widths.scss
@@ -15,29 +15,31 @@
 // so we disable stylelint for that rule
 /* stylelint-disable declaration-no-important */
 
+@use "sass:math";
+
 .nhsuk-u-one-half {
   float: left;
-  width: percentage(1 / 2) !important;
+  width: percentage(1 * 0.5) !important;
 }
 
 .nhsuk-u-one-third {
   float: left;
-  width: percentage(1 / 3) !important;
+  width: percentage(math.div(1, 3)) !important;
 }
 
 .nhsuk-u-two-thirds {
   float: left;
-  width: percentage(2 / 3) !important;
+  width: percentage(math.div(2, 3)) !important;
 }
 
 .nhsuk-u-one-quarter {
   float: left;
-  width: percentage(1 / 4) !important;
+  width: percentage(1 * 0.25) !important;
 }
 
 .nhsuk-u-three-quarters {
   float: left;
-  width: percentage(3 / 4) !important;
+  width: percentage(3 * 0.25) !important;
 }
 
 /**
@@ -56,7 +58,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(1 / 2) !important;
+    width: percentage(1 * 0.5) !important;
   }
 }
 
@@ -64,7 +66,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(1 / 3) !important;
+    width: percentage(math.div(1, 3)) !important;
   }
 }
 
@@ -72,7 +74,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(2 / 3) !important;
+    width: percentage(math.div(2, 3)) !important;
   }
 }
 
@@ -80,7 +82,7 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(1 / 4) !important;
+    width: percentage(1 * 0.25) !important;
   }
 }
 
@@ -88,6 +90,6 @@
   width: 100% !important;
   @include mq($from: tablet) {
     float: left;
-    width: percentage(3 / 4) !important;
+    width: percentage(3 * 0.25) !important;
   }
 }

--- a/packages/core/vendor/sass-mq.scss
+++ b/packages/core/vendor/sass-mq.scss
@@ -8,7 +8,7 @@
 
 /// Base font size on the `<body>` element
 /// @type Number (unit)
-@use "sass:math";
+@use 'sass:math';
 
 $mq-base-font-size: 16px !default;
 
@@ -249,7 +249,7 @@ $mq-media-type: all !default;
     $large: ();
 
     @if length($list) > 1 {
-        $seed: nth($list, ceil(length($list) * 0.5));
+        $seed: nth($list, ceil(length($list) * .5));
 
         @each $item in $list {
             @if ($item == $seed) {

--- a/packages/core/vendor/sass-mq.scss
+++ b/packages/core/vendor/sass-mq.scss
@@ -8,6 +8,8 @@
 
 /// Base font size on the `<body>` element
 /// @type Number (unit)
+@use "sass:math";
+
 $mq-base-font-size: 16px !default;
 
 /// Responsive mode
@@ -98,7 +100,7 @@ $mq-media-type: all !default;
     } @else if unit($px) == em {
         @return $px;
     }
-    @return ($px / $base-font-size) * 1em;
+    @return math.div($px, $base-font-size) * 1em;
 }
 
 /// Get a breakpoint's width
@@ -247,7 +249,7 @@ $mq-media-type: all !default;
     $large: ();
 
     @if length($list) > 1 {
-        $seed: nth($list, ceil(length($list) / 2));
+        $seed: nth($list, ceil(length($list) * 0.5));
 
         @each $item in $list {
             @if ($item == $seed) {


### PR DESCRIPTION
## Description
Closes https://github.com/nhsuk/nhsuk-frontend/issues/752

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
