### PR TITLE
Fix search focus padding

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -194,7 +194,7 @@
     box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-color;
     outline: $nhsuk-focus-width solid transparent;
     outline-offset: $nhsuk-focus-width;
-    padding: 0 9px;
+    padding: 0 13px;
   }
   &::placeholder {
     color: $color_nhsuk-grey-1;


### PR DESCRIPTION
## Description

Currently the :focus state of .nhsuk-search__input has its' padding set in a way which displaces the placeholder and text after the element is focused for input:

![focus padding at 9px](https://github.com/nhsuk/nhsuk-frontend/assets/78462/2c88ba70-0d3c-40fc-b1ae-982ec52715fa)

I've tested this on desktop WebKit (Safari 16.6), mobile WebKit (Safari for iOS17) and Blink (Chrome 117).

This PR changes the padding on the :focus state from 9px to 13px.

![focus padding at 13px](https://github.com/nhsuk/nhsuk-frontend/assets/78462/b15a40ee-8d34-4c18-b7c7-b025681f4d3e)

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
