### PR TITLE
Remove standalone icon SVG files

### DIFF
--- a/packages/assets/icons/icon-arrow-left.svg
+++ b/packages/assets/icons/icon-arrow-left.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-  <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
-</svg>

--- a/packages/assets/icons/icon-arrow-right-circle.svg
+++ b/packages/assets/icons/icon-arrow-right-circle.svg
@@ -1,4 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <path d="M0 0h24v24H0z" fill="none"></path>
-  <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
-</svg>

--- a/packages/assets/icons/icon-arrow-right.svg
+++ b/packages/assets/icons/icon-arrow-right.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-  <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-</svg>

--- a/packages/assets/icons/icon-chevron-left.svg
+++ b/packages/assets/icons/icon-chevron-left.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-</svg>

--- a/packages/assets/icons/icon-chevron-right.svg
+++ b/packages/assets/icons/icon-chevron-right.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-</svg>

--- a/packages/assets/icons/icon-close.svg
+++ b/packages/assets/icons/icon-close.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" height="34" width="34">
-  <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-</svg>

--- a/packages/assets/icons/icon-cross.svg
+++ b/packages/assets/icons/icon-cross.svg
@@ -1,4 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z"></path>
-  <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z"></path>
-</svg>

--- a/packages/assets/icons/icon-emdash-small.svg
+++ b/packages/assets/icons/icon-emdash-small.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__emdash" xmlns="http://www.w3.org/2000/svg" width="16" height="1" aria-hidden="true">
-  <path d="M0 0h16v1H0z"></path>
-</svg>

--- a/packages/assets/icons/icon-emdash.svg
+++ b/packages/assets/icons/icon-emdash.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__emdash" xmlns="http://www.w3.org/2000/svg" width="19" height="1" aria-hidden="true">
-  <path d="M0 0h19v1H0z"></path>
-</svg>

--- a/packages/assets/icons/icon-minus.svg
+++ b/packages/assets/icons/icon-minus.svg
@@ -1,4 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__minus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <circle cx="12" cy="12" r="10"></circle>
-  <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M8 12h8"></path>
-</svg>

--- a/packages/assets/icons/icon-plus.svg
+++ b/packages/assets/icons/icon-plus.svg
@@ -1,4 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__plus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-  <circle cx="12" cy="12" r="10"></circle>
-  <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M12 8v8M8 12h8"></path>
-</svg>

--- a/packages/assets/icons/icon-search.svg
+++ b/packages/assets/icons/icon-search.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" height="34" width="34">
-  <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-</svg>

--- a/packages/assets/icons/icon-tick.svg
+++ b/packages/assets/icons/icon-tick.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" height="34" width="34">
-  <path stroke-width="4" stroke-linecap="round" stroke="#007f3b" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
-</svg>


### PR DESCRIPTION
These standalone `.svg` icon files aren't used by any of the components, as each component either embeds the SVG [directly within the Nunjucks macro](https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/components/pagination/template.njk#L13-L15) or includes it [using a data-url in the CSS](https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/components/details/_details.scss#L140).

On the one hand, maybe it’s useful to have these as standalone files just as a reference, so that all the icons can be easily reviewed together?

But on the other hand, duplicating them here runs the risk of them accidentally deviating from the actual icons used by the components?

Including them within the `nhsuk-frontend` package also adds another 100kb to the package (as they’re included twice, once in `packages/assets` and once in `dist/app/asset`).

Note: It’s possible that these _are_ used somewhere and I’ve missed it somehow, but I’ve done a bunch of services across the code, and I can’t find anything that does.