### PR TITLE
Simplify template logic for header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 :wrench: **Fixes**
 
+- Remove the boolean `showNav`, `showSearch` and `transactional` options from the header component. Respective parts of the header are now shown if values for `primaryLinks`, `search` or `transactionalService` options are provided. Additionally, the `searchAction` option is renamed `search.action` and the `searchInputName` option is renamed `search.name`. Finally, the label, button and placeholder text for the search input can be updated using the new `search.visuallyHiddenLabel`, `search.visuallyHiddenButton` and `search.placeholder` options. ([PR 996](https://github.com/nhsuk/nhsuk-frontend/pull/996))
 - Update header styles so that `.nhsuk-header__search-no-nav` class is no longer needed when header contains a search field but no navigation ([PR 1046](https://github.com/nhsuk/nhsuk-frontend/pull/1046))
 - Update navigation list item padding to vertically align navigation items with width container ([PR 1033](https://github.com/nhsuk/nhsuk-frontend/pull/1033))
 

--- a/app/_templates/page.njk
+++ b/app/_templates/page.njk
@@ -38,11 +38,8 @@
   }) }}
 
   {{ header({
-    "showNav": "false",
-    "showSearch": "false",
     "homeHref": baseUrl
-    })
-  }}
+  }) }}
 {% endblock %}
 
 

--- a/app/components/all.njk
+++ b/app/components/all.njk
@@ -36,8 +36,7 @@
   }) }}
 
   {{ header({
-      "showNav": "true",
-      "showSearch": "true",
+      "search": true,
       "primaryLinks": [
         {
           "url"  : "https://www.nhs.uk/conditions",

--- a/app/components/header/header-logo.njk
+++ b/app/components/header/header-logo.njk
@@ -5,10 +5,6 @@
 
 {% block body %}
 
-  {{ header({
-      "showNav": "false",
-      "showSearch": "false"
-    })
-  }}
+  {{ header() }}
 
 {% endblock %}

--- a/app/components/header/header-navigation.njk
+++ b/app/components/header/header-navigation.njk
@@ -6,8 +6,6 @@
 {% block body %}
 
   {{ header({
-      "showNav": "true",
-      "showSearch": "false",
       "primaryLinks": [
         {
           "url"  : "https://www.nhs.uk/conditions",

--- a/app/components/header/header-org-white-nav.njk
+++ b/app/components/header/header-org-white-nav.njk
@@ -6,8 +6,6 @@
 {% block body %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
     "classes": "nhsuk-header--white nhsuk-header--white-nav",
     "organisation": {
       "name": "Anytown Anyplace",
@@ -35,7 +33,10 @@
         'url' : '#',
         'label' : 'Our research'
       }
-    ]
+    ],
+    "search": {
+      "visuallyHiddenLabel": "Search the Anytown Anyplace Anywhere website"
+    }
   })
 }}
 

--- a/app/components/header/header-org-white.njk
+++ b/app/components/header/header-org-white.njk
@@ -6,8 +6,6 @@
 {% block body %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
     "classes": "nhsuk-header--white",
     "organisation": {
       "name": "Anytown Anyplace",
@@ -35,7 +33,10 @@
         'url' : '#',
         'label' : 'Our research'
       }
-    ]
+    ],
+    "search": {
+      "visuallyHiddenLabel": "Search the Anytown Anyplace Anywhere website"
+    }
   })
 }}
 

--- a/app/components/header/header-org.njk
+++ b/app/components/header/header-org.njk
@@ -6,8 +6,6 @@
 {% block body %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
     "organisation": {
       "name": "Anytown Anyplace",
       "split": "Anywhere",
@@ -34,7 +32,10 @@
         'url' : '#',
         'label' : 'Our research'
       }
-    ]
+    ],
+    "search": {
+      "visuallyHiddenLabel": "Search the Anytown Anyplace Anywhere website"
+    }
   })
 }}
 

--- a/app/components/header/header-search.njk
+++ b/app/components/header/header-search.njk
@@ -6,35 +6,7 @@
 {% block body %}
 
   {{ header({
-      "showNav": "false",
-      "showSearch": "true",
-      "primaryLinks": [
-        {
-          "url"  : "https://www.nhs.uk/conditions",
-          "label" : "Health A-Z"
-        },
-        {
-          'url' : 'https://www.nhs.uk/live-well/',
-          'label' : 'Live Well'
-        },
-        {
-          'url' : 'https://www.nhs.uk/mental-health/',
-          'label' : 'Mental health'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/conditions/social-care-and-support/',
-          'label' : 'Care and support'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/pregnancy/',
-          'label' : 'Pregnancy'
-        },
-        {
-          'url' : 'https://www.nhs.uk/nhs-services/',
-          'label' : 'NHS services'
-        }
-      ]
-    })
-  }}
+    "search": true
+  }) }}
 
 {% endblock %}

