### PR TITLE
Update table styles so nhsuk-table has bottom margin

### DIFF
--- a/packages/components/tables/_tables.scss
+++ b/packages/components/tables/_tables.scss
@@ -11,7 +11,7 @@
 .nhsuk-table-container {
   @include nhsuk-responsive-margin(7, "bottom");
 
-  display: block;
+  // display: block;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   overflow-x: auto;
@@ -20,6 +20,16 @@
   .nhsuk-table {
     margin: 0; /* [1] */
   }
+}
+
+.nhsuk-table {
+  @include nhsuk-font($size: 19);
+  
+  width: 100%;
+  @include nhsuk-responsive-margin(7, "bottom");
+
+  border-spacing: 0;
+  border-collapse: collapse;
 }
 
 /* Table row hover
@@ -72,8 +82,6 @@
  */
 
 .nhsuk-table-responsive {
-  margin-bottom: 0;
-  width: 100%;
 
   thead {
     @include visually-hidden; /* [1] */
@@ -85,7 +93,7 @@
 
   .nhsuk-table__body {
     .nhsuk-table-responsive__heading {
-      font-weight: $nhsuk-font-bold;
+      @include nhsuk-typography-weight-bold;
       padding-right: nhsuk-spacing(3);
       text-align: left; /* [8] */
 


### PR DESCRIPTION
This fixes some inconsistency with the table styles.

The current table styles rely on a bottom margin being applied to the `table` element rather than `nhsuk-table`. The responsive table variant resets this so it has no bottom margin.

The styles include a `nhsuk-table-container` class that's presumably meant to wrap tables, but this is not used or documented on the design system site. I might guess it was added for a specific use case. For now I've left it, but teams shouldn't need to use it to get the correct bottom margin.

This applies some basic styles to `nhsuk-table` similar to how `govuk-table` styles it. If `nhsuk-table-container` can still be used.