### PR TITLE
Fixx misaligned icons

### DIFF
--- a/packages/components/action-link/_action-link.scss
+++ b/packages/components/action-link/_action-link.scss
@@ -62,14 +62,14 @@
     height: 36px;
     left: -3px;
     position: absolute;
-    top: -2px;
+    margin: auto;
+    top: 0;
+    bottom: 0;
     width: 36px;
 
     @include mq($until: tablet) {
       height: 24px;
       left: -2px;
-      margin-bottom: 0;
-      top: 2px;
       width: 24px;
     }
   }

--- a/packages/components/back-link/_back-link.scss
+++ b/packages/components/back-link/_back-link.scss
@@ -28,7 +28,9 @@
     height: 24px;
     left: -8px; /* 2 */
     position: absolute;
-    top: -1px; /* 3 */
+    margin: auto; /* 3 */
+    top: 0; /* 3 */
+    bottom: 0; /* 3 */
     width: 24px;
   }
 

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -100,11 +100,14 @@
     background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__chevron-left' xmlns='http://www.w3.org/2000/svg' fill='%23005eb8' height='24' width='24' viewBox='8 0 24 24' aria-hidden='true'%3E%3Cpath d='M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z'%3E%3C/path%3E%3C/svg%3E")
       no-repeat;
     content: "";
+    background-position: left top;
     display: inline-block;
     height: 18px;
     left: 0;
     position: absolute;
-    top: 0;
+    margin: auto;
+    top: -2px;
+    bottom: 2px;
     width: 10px;
   }
 }

--- a/packages/components/checkboxes/_checkboxes.scss
+++ b/packages/components/checkboxes/_checkboxes.scss
@@ -61,7 +61,9 @@ $nhsuk-checkboxes-label-padding-left-right: 12px;
   height: $nhsuk-checkboxes-size;
   left: 0;
   position: absolute;
+  margin: auto;
   top: 0;
+  bottom: 0;
   width: $nhsuk-checkboxes-size;
 }
 
@@ -75,7 +77,9 @@ $nhsuk-checkboxes-label-padding-left-right: 12px;
   left: 10px;
   opacity: 0; /* 2 */
   position: absolute;
-  top: 13px;
+  margin: auto;
+  top: -4px;
+  bottom: 0;
   -ms-transform: rotate(-45deg);
   -webkit-transform: rotate(-45deg);
   transform: rotate(-45deg);

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -437,6 +437,11 @@
 }
 
 .nhsuk-icon__chevron-down {
+  margin: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+
   .nhsuk-header__menu-toggle[aria-expanded="true"] & {
     transform: rotate(270deg);
   }

--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -59,7 +59,7 @@
 
   .nhsuk-icon {
     position: absolute;
-    top: calc(1.25em * 0.8px - 20px); /* [3] */
+    top: calc((1.25em / 10px) * 8px - 20px); /* [3] */
 
     @include mq($media-type: print) {
       color: $color_nhsuk-black;

--- a/packages/components/pagination/_pagination.scss
+++ b/packages/components/pagination/_pagination.scss
@@ -7,6 +7,7 @@
  * 2. Append the word 'page' after next and
  *    previous on print stylesheets to make it easier
  *    to understand in print context.
+ * 3. Vertically align the icon with the text.
  */
 
 .nhsuk-pagination {
@@ -58,11 +59,10 @@
 
   .nhsuk-icon {
     position: absolute;
-    top: -2px;
+    top: calc(1.25em * 0.8px - 20px); /* [3] */
 
     @include mq($media-type: print) {
       color: $color_nhsuk-black;
-      margin-top: 0;
     }
   }
 

--- a/packages/components/radios/_radios.scss
+++ b/packages/components/radios/_radios.scss
@@ -65,7 +65,9 @@ $nhsuk-radios-focus-width: $nhsuk-focus-width + 1px;
   height: $nhsuk-radios-size;
   left: 0;
   position: absolute;
+  margin: auto;
   top: 0;
+  bottom: 0;
   width: $nhsuk-radios-size;
 }
 
@@ -78,7 +80,9 @@ $nhsuk-radios-focus-width: $nhsuk-focus-width + 1px;
   left: 10px;
   opacity: 0;
   position: absolute;
-  top: 10px;
+  margin: auto;
+  top: 0;
+  bottom: 0;
   width: 0;
 }
 


### PR DESCRIPTION
## Description
Resolves #662 + some additional related bugs
- Vertically align back link icon with text at large font sizes
- Vertically align back breadcrumb icon with text at large font sizes
- Vertically align action link icon with text at large font sizes
- Vertically align pagination icon with text at large font sizes - this uses a regression that I determined experimentally and manually
- Vertically align header 'more' icon with text at large font sizes
- Vertically align radio button with text at large font sizes
- Vertically algin checkbox buttons with text at large font sizes

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry

So far only tested on chrome 120 on windows.