--- a/app/components/header/header-service-name-with-nav.njk
+++ b/app/components/header/header-service-name-with-nav.njk
@@ -9,8 +9,9 @@
     "service": {
       "name": "Digital service manual"
     },
-    "showNav": "true",
-    "showSearch": "true",
+    "search": {
+      "visuallyHiddenLabel": "Search the NHS digital service manual"
+    },
     "primaryLinks": [
         {
           "url"  : "#",

--- a/app/components/header/header-service-name.njk
+++ b/app/components/header/header-service-name.njk
@@ -6,10 +6,9 @@
 {% block body %}
 
   {{ header({
-      "service": {
-        "name": "Prototype kit"
-      }
-    })
-  }}
+    "service": {
+      "name": "Prototype kit"
+    }
+  }) }}
 
 {% endblock %}

--- a/app/components/header/header-transactional-service-name.njk
+++ b/app/components/header/header-transactional-service-name.njk
@@ -6,12 +6,9 @@
 {% block body %}
 
   {{ header({
-      "transactionalService": {
-        "name": "Find your NHS number"
-      },
-      "showNav": "false",
-      "showSearch": "false"
-    })
-  }}
+    "transactionalService": {
+      "name": "Find your NHS number"
+    }
+  }) }}
 
 {% endblock %}

--- a/app/components/header/index.njk
+++ b/app/components/header/index.njk
@@ -6,35 +6,33 @@
 {% block body %}
 
   {{ header({
-      "showNav": "true",
-      "showSearch": "true",
-      "primaryLinks": [
-        {
-          "url"  : "https://www.nhs.uk/conditions",
-          "label" : "Health A-Z"
-        },
-        {
-          'url' : 'https://www.nhs.uk/live-well/',
-          'label' : 'Live Well'
-        },
-        {
-          'url' : 'https://www.nhs.uk/mental-health/',
-          'label' : 'Mental health'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/conditions/social-care-and-support/',
-          'label' : 'Care and support'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/pregnancy/',
-          'label' : 'Pregnancy'
-        },
-        {
-          'url' : 'https://www.nhs.uk/nhs-services/',
-          'label' : 'NHS services'
-        }
-      ]
-    })
-  }}
+    "search": true,
+    "primaryLinks": [
+      {
+        "url"  : "https://www.nhs.uk/conditions",
+        "label" : "Health A-Z"
+      },
+      {
+        'url' : 'https://www.nhs.uk/live-well/',
+        'label' : 'Live Well'
+      },
+      {
+        'url' : 'https://www.nhs.uk/mental-health/',
+        'label' : 'Mental health'
+      },
+      {
+        'url'  : 'https://www.nhs.uk/conditions/social-care-and-support/',
+        'label' : 'Care and support'
+      },
+      {
+        'url'  : 'https://www.nhs.uk/pregnancy/',
+        'label' : 'Pregnancy'
+      },
+      {
+        'url' : 'https://www.nhs.uk/nhs-services/',
+        'label' : 'NHS services'
+      }
+    ]
+  }) }}
 
 {% endblock %}

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -108,8 +108,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
+    "search": true,
     "primaryLinks": [
       {
         "url"  : "https://www.nhs.uk/conditions",
@@ -221,8 +220,6 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-      "showNav": "true",
-      "showSearch": "false",
       "primaryLinks": [
         {
           "url"  : "https://www.nhs.uk/conditions",
@@ -291,36 +288,8 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "false",
-    "showSearch": "true",
-    "primaryLinks": [
-        {
-          "url"  : "https://www.nhs.uk/conditions",
-          "label" : "Health A-Z"
-        },
-        {
-          'url' : 'https://www.nhs.uk/live-well/',
-          'label' : 'Live Well'
-        },
-        {
-          'url' : 'https://www.nhs.uk/mental-health/',
-          'label' : 'Mental health'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/conditions/social-care-and-support/',
-          'label' : 'Care and support'
-        },
-        {
-          'url'  : 'https://www.nhs.uk/pregnancy/',
-          'label' : 'Pregnancy'
-        },
-        {
-          'url' : 'https://www.nhs.uk/nhs-services/',
-          'label' : 'NHS services'
-        }
-      ]
-  })
-}}
+  "search": true
+}) }}
 ```
 
 ### Header with logo
@@ -346,11 +315,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 ```
 {% from 'components/header/macro.njk' import header %}
 
