### PR TITLE
Prevent vertical text overflow in inputs

### DIFF
--- a/packages/components/input/_input.scss
+++ b/packages/components/input/_input.scss
@@ -18,7 +18,6 @@
   border: $nhsuk-border-width-form-element solid $nhsuk-form-border-color; /* 2 */
   border-radius: 0;
   box-sizing: border-box;
-  height: 40px;
   margin-top: 0;
   padding: nhsuk-spacing(1);
   width: 100%;
@@ -95,7 +94,6 @@
   cursor: default; // emphasises non-editable status of prefixes and suffixes
   display: inline-block;
   flex: 0 0 auto;
-  height: 40px;
   min-width: nhsuk-px-to-rem(40px);
   padding: nhsuk-spacing(1);
   text-align: center;

--- a/packages/components/select/_select.scss
+++ b/packages/components/select/_select.scss
@@ -7,7 +7,6 @@
 
   border: $nhsuk-border-width-form-element solid $nhsuk-form-border-color;
   box-sizing: border-box;
-  height: 40px;
   max-width: 100%;
   padding: nhsuk-spacing(1);
 


### PR DESCRIPTION
## Description
Fixes #921
Prevents text from vertically overflowing/being cut off from inputs at large font sizes, by not restricting input heights to 40px and instead letting them scale to the font size.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry

Only tested on chrome 120 on windows so far.