### PR TITLE
Adjust nested list spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix alignment of copyright footer
 
+- Fix spacing of nested lists
+
 ## 8.1.0 - 11 January 2024
 
 :wrench: **Fixes**

--- a/app/components/nested-lists/index.njk
+++ b/app/components/nested-lists/index.njk
@@ -1,0 +1,24 @@
+{% set html_style = 'background-color: #f0f4f5;' %}
+{% set title = 'Sitemap' %}
+{% extends 'layout.njk' %}
+
+{% block body %}
+  <div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper" id="maincontent">
+      <h1>Sitemap</h1>
+      <ul>
+        <li><a href="https://www.nhs.uk/accessibility-statement/">Accessibility</a></li>
+        <li><a href="/">Home</a></li>
+        <li>
+            <a href="https://www.nhs.uk/our-policies">Our policies</a>
+            <ul>
+            <li><a href="https://www.nhs.uk/our-policies/cookies-policy">Cookies</a></li>
+            <li><a href="https://www.nhs.uk/our-policies/terms-and-conditions">Terms and conditions</a></li>
+            <li><a href="https://www.nhs.uk/our-policies/privacy-policy">Privacy policy</a></li>
+            </ul>
+        </li>
+        <li><a href="/components/nested-lists/index.html">Sitemap</a></li>
+      </ul>
+    </main>
+  </div>
+{% endblock %} 

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -100,6 +100,7 @@
     <li><a href="../components/label/index.html">Label</a></li>
     <li><a href="../components/label/bold.html">Label with bold text</a></li>
     <li><a href="../components/label/page-heading.html">Label as page heading</a></li>
+    <li><a href="../components/nested-lists/index.html">Nested list (sitemap)</a></li>
     <li><a href="../components/pagination/index.html">Pagination</a></li>
     <li><a href="../components/radios/index.html">Radios</a></li>
     <li><a href="../components/radios/inline.html">Radios inline</a></li>

--- a/packages/core/styles/_lists.scss
+++ b/packages/core/styles/_lists.scss
@@ -33,6 +33,16 @@
   }
 }
 
+%nhsuk-list %nhsuk-list {
+  margin-bottom: 0;
+
+  &::before {
+    content: "";
+    display: block;
+    @include nhsuk-responsive-margin(2, "bottom");
+  }
+}
+
 %nhsuk-list--bullet {
   list-style-type: disc;
   padding-left: 20px; /* [1] */


### PR DESCRIPTION
## Description

Adds additional spacing at the beginning of nested lists, and removes unnecessary spacing at the end of them. Resolves #430 by a solution which is effectively https://github.com/nhsuk/nhsuk-frontend/issues/430#issuecomment-489084964. Also adds an example page, `/components/nested-lists/index.html`, to demonstrate/test that this does indeed work (I wasn't sure if this was necessary/the best way to do this but did it anyway).

Before:
![before](https://github.com/nhsuk/nhsuk-frontend/assets/50246616/b460c75f-acfd-4528-8752-6f3b4442d2d9)
After:
![after](https://github.com/nhsuk/nhsuk-frontend/assets/50246616/ab314195-0675-4720-9980-520143b35673)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry

Regarding testing: I have tested against all expected resolutions, but only in Chrome 120, Firefox 122 & Edge 121 (all on Windows); I don't have access to any of the other browsers/devices currently. I also don't currently have access to any of the assistive technology support; I'd hope that what is essentially a CSS-only change wouldn't affect accessibility. Apologies for this lack of testing.
I also tried running the backstop tests but it didn't really work (see https://github.com/nhsuk/nhsuk-frontend/pull/920#issuecomment-1929200064); all backstop tests that fail also fail on `main`