### PR TITLE
Update arrow icons to be visually consistent with other arrow-like icons

### DIFF
--- a/packages/assets/icons/icon-arrow-left.svg
+++ b/packages/assets/icons/icon-arrow-left.svg
@@ -1,3 +1,3 @@
 <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-  <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+  <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
 </svg>

--- a/packages/assets/icons/icon-arrow-right.svg
+++ b/packages/assets/icons/icon-arrow-right.svg
@@ -1,3 +1,3 @@
 <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-  <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+  <path d="m14.7 6.3 5 5c.2.2.3.4.3.7 0 .3-.1.5-.3.7l-5 5a1 1 0 0 1-1.4-1.4l3.3-3.3H5a1 1 0 0 1 0-2h11.6l-3.3-3.3a1 1 0 1 1 1.4-1.4Z"></path>
 </svg>

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -21,7 +21,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
         <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">Treatments</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+          <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
         </svg>
       </a>
     </li>
@@ -31,7 +31,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
         <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">Symptoms</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+          <path d="m14.7 6.3 5 5c.2.2.3.4.3.7 0 .3-.1.5-.3.7l-5 5a1 1 0 0 1-1.4-1.4l3.3-3.3H5a1 1 0 0 1 0-2h11.6l-3.3-3.3a1 1 0 1 1 1.4-1.4Z"></path>
         </svg>
       </a>
     </li>
@@ -102,7 +102,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
         <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">Treatments</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+          <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
         </svg>
       </a>
     </li>

--- a/packages/components/pagination/template.njk
+++ b/packages/components/pagination/template.njk
@@ -11,7 +11,7 @@
         <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">{{ params.previousPage }}</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+          <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
         </svg>
       </a>
     </li>
@@ -23,7 +23,7 @@
         <span class="nhsuk-u-visually-hidden">:</span>
         <span class="nhsuk-pagination__page">{{ params.nextPage }}</span>
         <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+          <path d="m14.7 6.3 5 5c.2.2.3.4.3.7 0 .3-.1.5-.3.7l-5 5a1 1 0 0 1-1.4-1.4l3.3-3.3H5a1 1 0 0 1 0-2h11.6l-3.3-3.3a1 1 0 1 1 1.4-1.4Z"></path>
         </svg>
       </a>
     </li>


### PR DESCRIPTION
## Description

In reviewing #1026, the difference in arrows used for pagination versus chevrons used in other components and the right-pointing action link icon becomes clearer, with the pagination arrows looking like they are from a different icon set.

Also, with the numbered pagination option, it looks like the arrows might be rendered smaller; at which point **the arrow tips become harder to identify**.

This PR update the pagination arrow icons to have open arrow tips, using the same path metrics as those used by the other arrow icons.

This could also potentially be merged into and be part of #1026, or merged separately (with corresponding a changelog entry). 

### Pagination before

![Pagination component with current arrow icons.](https://github.com/user-attachments/assets/1186eb00-d467-470b-8092-4011f3f84667)

### Pagination after

![Pagination component with revised arrow icons.](https://github.com/user-attachments/assets/af3f9b20-a41e-42af-ac19-da525cac702f)

### Arrow icons before

![All current arrow icons](https://github.com/user-attachments/assets/f0e69181-6b91-40cb-86bb-16032f833f4e)

### Arrow icons after

![All revised arrow icons](https://github.com/user-attachments/assets/ee3164f3-ff8c-42b7-af55-b9820e709d5a)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
