### PR TITLE
Use lowercase html param in Inset text example

### DIFF
--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -249,7 +249,7 @@ Example:
 
 ```
 {{ insetText({
-  "HTML": "<p>If you drive you must tell the <a href='https://www.gov.uk/contact-the-dvla/' title='External website'>DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href='https://www.gov.uk/dizziness-and-driving' title='External website'>driving with vertigo</a></p>"
+  "html": "<p>If you drive you must tell the <a href='https://www.gov.uk/contact-the-dvla/' title='External website'>DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href='https://www.gov.uk/dizziness-and-driving' title='External website'>driving with vertigo</a></p>"
 }) }}
 ```
 


### PR DESCRIPTION
The inset text component was updated to support a lowercase `html` param in https://github.com/nhsuk/nhsuk-frontend/pull/951

Thanks @paulrobertlloyd for spotting. 👀 