### PR TITLE
Update gov.uk character count link

### DIFF
--- a/packages/components/character-count/README.md
+++ b/packages/components/character-count/README.md
@@ -167,4 +167,4 @@ If you are using Nunjucks macros in production be aware that using `html` argume
 
 ## Thanks to the Government Digital Service (GDS)
 
-This component and documentation has been taken from [GOV.UK Frontend - Character Count component](https://github.com/alphagov/govuk-frontend/tree/main/package/govuk/govuk/components/character-count) with a few minor adaptations.
+This component and documentation has been taken from [GOV.UK Frontend - Character Count component](https://github.com/alphagov/govuk-frontend/tree/main/package/govuk/components/character-count) with a few minor adaptations.


### PR DESCRIPTION
## Description
Fix incorrect link to the gov.uk character count github repo

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
