### PR TITLE
Use fallback font if not including NHS font face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- `font-family` is now being set (to the fallback font) even when not including NHS typefaces
+
 ## 6.1.0 - 12 January 2022
 
 :new: **New features**

--- a/packages/core/elements/_page.scss
+++ b/packages/core/elements/_page.scss
@@ -22,6 +22,9 @@ html {
     @include _nhsuk-font-face-frutiger;
     font-family: $nhsuk-font, $nhsuk-font-fallback;
   }
+  @else {
+    font-family: $nhsuk-font-fallback;
+  }
 }
 
 body {


### PR DESCRIPTION
## Description

There is a configuration option `$nhsuk-include-font-face` which controls if the NHS corporate font is included in the compiled CSS. In the current implementation, if this option is false then `font-face` is not set at all, which leads to unstyled text.

This change makes it so that if the fonts are not included, a `font-face` declaration is still made using only the fallback fonts (as set in `$nhsuk-font-fallback`).

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
