### PR TITLE
Use paragraphs for error messages

### DIFF
--- a/packages/components/error-message/README.md
+++ b/packages/components/error-message/README.md
@@ -11,10 +11,10 @@ Find out more about the error message component and when to use it in the [NHS d
 ### HTML markup
 
 ```html
-<span class="nhsuk-error-message">
+<p class="nhsuk-error-message">
   <span class="nhsuk-u-visually-hidden">Error:</span>
   Error message about full name goes here
-</span>
+</p>
 ```
 
 ### Nunjucks macro

--- a/packages/components/error-message/_error-message.scss
+++ b/packages/components/error-message/_error-message.scss
@@ -8,5 +8,6 @@
   clear: both;
   color: $nhsuk-error-color;
   display: block;
+  margin-top: 0; // Reset any default browser margins for paragraphs
   margin-bottom: nhsuk-spacing(3);
 }

--- a/packages/components/error-message/template.njk
+++ b/packages/components/error-message/template.njk
@@ -2,10 +2,10 @@
 
 {% set visuallyHiddenText = params.visuallyHiddenText | default("Error") -%}
 
-<span class="nhsuk-error-message
+<p class="nhsuk-error-message
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- if params.id %} id="{{ params.id }}"{% endif %}
 {{- nhsukAttributes(params.attributes) }}>
   {% if visuallyHiddenText %}<span class="nhsuk-u-visually-hidden">{{ visuallyHiddenText }}:</span> {% endif -%}
   {{ params.html | safe if params.html else params.text }}
-</span>
+</p>


### PR DESCRIPTION
## Description
Fixes #1029.

I'm unsure if this should be considered a breaking change or not - might be worth a discussion.

Visually there should be no difference.

|Before| After|
|-|-|
|[Video with span](https://github.com/user-attachments/assets/5585e91a-3320-4c41-8523-879355f7006f)|[Video with paragraph](https://github.com/user-attachments/assets/4cf84e6b-cffd-4d11-9a87-ee13df0fc045)|


## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
