### PR TITLE
Fix Sass deprecation on `mix` function (passing a number without unit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+- Fix Sass deprecation on `mix` function (passing a number without unit) ([PR 995](https://github.com/nhsuk/nhsuk-frontend/pull/995))
+
 ## 8.3.0 - 24 July 2024
 
 :new: **New features**

--- a/packages/core/settings/_colours.scss
+++ b/packages/core/settings/_colours.scss
@@ -65,11 +65,11 @@ $alpha-transparency-50: 0.5;
 //
 
 @function tint($color, $percentage) {
-  @return mix(white, $color, $percentage * 1%);
+  @return mix(white, $color, $percentage);
 }
 
 @function shade($color, $percentage) {
-  @return mix(black, $color, $percentage * 1%);
+  @return mix(black, $color, $percentage);
 }
 
 //


### PR DESCRIPTION
## Description

SASS is showing the following deprecation warning. Example:

```
Deprecation Warning: $weight: Passing a number without unit % (50%*%) is deprecated.

To preserve current behavior: calc($weight / 1% / 1% * 1%)

More info: https://sass-lang.com/d/function-units

   ╷
72 │   @return mix(black, $color, $percentage * 1%);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    packages/core/settings/_colours.scss 72:11  shade()
    packages/core/settings/_colours.scss 90:29  @import
    packages/core/settings/_all.scss 6:9        @import
    packages/core/all.scss 6:9                  @import
    packages/nhsuk.scss 2:9                     root stylesheet
```

As we are always passing a percentage to the `tint` and `shade` functions, we don’t need to multiple the incoming value by 1%. This resolves this warning.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
