### PR TITLE
Removing pattern from date input to follow govuk-frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Change "Contact us" in the footer link examples to "Give us feedback" ([PR 972](https://github.com/nhsuk/nhsuk-frontend/pull/972))
+- Remove the pattern from the date input component
 
 :new: **New features**
 

--- a/packages/components/date-input/template.njk
+++ b/packages/components/date-input/template.njk
@@ -67,7 +67,7 @@
         value: item.value,
         inputmode: item.inputmode if item.inputmode else "numeric",
         autocomplete: item.autocomplete,
-        pattern: item.pattern if item.pattern else "[0-9]*",
+        pattern: item.pattern,
         attributes: item.attributes
       }) | indent(6) | trim }}
     </div>


### PR DESCRIPTION
## Description
Remove pattern attribute from date input component
This matches the update govuk-frontend has done

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
