### PR TITLE
Removes unused scss classes from breadcrumbs

### DIFF
--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -18,26 +18,6 @@
   padding-bottom: nhsuk-spacing(3);
   padding-top: 20px; /* [2] */
 
-  .nhsuk-icon__chevron-right {
-    fill: $color_nhsuk-grey-3;
-    height: 18px;
-    position: relative;
-    top: 5px;
-    width: 18px;
-
-    @include mq($from: large-desktop) {
-      margin: 0 3px 0 5px;
-    }
-  }
-
-  .nhsuk-icon__chevron-left {
-    float: left;
-    height: 24px;
-    left: -8px;
-    position: relative;
-    width: 24px;
-  }
-
   + .nhsuk-width-container .nhsuk-main-wrapper {
     padding-top: 0;
   }


### PR DESCRIPTION
## Description
Removes `nhsuk-icon__chevron-right` and `nhsuk-icon__chevron-left` classes, as they seem to be unused by the breadcrumbs component, which uses a `:before` and `:after` class, which styles the chevrons. 

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
