### PR TITLE
fixes care card print bug https://github.com/nhsuk/nhsuk-service-manu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Fix layout bug where breadcrumb component was changing height when more than one link shown
+- Fix print styling bug with emergecy care card ([Issue 533]([https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/533]))
 
 ## 9.0.0 - 18 September 2024
 

--- a/packages/components/card/card.scss
+++ b/packages/components/card/card.scss
@@ -250,6 +250,10 @@ $card-border-hover-color: $color_nhsuk-grey-3;
         color: $color_nhsuk-black; /* [16] */
       }
     }
+    @include mq($media-type: print) {
+      background-color: white;
+      color: $nhsuk-print-text-color;
+    }
   }
 
   .nhsuk-details,


### PR DESCRIPTION
Fixes care card print bug https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/533

## Description
This PR makes the background white and text black on the emergency care card (https://github.com/nhsuk/nhsuk-frontend/blob/main/app/components/card/care-card-emergency.njk). 

This PR:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/df05cf63-f8f3-4e17-9685-adc7eff47709">


Before this PR, printing with background images turned off:
<img width="930" alt="image" src="https://github.com/user-attachments/assets/54cf9a87-8c71-4191-8234-50762fa00b7e">

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
