### PR TITLE
[refs #721] Add menu and search toggles when JS is disabled

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -36,6 +36,8 @@
  * 15. Remove random top margin in Safari
  * 16. Align close icon with nav item arrow icons
  * 17. Add nhsuk-spacing(9) to align right and left main nav with header
+ * 18.
+ * 19. Hide input checkboxes from UI. These are required for menu and search bar toggling when JS is disabled
  */
 
 .nhsuk-header {
@@ -174,7 +176,23 @@
     @include nhsuk-focused-button();
     box-shadow: 0 0 0 2px $nhsuk-focus-color, 0 $nhsuk-focus-width 0 2px $nhsuk-focus-text-color;
   }
+}
 
+input#noJsSearchToggle {
+  display: none; /* [19] */
+}
+
+.nhsuk-header__search-toggle--no-js {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  opacity: 0;
+
+  body.js-enabled & {
+    display: none;
+  }
 }
 
 .nhsuk-header__search-form {
@@ -212,7 +230,8 @@
   .nhsuk-header__search-wrap {
     display: none;
 
-    &.js-show {
+    &.js-show,
+    #noJsSearchToggle:checked ~ .nhsuk-header & {
       clear: both;
       display: flex;
       margin-bottom: -20px;
@@ -322,6 +341,10 @@
       .nhsuk-icon__close {
         fill: $nhsuk-focus-text-color;
       }
+    }
+
+    body:not(.js-enabled) & {
+      position: relative;
     }
   }
 
@@ -475,7 +498,23 @@
 
     box-shadow: 0 0 0 2px $nhsuk-focus-color, 0 $nhsuk-focus-width 0 2px $nhsuk-focus-text-color;
   }
+}
 
+input#noJsMenuToggle {
+  display: none; /* [19] */
+}
+
+.nhsuk-header__menu-toggle--no-js {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  opacity: 0;
+
+  body.js-enabled & {
+    display: none;
+  }
 }
 
 /* 'only' modifier for when there is only the menu in the header, no search
@@ -498,7 +537,8 @@
   display: none;
   overflow: hidden;
 
-  &.js-show {
+  &.js-show,
+  #noJsMenuToggle:checked ~ .nhsuk-header & {
     display: block;
 
     @include mq($until: large-desktop) {

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -9,6 +9,9 @@
   </svg>
 {% endset %}
 
+<input type="checkbox" id="noJsMenuToggle" aria-hidden="true" />
+<input type="checkbox" id="noJsSearchToggle" aria-hidden="true" />
+
 <header class="nhsuk-header
 {%- if params.transactional or params.transactionalService %} nhsuk-header--transactional{% endif %}
 {%- if params.organisation and params.organisation.name %} nhsuk-header--organisation{% endif %}
@@ -55,7 +58,7 @@
       <div class="nhsuk-header__content" id="content-header">
 
         <div class="nhsuk-header__menu">
-          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu<label for="noJsMenuToggle" class="nhsuk-header__menu-toggle--no-js" aria-hidden="true">Toggle menu</label></button>
         </div>
 
         <div class="nhsuk-header__search">
@@ -64,6 +67,7 @@
               <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
             </svg>
             <span class="nhsuk-u-visually-hidden">Search</span>
+            <label for="noJsSearchToggle" class="nhsuk-header__search-toggle--no-js" aria-hidden="true">Toggle search</label>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
             <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
@@ -75,11 +79,12 @@
                 </svg>
                 <span class="nhsuk-u-visually-hidden">Search</span>
               </button>
-              <button class="nhsuk-search__close" id="close-search">
+              <button class="nhsuk-search__close" id="close-search" type="button">
                 <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
                   <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
                 </svg>
                 <span class="nhsuk-u-visually-hidden">Close search</span>
+                <label for="noJsSearchToggle" class="nhsuk-header__search-toggle--no-js" aria-hidden="true">Close search</label>
               </button>
             </form>
           </div>
@@ -97,6 +102,7 @@
               <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
             </svg>
             <span class="nhsuk-u-visually-hidden">Close menu</span>
+            <label for="noJsMenuToggle" class="nhsuk-header__menu-toggle--no-js" aria-hidden="true">Close menu</label>
           </button>
         </p>
         <ul class="nhsuk-header__navigation-list">
@@ -134,6 +140,7 @@
               <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
             </svg>
             <span class="nhsuk-u-visually-hidden">Search</span>
+            <label for="noJsSearchToggle" class="nhsuk-header__search-toggle--no-js" aria-hidden="true">Toggle search</label>
           </button>
           <div class="nhsuk-header__search-wrap" id="wrap-search">
             <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
@@ -145,11 +152,12 @@
                 </svg>
                 <span class="nhsuk-u-visually-hidden">Search</span>
               </button>
-              <button class="nhsuk-search__close" id="close-search">
+              <button class="nhsuk-search__close" id="close-search" type="button">
                 <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
                   <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
                 </svg>
                 <span class="nhsuk-u-visually-hidden">Close search</span>
+                <label for="noJsSearchToggle" class="nhsuk-header__search-toggle--no-js" aria-hidden="true">Close search</label>
               </button>
             </form>
           </div>
@@ -165,7 +173,7 @@
 
       <div class="nhsuk-header__content" id="content-header">
         <div class="nhsuk-header__menu nhsuk-header__menu--only">
-          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu<label for="noJsMenuToggle" class="nhsuk-header__menu-toggle--no-js" aria-hidden="true">Toggle menu</label></button>
         </div>
       </div>
     </div>{# close nhsuk-header__container #}
@@ -178,6 +186,7 @@
               <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
             </svg>
             <span class="nhsuk-u-visually-hidden">Close menu</span>
+            <label for="noJsMenuToggle" class="nhsuk-header__menu-toggle--no-js" aria-hidden="true">Close menu</label>
           </button>
         </p>
         <ul class="nhsuk-header__navigation-list">


### PR DESCRIPTION
This commit adds toggle functionality for the menu and search header buttons
when the user has JS disabled, via input checkbox toggles.
See https://github.com/nhsuk/nhsuk-frontend/issues/721

## Description

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
