### PR TITLE
Updating secondary and reverse button to use correct variable rather the darken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated header component unit tests ([PR 900](https://github.com/nhsuk/nhsuk-frontend/pull/900)).
 - Fixed bug where the header didn't align with the main width container ([PR 902](https://github.com/nhsuk/nhsuk-frontend/pull/902)). This fixes [Issue 901](https://github.com/nhsuk/nhsuk-frontend/issues/901)
+- Updating secondary and reverse buttosn to use their hover variable rather than darken
 
 ## 8.0.2 - 19 October 2023
 

--- a/packages/components/button/_button.scss
+++ b/packages/components/button/_button.scss
@@ -117,7 +117,7 @@ $button-shadow-size: 4px;
   box-shadow: 0 $button-shadow-size 0 $nhsuk-secondary-button-shadow-color;
 
   &:hover {
-    background-color: darken($nhsuk-secondary-button-color, 10%);
+    background-color: $nhsuk-secondary-button-hover-color;
   }
 
   &:focus {
@@ -145,7 +145,7 @@ $button-shadow-size: 4px;
   color: $nhsuk-reverse-button-text-color;
 
   &:hover {
-    background-color: darken($nhsuk-reverse-button-color, 5%);
+    background-color: $nhsuk-reverse-button-hover-color;
     color: $nhsuk-reverse-button-text-color;
   }
 


### PR DESCRIPTION
## Description
When working on Figma Asad spotted that secondary and reverse buttons were using the SCSS darken to change their color on hover.
We already have variables defined for this state, so this PR changes the buttons to use those variables.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
