### PR TITLE
Let page width be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+:new: **New features**
+
+- Make nhsuk-page-width a default so that services can override it ([PR 971](https://github.com/nhsuk/nhsuk-frontend/pull/971))
+
 ## 8.2.0 - 12 June 2024
 
 :recycle: **Changes**

--- a/packages/core/settings/_globals.scss
+++ b/packages/core/settings/_globals.scss
@@ -34,7 +34,7 @@ $nhsuk-icon-size: 34px !default;
 // Grid spacing
 //
 
-$nhsuk-page-width: 960px;
+$nhsuk-page-width: 960px !default;
 $nhsuk-gutter: 32px;
 $nhsuk-gutter-half: $nhsuk-gutter * 0.5;
 


### PR DESCRIPTION
## Description
Updates `$nhsuk-page-width` to be a SASS default, which would let teams override it. Nearly every other item in `globals.scss` can be overridden already. This works the same way as GOV.UK for setting page width.

## Checklist
- [x] CHANGELOG entry
