### PR TITLE
Add 36 to type scale and swap headings to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Change "Contact us" in the footer link examples to "Give us feedback" ([PR 972](https://github.com/nhsuk/nhsuk-frontend/pull/972))
 - Remove the pattern from the date input component
+- Large headings, legends and labels updated to use 36px rather than 32px. ([PR 989](https://github.com/nhsuk/nhsuk-frontend/pull/989))
 
 :new: **New features**
 

--- a/packages/components/fieldset/_fieldset.scss
+++ b/packages/components/fieldset/_fieldset.scss
@@ -40,7 +40,7 @@
 }
 
 .nhsuk-fieldset__legend--l {
-  @include nhsuk-font($size: 32, $weight: bold);
+  @include nhsuk-font($size: 36, $weight: bold);
   margin-bottom: nhsuk-spacing(3);
 }
 

--- a/packages/components/label/_label.scss
+++ b/packages/components/label/_label.scss
@@ -23,7 +23,7 @@
 }
 
 .nhsuk-label--l {
-  @include nhsuk-typography-responsive(32);
+  @include nhsuk-typography-responsive(36);
 }
 
 .nhsuk-label--m {

--- a/packages/core/settings/_typography.scss
+++ b/packages/core/settings/_typography.scss
@@ -57,6 +57,21 @@ $nhsuk-typography-scale: (
       line-height: 1.15
     )
   ),
+  36: (
+    null: (
+      font-size: 27px,
+      line-height: 32px
+    ),
+    tablet: (
+      font-size: 36px,
+      line-height: 40px
+    ),
+    print: (
+      font-size: 27pt,
+      line-height: 1.05
+    )
+  ),
+  // 32 is deprecated and will be removed in next major version
   32: (
     null: (
       font-size: 24px,

--- a/packages/core/settings/_typography.scss
+++ b/packages/core/settings/_typography.scss
@@ -72,20 +72,21 @@ $nhsuk-typography-scale: (
     )
   ),
   // 32 is deprecated and will be removed in next major version
-  32: (
-    null: (
-      font-size: 24px,
-      line-height: 32px
+  32:
+    (
+      null: (
+        font-size: 24px,
+        line-height: 32px
+      ),
+      tablet: (
+        font-size: 32px,
+        line-height: 40px
+      ),
+      print: (
+        font-size: 24pt,
+        line-height: 1.05
+      )
     ),
-    tablet: (
-      font-size: 32px,
-      line-height: 40px
-    ),
-    print: (
-      font-size: 24pt,
-      line-height: 1.05
-    )
-  ),
   24: (
     null: (
       font-size: 20px,

--- a/packages/core/styles/_typography.scss
+++ b/packages/core/styles/_typography.scss
@@ -28,7 +28,7 @@ h1,
 }
 
 %nhsuk-heading-l {
-  @include nhsuk-typography-responsive(32);
+  @include nhsuk-typography-responsive(36);
 
   display: block;
   font-weight: $nhsuk-font-bold;
@@ -105,7 +105,7 @@ h6,
 /* Captions to be used inside headings */
 
 .nhsuk-caption-xl {
-  @include nhsuk-font(32);
+  @include nhsuk-font(36);
 
   color: $nhsuk-secondary-text-color;
   display: block;

--- a/packages/core/tools/_typography.scss
+++ b/packages/core/tools/_typography.scss
@@ -106,7 +106,7 @@
 //   }
 //
 //  .foo {
-//    @include nhsuk-typography-responsive(32, $important: true);
+//    @include nhsuk-typography-responsive(36, $important: true);
 //   }
 //
 // @param {Map} $font-map - Font map
@@ -121,6 +121,7 @@
 //
 
 @mixin nhsuk-typography-responsive($size, $override-line-height: false, $important: false) {
+
   @if not map-has-key($nhsuk-typography-scale, $size) {
     @error "Unknown font size `#{$size}` - expected a point from the typography scale.";
   }
@@ -170,7 +171,7 @@
 //   }
 //
 //  .foo {
-//    @include nhsuk-font(32, $weight: bold);
+//    @include nhsuk-font(36, $weight: bold);
 //   }
 //
 // @param {Number} $size - Size of the font as it would appear on desktop -


### PR DESCRIPTION
## Description
In our typography scale, the large size seems smaller than necessary. On GOV.UK it's 36px, whereas in NHS it's 32px. Once our heading guidance is updated, we may see more headings using the large size, so I am proposing updating our type scale to use 36px rather than 32px.

The GOV.UK scale goes:
- Desktop: 24px > 36px > 48px
- Mobile: 21px > 27px > 32px

NHS:
- Desktop: 24px > 32px > 48px
- Mobile: 20px > 24px > 32px

To swap the size would likely be a breaking change - users may be relying on the `.nhsuk-u-font-size-32` classes or passing 32 to the font mixins.

I am proposing adding 36 to the scale and updating the heading mixins to use it, and leave 32 for now. We can then remove 32 from the scale at the next major version.

| Mobile before | Mobile after |
|----------|----------|
|![heading-l-mobile-24px](https://github.com/user-attachments/assets/ebeee723-a19d-4605-b044-116e6e542999)   | ![heading-l-mobile-27px](https://github.com/user-attachments/assets/f96de714-f873-4698-857a-57c1c2020123)   |

| Desktop before | Desktop after |
|----------|----------|
|![heading-l-desktop-32px](https://github.com/user-attachments/assets/919268df-f1e7-4386-9645-f47135bb287b)| ![heading-l-desktop-36px](https://github.com/user-attachments/assets/327fdaf5-349a-4317-9a0b-d7a0993090bb)   |

| Scale mobile | Scale desktop |
|----------|----------|
| ![heading-scale-mobile](https://github.com/user-attachments/assets/7b11005f-98ef-43df-8859-7f2877df0006)|![heading-scale-desktop](https://github.com/user-attachments/assets/dddf69df-131f-466f-999d-6cc28f39805c) |

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
