### PR TITLE
fix low contrast of placeholder text in firefox

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -193,6 +193,7 @@
   &::placeholder {
     color: $color_nhsuk-grey-1;
     font-size: $nhsuk-base-font-size;
+    opacity: 1; // fixes low contrast of placeholder text in firefox
   }
   &:-ms-input-placeholder {
     color: $color_nhsuk-grey-1;


### PR DESCRIPTION
## Description
Fixes an issue raised in a recent accessibility audit.

Dig report: https://alpha.hugr.app/view/7e2117#DIG602
Dig reported that the search bar placeholder text is low contrast.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
