### PR TITLE
Add missing exclamation mark to details component browser compatibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Correctly assess whether the details component is supported on browsers
+
 ## 6.1.0 - 12 January 2022
 
 :new: **New features**

--- a/packages/components/details/details.js
+++ b/packages/components/details/details.js
@@ -8,7 +8,7 @@ import { toggleAttribute } from '../../common';
 export default () => {
   // Does the browser support details component
   const nativeSupport = typeof document.createElement('details').open === 'boolean';
-  if (nativeSupport) {
+  if (!nativeSupport) {
     return;
   }
 


### PR DESCRIPTION
## Description

This corrects an outstanding bug in the details component which was introduced [with the following commit](https://github.com/nhsuk/nhsuk-frontend/commit/b96defbac870f7de758923038454e14503462d30).

It's a straight forward change as it's an exclamation mark that is missing to negate the condition.

Currently, the bug manifests itself on pages that use details components where the components aren't attributed correctly.

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [X] CHANGELOG entry
