### PR TITLE
Draft: Move breadcrumb inside nhs-width-container

### DIFF
--- a/app/_templates/page.njk
+++ b/app/_templates/page.njk
@@ -48,9 +48,8 @@
 
 {% block body %}
 
-  {% block breadcrumb %}{% endblock %}
-
   <div class="nhsuk-width-container">
+    {% block outerContent %}{% endblock %}
     <main class="nhsuk-main-wrapper" id="maincontent">
 
       <div class="nhsuk-grid-row">

--- a/app/components/all.njk
+++ b/app/components/all.njk
@@ -64,7 +64,7 @@
   }}
 {% endblock %}
 
-{% block breadcrumb %}
+{% block outerContent %}
   {{ breadcrumb({
     items: [
       {

--- a/app/pages/about.njk
+++ b/app/pages/about.njk
@@ -7,7 +7,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block breadcrumb %}
+{% block outerContent %}
   {{ breadcrumb({
     items: [
       {

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -7,7 +7,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block breadcrumb %}
+{% block outerContent %}
   {{ breadcrumb({
     items: [
       {

--- a/app/pages/install.njk
+++ b/app/pages/install.njk
@@ -7,7 +7,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block breadcrumb %}
+{% block outerContent %}
   {{ breadcrumb({
     items: [
       {

--- a/app/styles/lists.njk
+++ b/app/styles/lists.njk
@@ -6,7 +6,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block breadcrumb %}
+{% block outerContent %}
   {{ breadcrumb({
     items: [
       {

--- a/packages/components/breadcrumb/_breadcrumb.scss
+++ b/packages/components/breadcrumb/_breadcrumb.scss
@@ -4,8 +4,6 @@
 
 /**
  * 1. Hide the breadcrumb on print stylesheets.
- * 2. Bespoke spacing numbers used as there is no 20px
- *    spacing mapped in settings/spacing.
  * 3. Don't show the full breadcrumb below tablet size.
  * 4. Typography sizing mixin, see core/tools/_typography
  * 5. and core/settings/_typography for size maps.
@@ -15,12 +13,8 @@
 .nhsuk-breadcrumb {
   @include print-hide(); /* [1] */
 
-  padding-bottom: nhsuk-spacing(3);
-  padding-top: 20px; /* [2] */
-
-  + .nhsuk-width-container .nhsuk-main-wrapper {
-    padding-top: 0;
-  }
+  margin-top: nhsuk-spacing(4);
+  margin-bottom: nhsuk-spacing(2);
 }
 
 .nhsuk-breadcrumb__list {

--- a/packages/components/breadcrumb/template.njk
+++ b/packages/components/breadcrumb/template.njk
@@ -1,27 +1,25 @@
 <nav class="nhsuk-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}" aria-label="Breadcrumb"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <div class="nhsuk-width-container">
-    <ol class="nhsuk-breadcrumb__list">
-  {%- for item in params.items %}
-    {%- if item.href %}
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
-    {%- endif -%}
-  {% endfor %}
-    {% if params.href %}
-      <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}">{{ params.text}}</a></li>
-      {% set lastHref = params.href %}
-      {% set lastText = params.text %}
-    {% else %}
-      {% set lastItem = params.items | last%}
-      {% set lastHref = lastItem.href %}
-      {% set lastText = lastItem.text %}
-    {% endif %}
-    </ol>
-    <p class="nhsuk-breadcrumb__back">
-      <a class="nhsuk-breadcrumb__backlink" href="{{ lastHref }}" {% for attribute, value in lastItem.attributes %}{{attribute}}="{{value}}"{% endfor %}>
-        <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
-        {{ lastText }}
-      </a>
-    </p>
-  </div>
+  <ol class="nhsuk-breadcrumb__list">
+{%- for item in params.items %}
+  {%- if item.href %}
+        <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>{% if not loop.last %}{% endif %}</li>
+  {%- endif -%}
+{% endfor %}
+  {% if params.href %}
+    <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="{{ params.href }}">{{ params.text}}</a></li>
+    {% set lastHref = params.href %}
+    {% set lastText = params.text %}
+  {% else %}
+    {% set lastItem = params.items | last%}
+    {% set lastHref = lastItem.href %}
+    {% set lastText = lastItem.text %}
+  {% endif %}
+  </ol>
+  <p class="nhsuk-breadcrumb__back">
+    <a class="nhsuk-breadcrumb__backlink" href="{{ lastHref }}" {% for attribute, value in lastItem.attributes %}{{attribute}}="{{value}}"{% endfor %}>
+      <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
+      {{ lastText }}
+    </a>
+  </p>
 </nav>


### PR DESCRIPTION
This is a quick proof-of-concept showing how the Breadcrumb component might move inside the `<div class="nhs-width-container">` to avoid having to define its own, and for consistency with the Back component.

This would be a breaking change as the HTML is different, and teams would have to update where the breadcrumb appears.

I've also switched the padding to be margin, for consistency with the Back link. The actual spacing values we use are tbc.

I've also added the `outerContent` block to the template used by the test app in the repo.

See [Review back link and breadcrumb spacing and positioning ](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/526)
