### PR TITLE
Update height and set minimum width of Selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Change "Contact us" in the footer link examples to "Give us feedback" ([PR 972](https://github.com/nhsuk/nhsuk-frontend/pull/972))
 - Remove the pattern from the date input component
+- Fix height of select component in Safari ([PR 987](https://github.com/nhsuk/nhsuk-frontend/pull/987))
+- Set minimum width of select component ([PR 987](https://github.com/nhsuk/nhsuk-frontend/pull/987))
 
 :new: **New features**
 

--- a/packages/components/select/_select.scss
+++ b/packages/components/select/_select.scss
@@ -8,6 +8,11 @@
   border: $nhsuk-border-width-form-element solid $nhsuk-form-border-color;
   box-sizing: border-box;
   height: 40px;
+  // This min-width was chosen because:
+  // - it makes the Select wider than it is tall (which is what users expect)
+  // - 20ex + 3ex matches the 'width-10' variant of the input component
+  // - it fits comfortably on screens as narrow as 240px wide
+  min-width: 20ex + 3ex;
   max-width: 100%;
   padding: nhsuk-spacing(1);
 

--- a/packages/components/select/_select.scss
+++ b/packages/components/select/_select.scss
@@ -2,17 +2,22 @@
    COMPONENTS/ #SELECT
    ========================================================================== */
 
+/**
+ * Select input sizing
+ * 1. Uses rems so that safari input scales with font size
+ * 2. This min-width was chosen because:
+ *    - it makes the Select wider than it is tall (which is what users expect)
+ *    - 20ex + 3ex matches the 'width-10' variant of the input component
+ *    - it fits comfortably on screens as narrow as 240px wide
+ */
+
 .nhsuk-select {
   @include nhsuk-font(19);
 
   border: $nhsuk-border-width-form-element solid $nhsuk-form-border-color;
   box-sizing: border-box;
-  height: 40px;
-  // This min-width was chosen because:
-  // - it makes the Select wider than it is tall (which is what users expect)
-  // - 20ex + 3ex matches the 'width-10' variant of the input component
-  // - it fits comfortably on screens as narrow as 240px wide
-  min-width: 20ex + 3ex;
+  height: 2.5rem; /* [1] */
+  min-width: 20ex + 3ex; /* [2] */
   max-width: 100%;
   padding: nhsuk-spacing(1);
 

--- a/packages/components/select/_select.scss
+++ b/packages/components/select/_select.scss
@@ -7,7 +7,7 @@
 
   border: $nhsuk-border-width-form-element solid $nhsuk-form-border-color;
   box-sizing: border-box;
-  min-height: 40px;
+  height: 40px;
   max-width: 100%;
   padding: nhsuk-spacing(1);
 


### PR DESCRIPTION
This fixes a minor bug with the select component in Safari, which is that the `min-height` property is ignored when the default native appearance is used, resulting in a select which is only 30px high. (Other browsers such as Chrome and Firefox seem to apply the minimum height.)

This restores the select to its previous fixed height of 40px. As the select will never wrap onto 2 or more lines (instead the text gets truncated), having a fixed height should be fine.

Additionally, this also introduces a minimum width to the select component (this property does work in all browsers), in case the options in the select are very short. In these cases, having a wider select means for a bigger target area, and is closer to what users expect. I’ve followed the GOV.UK Design System in setting the minimum width to match the `width-10` variant of the input component, which works out as 223px (see [their definition of this](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/components/select/_index.scss#L11C5-L15C23)).

## Screenshots (Safari)

| Before | After |
|--------|-------|
| <img width="377" alt="Screenshot 2024-07-18 at 08 55 11" src="https://github.com/user-attachments/assets/e460bd67-6dc3-429b-b561-d96099b12f50"> | <img width="386" alt="Screenshot 2024-07-18 at 08 55 28" src="https://github.com/user-attachments/assets/7c7e6f59-8358-4484-841c-b30f094595e0"> |
 | <img width="382" alt="Screenshot 2024-07-18 at 09 00 03" src="https://github.com/user-attachments/assets/cc024d4d-5f39-496b-ac0b-07678fd56ad5"> | <img width="342" alt="Screenshot 2024-07-18 at 08 59 47" src="https://github.com/user-attachments/assets/92aabb24-7c0b-45a1-a272-319e49f2b4e4"> |

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
