### PR TITLE
Fix/remove current page breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # NHS.UK frontend Changelog
 
-## 8.0.0 - TBA
+## 7.0.1 - TBA
 
-:boom: **Breaking changes**
+:wrench: **Fixes**
 
 - Breadcrumb update ([PR 872](https://github.com/nhsuk/nhsuk-frontend/pull/872))
 
@@ -48,9 +48,7 @@ You will now only need this:
 
 You can now add attributes to the last breadcrumb.
 
-Note: For backwards comatibility, 'href' and 'text' parameters outside of the items list will still work and display as the last breadcrumb. This will be removed in a future release meaning breadcrumbs can only be added via the items list.
-
-:wrench: **Fixes**
+Note: For backwards comatibility, 'href' and 'text' parameters outside of the items list will still work and display as the last breadcrumb. These will be removed in a future release.
 
 - Redo fix of checkbox label being unintentionally full width of the screen due to ordering of css files ([Issue 842](https://github.com/nhsuk/nhsuk-frontend/issues/842)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ You will now only need this:
 
 You can now add attributes to the last breadcrumb.
 
+Note: For backwards comatibility, 'href' and 'text' parameters outside of the items list will still work and display as the last breadcrumb. This will be removed in a future release meaning breadcrumbs can only be added via the items list.
+
 :wrench: **Fixes**
 
 - Redo fix of checkbox label being unintentionally full width of the screen due to ordering of css files ([Issue 842](https://github.com/nhsuk/nhsuk-frontend/issues/842)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,52 @@
 # NHS.UK frontend Changelog
 
-## 7.0.1 - TBA
+## 8.0.0 - TBA
+
+:boom: **Breaking changes**
+
+- Breadcrumb update
+
+We removed the need to add the last breadcrumb outside of the 'Items' list, now simply include it in the list of items. This also fixes the issue with not being able to add attributes to the last breadcrumb. Instead of having this:
+
+```
+  {{ breadcrumb({
+    items: [
+      {
+        href: "/level-one",
+        text: "Level one"
+      },
+      {
+        href: "/level-one/level-two",
+        text: "Level two"
+      }
+    ],
+    href: "/level-one/level-two/level-three",
+    text: "Level three"
+  }) }}
+```
+
+You will now only need this:
+
+```
+  {{ breadcrumb({
+    items: [
+      {
+        href: "/level-one",
+        text: "Level one",
+      },
+      {
+        href: "/level-one/level-two",
+        text: "Level two"
+      },
+      {
+        href: "/level-one/level-two/level-three",
+        text: "Level three"
+      }
+    ]
+  }) }}
+```
+
+You can now add attributes to the last breadcrumb.
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ You will now only need this:
 
 You can now add attributes to the last breadcrumb.
 
-Note: For backwards comatibility, 'href' and 'text' parameters outside of the items list will still work and display as the last breadcrumb. These will be removed in a future release.
+Note: For backwards compatibility, 'href' and 'text' parameters outside of the items list will still work and display as the last breadcrumb. These will be removed in a future release.
 
 - Redo fix of checkbox label being unintentionally full width of the screen due to ordering of css files ([Issue 842](https://github.com/nhsuk/nhsuk-frontend/issues/842)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 :boom: **Breaking changes**
 
-- Breadcrumb update
+- Breadcrumb update ([PR 872](https://github.com/nhsuk/nhsuk-frontend/pull/872))
 
-We removed the need to add the last breadcrumb outside of the 'Items' list, now simply include it in the list of items. This also fixes the issue with not being able to add attributes to the last breadcrumb. Instead of having this:
+We removed the need to add the last breadcrumb outside of the 'Items' list, now simply include it in the list of items. This also fixes the issue ([Issue 471](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/471) in the nhsuk Service Manual) with not being able to add attributes to the last breadcrumb. Instead of having this:
 
 ```
   {{ breadcrumb({

--- a/app/components/all.njk
+++ b/app/components/all.njk
@@ -74,10 +74,12 @@
       {
         text: "Health A-Z",
         href: "https://www.nhs.uk/conditions"
+      },
+      {
+        text: "Abscess",
+        href: "https://www.nhs.uk/conditions/abscess/"
       }
-    ],
-    href: "https://www.nhs.uk/conditions/abscess/",
-    text: "Abscess"
+    ]
   }) }}
 {% endblock %}
 

--- a/app/components/breadcrumb/index.njk
+++ b/app/components/breadcrumb/index.njk
@@ -22,6 +22,8 @@
         attributes: {lang: "en"}
       }
     ],
+    href: "/level-one/level-two/level-three/level-four",
+    text: "Level four",
     classes: "example-class-one example-class-two",
     attributes: {lang: "en"}
   }) }}

--- a/app/components/breadcrumb/index.njk
+++ b/app/components/breadcrumb/index.njk
@@ -9,15 +9,20 @@
     items: [
       {
         href: "/level-one",
-        text: "Level one"
+        text: "Level one",
+        attributes: {lang: "en"}
       },
       {
         href: "/level-one/level-two",
         text: "Level two"
+      },
+      {
+        href: "/level-one/level-two/level-three",
+        text: "Level three"
       }
     ],
-    href: "/level-one/level-two/level-three",
-    text: "Level three"
+    classes: "example-class-one example-class-two",
+    attributes: {lang: "en"}
   }) }}
 
 {% endblock %}

--- a/app/components/breadcrumb/index.njk
+++ b/app/components/breadcrumb/index.njk
@@ -18,7 +18,8 @@
       },
       {
         href: "/level-one/level-two/level-three",
-        text: "Level three"
+        text: "Level three",
+        attributes: {lang: "en"}
       }
     ],
     classes: "example-class-one example-class-two",

--- a/app/pages/about.njk
+++ b/app/pages/about.njk
@@ -9,8 +9,12 @@
 
 {% block breadcrumb %}
   {{ breadcrumb({
-    href: "../",
-    text: "NHS.UK frontend"
+    items: [
+      {
+        href: "../",
+        text: "NHS.UK frontend"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -9,8 +9,12 @@
 
 {% block breadcrumb %}
   {{ breadcrumb({
-    href: "../",
-    text: "NHS.UK frontend"
+    items: [
+      {
+        href: "../",
+        text: "NHS.UK frontend"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/app/pages/install.njk
+++ b/app/pages/install.njk
@@ -9,8 +9,12 @@
 
 {% block breadcrumb %}
   {{ breadcrumb({
-    href: "../",
-    text: "NHS.UK frontend"
+    items: [
+      {
+        href: "../",
+        text: "NHS.UK frontend"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -64,6 +64,8 @@ The breadcrumb Nunjucks macro takes the following arguments:
 | items[].text       | string | Yes      | Text to use within the breadcrumbs item.                                                           |
 | items[].href       | string | Yes      | Link for the breadcrumbs item.                                                                     |
 | items[].attributes | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.      |
+| href               | string | No       | Link of the last page to appear in breadcrumb list. Avoid adding last breadcrumb this way, instead you should include your last breadcrumb in the items list.|
+| text               | string | No       | Text of the last page to appear in breadcrumb list. Avoid adding last breadcrumb this way, instead you should include your last breadcrumb in the items list.|
 | classes            | string | No       | Optional additional classes to add to the breadcrumbs container. Separate each class with a space. |
 | attributes         | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container.       |
 

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -37,15 +37,20 @@ Find out more about the breadcrumb component and when to use it in the [NHS digi
   items: [
     {
       href: "/level-one",
-      text: "Level one"
+      text: "Level one",
+      attributes: {lang: "en"}
     },
     {
       href: "/level-one/level-two",
       text: "Level two"
+    },
+    {
+      href: "/level-one/level-two/level-three",
+      text: "Level three"
     }
   ],
-  href: "/level-one/level-two/level-three",
-  text: "Level three"
+  classes: "example-class-one example-class-two",
+  attributes: {lang: "en"}
 }) }}
 ```
 
@@ -59,8 +64,6 @@ The breadcrumb Nunjucks macro takes the following arguments:
 | items[].text       | string | Yes      | Text to use within the breadcrumbs item.                                                           |
 | items[].href       | string | Yes      | Link for the breadcrumbs item.                                                                     |
 | items[].attributes | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.      |
-| href               | string | Yes      | Link of the current page                                                                           |
-| text               | string | Yes      | Text for the current page                                                                          |
 | classes            | string | No       | Optional additional classes to add to the breadcrumbs container. Separate each class with a space. |
 | attributes         | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container.       |
 

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -64,8 +64,8 @@ The breadcrumb Nunjucks macro takes the following arguments:
 | items[].text       | string | Yes      | Text to use within the breadcrumbs item.                                                           |
 | items[].href       | string | Yes      | Link for the breadcrumbs item.                                                                     |
 | items[].attributes | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.      |
-| href               | string | No       | Link of the last page to appear in breadcrumb list. Avoid adding last breadcrumb this way, instead you should include your last breadcrumb in the items list.|
-| text               | string | No       | Text of the last page to appear in breadcrumb list. Avoid adding last breadcrumb this way, instead you should include your last breadcrumb in the items list.|
+| href (DEPRECATED)  | string | No       | Link of the last breadcrumb. Include in items list instead.                                        |
+| text (DEPRECATED)  | string | No       | Text of the last breadcrumb. Include in items list instead                                         |
 | classes            | string | No       | Optional additional classes to add to the breadcrumbs container. Separate each class with a space. |
 | attributes         | object | No       | Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container.       |
 

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -7,12 +7,20 @@
           <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
     {%- endif -%}
   {% endfor %}
+    {% if params.href %}
+      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}">{{ params.text}}</a></li>
+      {% set lastHref = params.href %}
+      {% set lastText = params.text %}
+    {% else %}
+      {% set lastItem = params.items | last%}
+      {% set lastHref = lastItem.href %}
+      {% set lastText = lastItem.text %}
+    {% endif %}
     </ol>
-    {% set lastItem = params.items | last%}
     <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" href="{{ lastItem.href }}" {% for attribute, value in lastItem.attributes %}{{attribute}}="{{value}}"{% endfor %}>
+      <a class="nhsuk-breadcrumb__backlink" href="{{ lastHref }}" {% for attribute, value in lastItem.attributes %}{{attribute}}="{{value}}"{% endfor %}>
         <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
-        {{ lastItem.text }}
+        {{ lastText }}
       </a>
     </p>
   </div>

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -4,15 +4,15 @@
     <ol class="nhsuk-breadcrumb__list">
   {%- for item in params.items %}
     {%- if item.href %}
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
     {%- endif -%}
   {% endfor %}
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.text}}</a></li>
     </ol>
+    {% set lastItem = params.items | last%}
     <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" href="{{ params.href }}">
+      <a class="nhsuk-breadcrumb__backlink" href="{{ lastItem.href }}">
         <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
-        {{ params.text }}
+        {{ lastItem.text }}
       </a>
     </p>
   </div>

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -10,7 +10,7 @@
     </ol>
     {% set lastItem = params.items | last%}
     <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" href="{{ lastItem.href }}">
+      <a class="nhsuk-breadcrumb__backlink" href="{{ lastItem.href }}" {% for attribute, value in lastItem.attributes %}{{attribute}}="{{value}}"{% endfor %}>
         <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
         {{ lastItem.text }}
       </a>


### PR DESCRIPTION
## Description
Removed the need to add the last breadcrumb outside of the 'Items' list, now simply include it in the list of items. This also fixes the issue ([Issue 471](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/471) in the nhsuk Service Manual) with not being able to add attributes to the last breadcrumb.

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [X] CHANGELOG entry