-{{ header({
-  "showNav": "false",
-  "showSearch": "false"
-  })
-}}
+{{ header() }}
 ```
 
 ---
@@ -383,13 +348,10 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 {{ header({
   "transactionalService": {
-      "name": "Find your NHS number",
-      "href": "https://www.nhs.uk/nhs-services/online-services/find-nhs-number/"
-    },
-    "showNav": "false",
-    "showSearch": "false"
-  })
-}}
+    "name": "Find your NHS number",
+    "href": "https://www.nhs.uk/nhs-services/online-services/find-nhs-number/"
+  }
+}) }}
 ```
 
 ### Header organisational
@@ -483,8 +445,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
+    "search": true,
     "organisation": {
       "name": "Anytown Anyplace",
       "split": "Anywhere",
@@ -607,8 +568,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
+    "search": true,
     "classes": "nhsuk-header--white",
     "organisation": {
       "name": "Anytown Anyplace",
@@ -732,8 +692,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
+    "search": true,
     "classes": "nhsuk-header--white nhsuk-header--white-nav",
     "organisation": {
       "name": "Anytown Anyplace",
@@ -770,28 +729,27 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 The header Nunjucks macro takes the following arguments:
 
-| Name                          | Type    | Required | Description                                                                                                                                       |
-| ----------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **showNav**                   | boolean | Yes      | Set to "true" to show the navigation links in the header.                                                                                         |
-| **showSearch**                | boolean | Yes      | Set to "true" to show the site search input form.                                                                                                 |
-| **homeHref**                  | string  | No       | The href of the link for the logo and mobile home link in the navigation links. Defaults to "/".                                                  |
-| **ariaLabel**                 | string  | No       | Aria label for the logo href. Defaults to "NHS homepage".                                                                                         |
-| **organisation**              | object  | No       | Settings for header with organisational logo.                                                                                                     |
-| **organisation.name**         | string  | No       | Organisation name value.                                                                                                                          |
-| **organisation.split**        | string  | No       | Longer organisation names can be split onto multiple lines.                                                                                       |
-| **organisation.descriptor**   | string  | No       | Organisation descriptor.                                                                                                                          |
-| **organisation.logoURL**      | string  | No       | Organisation logo if using a static asset, such as PNG, is preferred.                                                                             |
-| **primaryLinks**              | array   | No       | Array of navigation links for use in the header.                                                                                                  |
-| **primaryLinks[].url**        | string  | No       | The href of a navigation item in the header.                                                                                                      |
-| **primaryLinks[].label**      | string  | No       | The label of a navigation item in the header.                                                                                                     |
-| **primaryLinks[].classes**    | string  | No       | Optional additional classes to add to the list item.                                                                                              |
-| **primaryLinks[].attributes** | string  | No       | Any extra HTML attributes (for example data attributes) to add to the list item.                                                                  |
-| **transactional**             | string  | No       | Set to "true" if this is a transactional header (with smaller logo).                                                                              |
-| **transactionalService**      | object  | No       | Object containing the _name_ and _href_ of the transactional service.                                                                             |
-| **service**                   | object  | No       | Object containing the _name_ and optional boolean _longName_ of the service. Set this to "true" if the service name is longer than 22 characters. |
-| **classes**                   | string  | No       | Optional additional classes to add to the header container. Separate each class with a space.                                                     |
-| **attributes**                | object  | No       | Any extra HTML attributes (for example data attributes) to add to the header container.                                                           |
-| **searchAction**              | string  | No       | The search action endpoint. Defaults to "https://www.nhs.uk/search/"                                                                              |
-| **searchInputName**           | string  | No       | The name for the search field. Defaults to "q"                                                                                                    |
+| Name                           | Type   | Required | Description                                                                                                                                       |
+| ------------------------------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **homeHref**                   | string | No       | The href of the link for the logo and mobile home link in the navigation links. Defaults to "/".                                                  |
+| **ariaLabel**                  | string | No       | Aria label for the logo href. Defaults to "NHS homepage".                                                                                         |
+| **organisation**               | object | No       | Settings for header with organisational logo.                                                                                                     |
+| **organisation.name**          | string | No       | Organisation name value.                                                                                                                          |
+| **organisation.split**         | string | No       | Longer organisation names can be split onto multiple lines.                                                                                       |
+| **organisation.descriptor**    | string | No       | Organisation descriptor.                                                                                                                          |
+| **organisation.logoURL**       | string | No       | Organisation logo if using a static asset, such as PNG, is preferred.                                                                             |
+| **primaryLinks**               | array  | No       | Array of navigation links for use in the header.                                                                                                  |
+| **primaryLinks[].url**         | string | No       | The href of a navigation item in the header.                                                                                                      |
+| **primaryLinks[].label**       | string | No       | The label of a navigation item in the header.                                                                                                     |
+| **primaryLinks[].classes**     | string | No       | Optional additional classes to add to the list item.                                                                                              |
+| **primaryLinks[].attributes**  | string | No       | Any extra HTML attributes (for example data attributes) to add to the list item.                                                                  |
+| **transactionalService**       | object | No       | Object containing the _name_ and _href_ of the transactional service.                                                                             |
+| **service**                    | object | No       | Object containing the _name_ and optional boolean _longName_ of the service. Set this to "true" if the service name is longer than 22 characters. |
+| **search**                     | object | No       | Settings for the search input.                                                                                                                    |
+| **search.action**              | string | No       | The search action endpoint. Defaults to <https://www.nhs.uk/search>                                                                               |
+| **search.name**                | string | No       | The name for the search field. Defaults to "q"                                                                                                    |
+| **search.visuallyHiddenLabel** | string | No       | The label for the search field. Defaults to "Search the NHS website"                                                                              |
+| **classes**                    | string | No       | Optional additional classes to add to the header container. Separate each class with a space.                                                     |
+| **attributes**                 | object | No       | Any extra HTML attributes (for example data attributes) to add to the header container.                                                           |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -1,8 +1,10 @@
 {% from "../../macros/attributes.njk" import nhsukAttributes %}
 
-{# Define some defaults #}
-{% set showNav = params.showNav if params.showNav else "false" %}
-{% set showSearch = params.showSearch if params.showSearch else "false" %}
+{%- set searchAction = params.search.action | default('https://www.nhs.uk/search/') %}
+{%- set searchName = params.search.name | default('q') %}
+{%- set searchPlaceholder = params.search.placeholder | default('Search') %}
+{%- set searchVisuallyHiddenButton = params.search.visuallyHiddenButton | default('Search') %}
+{%- set searchVisuallyHiddenLabel = params.search.visuallyHiddenLabel | default('Search the NHS website') %}
 
 {% set nhsLogo %}
 <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80" height="40" width="100">
@@ -11,80 +13,72 @@
 {% endset %}
 
 <header class="nhsuk-header
-{%- if params.transactional or params.transactionalService %} nhsuk-header__transactional{% endif %}
-{%- if params.organisation and params.organisation.name %} nhsuk-header--organisation{% endif %}
+{%- if params.transactionalService %} nhsuk-header__transactional{% endif %}
+{%- if params.organisation %} nhsuk-header--organisation{% endif %}
 {%- if params.classes %} {{ params.classes }}{% endif %}" role="banner"
 {{- nhsukAttributes(params.attributes) }}>
-
   <div class="nhsuk-header__container">
     <div class="nhsuk-header__logo
-    {%- if showNav == "false" and showSearch == "false" and params.transactionalService %} nhsuk-header__transactional--logo{% endif %}
-    {%- if showNav == "false" and showSearch == "false" and not params.transactionalService %} nhsuk-header__logo--only{% endif %}">
-      {%- if params.organisation %}
-      <a class="nhsuk-header__link" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}" aria-label="{{ params.organisation.name }} {{ params.organisation.split }} {{ params.organisation.descriptor }} homepage">
-        {%- if params.organisation.logoURL %}
+    {%- if not params.primaryLinks and not params.search and params.transactionalService %} nhsuk-header__transactional--logo{% endif %}
+    {%- if not params.primaryLinks and not params.search and not params.transactionalService %} nhsuk-header__logo--only{% endif %}">
+    {%- if params.organisation %}
+      <a class="nhsuk-header__link" href="{{ params.homeHref | default('/') }}" aria-label="{{ params.organisation.name }} {{ params.organisation.split }} {{ params.organisation.descriptor }} homepage">
+      {%- if params.organisation.logoURL %}
         <img class="nhsuk-organisation-logo" src="{{ baseUrl }}{{ params.organisation.logoURL }}" alt=""/>
-        {%- else -%}
+      {%- else -%}
         {{ nhsLogo | safe }}
         <span class="nhsuk-organisation-name">{{ params.organisation.name }}{% if params.organisation.split %} <span class="nhsuk-organisation-name-split">{{ params.organisation.split }}</span>{% endif %}</span>
         {% if params.organisation.descriptor %}<span class="nhsuk-organisation-descriptor">{{ params.organisation.descriptor }}</span>{% endif %}
-        {%- endif %}
+      {%- endif %}
       </a>
-      {%- else -%}
-      <a class="nhsuk-header__link{% if params.service %} nhsuk-header__link--service {% endif %}" href="{% if params.homeHref %}{{ params.homeHref }}{% else %}/{% endif %}" aria-label="{% if params.ariaLabel %}{{ params.ariaLabel }}{% else %}NHS homepage{% endif %}">
+    {%- else -%}
+      <a class="nhsuk-header__link{% if params.service %} nhsuk-header__link--service {% endif %}" href="{{ params.homeHref | default('/') }}" aria-label="{{ params.ariaLabel | default('NHS homepage') }}">
         {{ nhsLogo | safe }}
         {%- if params.service %}
-        <span class="nhsuk-header__service-name">
-          {{ params.service.name }}
-        </span>
+        <span class="nhsuk-header__service-name">{{ params.service.name }}</span>
         {%- endif %}
       </a>
-      {%- endif %}
+    {%- endif %}
     </div>
 
-{%- if showNav == "false" and showSearch == "false"%}
-  {%- if params.transactionalService%}
+{%- if params.transactionalService and not params.primaryLinks and not params.search %}
     <div class="nhsuk-header__transactional-service-name">
-      <a class="nhsuk-header__transactional-service-name--link" href="{% if params.transactionalService.href %}{{ params.transactionalService.href }}{% else %}/{% endif %}">{{ params.transactionalService.name }}</a>
+      <a class="nhsuk-header__transactional-service-name--link" href="{{ params.transactionalService.href | default('/') }}">{{ params.transactionalService.name }}</a>
     </div>
-  {%- endif %}
-{% endif -%}
+{%- endif %}
 
-{% if showSearch == "true" %}
+{%- if params.search %}
     <div class="nhsuk-header__content" id="content-header">
       <div class="nhsuk-header__search">
-          <div class="nhsuk-header__search-wrap" id="wrap-search">
-            <form class="nhsuk-header__search-form" id="search" action="{{ params.searchAction if params.searchAction else 'https://www.nhs.uk/search/' }}" method="get" role="search">
-              <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
-              <input class="nhsuk-search__input" id="search-field" name="{{ params.searchInputName if params.searchInputName else "search-field" }}" type="search" placeholder="Search" autocomplete="off" >
-              <button class="nhsuk-search__submit" type="submit">
-                <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                  <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-                </svg>
-                <span class="nhsuk-u-visually-hidden">Search</span>
-              </button>
-            </form>
-          </div>
+        <div class="nhsuk-header__search-wrap" id="wrap-search">
+          <form class="nhsuk-header__search-form" id="search" action="{{ searchAction }}" method="get" role="search">
+            <label class="nhsuk-u-visually-hidden" for="search-field">{{ searchVisuallyHiddenLabel }}</label>
+            <input class="nhsuk-search__input" id="search-field" name="{{ searchName }}" type="search" placeholder="Search" autocomplete="off">
+            <button class="nhsuk-search__submit" type="submit">
+              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
+              <span class="nhsuk-u-visually-hidden">{{ searchVisuallyHiddenButton }}</span>
+            </button>
+          </form>
         </div>
+      </div>
     </div>
-{% endif -%}
-  </div>{# close nhsuk-header__container #}
+{%- endif %}
+  </div>
 
-{% if showNav == "true" and params.primaryLinks %}
+{%- if params.primaryLinks and params.primaryLinks.length > 0 %}
   <div class="nhsuk-navigation-container">
     <nav class="nhsuk-navigation" id="header-navigation" role="navigation" aria-label="Primary navigation">
       <ul class="nhsuk-header__navigation-list {%- if params.primaryLinks.length < 4 %} nhsuk-header__navigation-list--left-aligned{% endif %}">
-        {%- for item in params.primaryLinks %}
+      {%- for item in params.primaryLinks %}
         <li class="nhsuk-header__navigation-item {%- if item.classes %} {{ item.classes }}{% endif %}" {{- nhsukAttributes(item.attributes) }}>
-          <a class="nhsuk-header__navigation-link"  href="{{item.url}}">
-            {{item.label}}
-          </a>
+          <a class="nhsuk-header__navigation-link" href="{{ item.url }}">{{ item.label }}</a>
         </li>
         {%- endfor %}
         <li class="nhsuk-mobile-menu-container">
           <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
-            <span class="nhsuk-u-visually-hidden">Browse</span>
-            More
+            <span class="nhsuk-u-visually-hidden">Browse </span>More
             <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
             </svg>
@@ -93,5 +87,5 @@
       </ul>
     </nav>
   </div>
-{% endif -%}
+{%- endif %}
 </header>

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -41,7 +41,7 @@
     {%- endif %}
     </div>
 
-{%- if params.transactionalService and not params.primaryLinks and not params.search %}
+{%- if params.transactionalService %}
     <div class="nhsuk-header__transactional-service-name">
       <a class="nhsuk-header__transactional-service-name--link" href="{{ params.transactionalService.href | default('/') }}">{{ params.transactionalService.name }}</a>
     </div>


### PR DESCRIPTION
## Description

Prior to any work on adding account links to the header, or refining its design, this PR aims to reduce the complexity of the component template, and remove repetition of navigation and search markup.

This PR:

- Shows or hides navigation and search markup by querying the presence of values for `params.primaryLinks` and `params.search` respectively
- Removes repetition of navigation and search markup thanks to simplified logic and fewer variables
- Uses the [`default` filter](https://mozilla.github.io/nunjucks/templating.html#default-value-default-boolean) for values as opposed to longer `if`/`else` tags
- Adds an option to set the (visually hidden) label for the search input
- Allows a transactional service name to be used alongside navigation and/or search
- Changes the default search query param from `search-field` to `q`, to match that used by the NHS.UK website (all the other fallback values do this, so this should as well)

As this PR stands, this is a breaking change, although only in terms of the Nunjucks macro options. Here are the changes:

| Option | Change | Note |
|-|-|-|
| `showNav` | **Removed** | Navigation shown if `primaryLinks` option provided |
| `showSearch` | **Removed** | Search shown if `search` option provided |
| `transactional` | **Removed** | Transactional header used if `transactionService` option provided |
| `search` | **New** | Used to collate all search related options |
| `search.placeholder` | **New option** | Change the search placeholder text. Defaults to ‘Search’ |
| `search.visuallyHiddenButton` | **New** | Change the (visually hidden) search button text. Defaults to ‘Search’ |
| `search.visuallyHiddenLabel` | **New** | Change the (visually hidden) search label. Defaults to ‘Search the NHS website’ |
| `searchAction` | **Renamed** | Becomes `search.action`. Defaults to `https://www.nhs.uk/search/` |
| `searchInputName` | **Renamed** | Becomes `search.name`. Defaults to `q` |

It should be noted that the service manual website, as just one example, currently has the label ‘Search the NHS website’, when in fact you can only search the service manual website. The new `search{}.visuallyHiddenLabel` option would make it possible to use a correct label.

If this PR is accepted, a separate PR can be made against the service manual to update these options.

There’s a whole load of other refinements that could be made in terms of markup, styles and the different options provided, but I’ve tried to keep this change tightly scoped to focus only on reducing the complexity of this component’s templating logic, with the side effect being a reduction in the number of interconnected macro options provided to authors.

## Why remove `showNav`, `showSearch` and `transactional` options?

While it could be suggested that these options make it easy to show/hide parts of the header, this can be achieved with Nunjucks in other ways. For example, currently you might do the following:

```njk
{# If `user.loggedIn` is `true`, navigation is shown #}
{{ header({
  service: {
    name: "Example"
  },
  showNav: user.loggedIn,
  primaryLinks: [{
    url : "#",
    label : "Item one"
  }, {
    url : "#",
    label : "Item two"
  }]
}) }}
```

This could be written thus:

```njk
{# When `user.loggedIn` is `true`, navigation is shown #}
{{ header({
  service: {
    name: "Example"
  },
  primaryLinks: [{
    url : "#",
    label : "Item one"
  }, {
    url : "#",
    label : "Item two"
  }] if user.loggedIn
}) }}
```

It can also get tricky and complex if you have to manage the state of the header across multiple options. The changes in this PR hopefully make it easier to manage this.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
