### PR TITLE
Add option to disable error summary focusing on page load

### DIFF
--- a/packages/components/error-summary/error-summary.js
+++ b/packages/components/error-summary/error-summary.js
@@ -104,13 +104,16 @@ function handleClick(event) {
   }
 }
 
-export default () => {
+export default ({ focusOnPageLoad = true } = {}) => {
   // Error summary component
   const errorSummary = document.querySelector('.nhsuk-error-summary');
 
   if (errorSummary) {
     // Focus error summary component if it exists
-    errorSummary.focus();
+
+    if (focusOnPageLoad) {
+      errorSummary.focus();
+    }
     errorSummary.addEventListener('click', handleClick);
   }
 };


### PR DESCRIPTION
## Description
Add option to disable error summary focusing on page load. This allows us to disable it when rendering examples on the design system

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
