### PR TITLE
Announce whitespace in screen reader announcements of visually hidden text

### DIFF
--- a/packages/components/tables/_tables.scss
+++ b/packages/components/tables/_tables.scss
@@ -99,6 +99,11 @@
 
     @include mq($from: desktop) {
       @include visually-shown(table-header-group); /* [2] */
+
+      &:before,
+      &:after {
+        content: "";
+      }
     }
   }
 

--- a/packages/core/tools/_mixins.scss
+++ b/packages/core/tools/_mixins.scss
@@ -38,6 +38,18 @@
 //
 
 @mixin visually-hidden() {
+  // Absolute positioning has the unintended consequence of removing any
+  // whitespace surrounding visually hidden text from the accessibility tree.
+  // Insert a space character before and after visually hidden text to separate
+  // it from any visible text surrounding it.
+  &::before {
+    content: "\00a0";
+  }
+
+  &::after {
+    content: "\00a0";
+  }
+
   border: 0;
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(50%);


### PR DESCRIPTION
This fixes a bug in the nhsuk-u-visually-hidden helper class where any whitespace surrounding visually hidden text isn't announced by screen readers.

This fix was added to `govuk-frontend` in [pull request #3868](https://github.com/alphagov/govuk-frontend/pull/3836) and released in [v4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) and has been re-applied here.

Thanks to @hannalaakso for the work upstream. 🙌 

I’ve also followed the approach of the GOV.UK Design System team of adding a Typography page with examples of using visually-hidden text, to make testing easier.