### PR TITLE
Add role=list to lists to fix VoiceOver not announcing as lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NHS.UK frontend Changelog
 
+## 6.1.3 - TBA
+
+:wrench: **Fixes**
+- Fix issue with VoiceOver on Safari (iOS and macOS) not announcing a list as a list. This affects some components that have a list with style `list-style-type: none`, ie those that have a class of `nhsuk-list` on the `<ul>`. This fixes the do/don't list and the error summary components. The contents list and pagination components don't seem to be affected.
+
 ## 6.1.2 - 8 August 2022
 
 :wrench: **Fixes**

--- a/packages/components/do-dont-list/template.njk
+++ b/packages/components/do-dont-list/template.njk
@@ -3,7 +3,7 @@
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <h{{ headingLevel }} class="nhsuk-do-dont-list__label">{{ params.title }}</h{{ headingLevel }}>
-  <ul class="nhsuk-list {% if params.type == 'tick' %}nhsuk-list--tick{% else %}nhsuk-list--cross{% endif %}">
+  <ul class="nhsuk-list {% if params.type == 'tick' %}nhsuk-list--tick{% else %}nhsuk-list--cross{% endif %}" role="list">
     {%- for data in params.items %}
     <li>
     {%- if params.type == 'cross' %}

--- a/packages/components/error-summary/template.njk
+++ b/packages/components/error-summary/template.njk
@@ -10,7 +10,7 @@
       {{ params.descriptionHtml | safe if params.descriptionHtml else params.descriptionText }}
     </p>
     {% endif -%}
-    <ul class="nhsuk-list nhsuk-error-summary__list">
+    <ul class="nhsuk-list nhsuk-error-summary__list" role="list">
     {%- for item in params.errorList %}
       <li>
       {%- if item.href %}


### PR DESCRIPTION
## Description
A recent accessibility audit found that when using VoiceOver on a do/don't list, that the list was not announced as a list. Further investgation found that this was a 'feature' of Safari and VoiceOver and that Apple regarded styling a list with `list-style-type: none` as an indication that the list is no longer a list as you are removing the default visible indication for a list. In our instance, we are restyling the list, so we might still expect it to be announced correctly, as it is with JAWS and NVDA. There is a good explanation of this here: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html

This issue has also been raised on govuk-frontend - [https://github.com/alphagov/govuk-frontend/issues/1471](https://github.com/alphagov/govuk-frontend/issues/1471).

The suggested solution of adding `role=list` is probably the best fix, even if it doesn't seem quite right of adding a list role to a list element, which goes against the [first rule of Using Aria](https://www.w3.org/TR/using-aria/#rule1).

However in our case I believe this is justified as it could be argued that we are removing the semantics of the list via CSS, so we need to add it back in again via the `role` atrribute. And the fact that sighted users are seeing a list and JAWS and NVDA announce the list, then it makes sense to add this fix so there is consistent behaviour with VoiceOver.  

I've also added the fix to the error summary component. Other components such as the contents list or pagination don't seem to be affected.

I've tested this fix with the following:

- VoiceOver on Safari 16, macOS Monterey 12.6
- VoiceOver on Safari on iOS 15.6.1
- NVDA 2022.3.1 on Firefox 106.0.2 and Chrome 107.0.5304.88
- JAWS 2021.2111.13 on Microsoft Edge 107.0.1418.24 and Chrome 107.0.5304.88
- Talkback (Accessibility version 13.5.01.0), Android 12, on Chome 99.0.4844.88

Where the VoiceOvers announce the list correctly, and there is no change with NVDA, JAWS or Talkback.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
