### PR TITLE
Pin Prettier version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "jest-environment-puppeteer": "^10.0.1",
         "minimist": "^1.2.8",
         "nunjucks": "^3.2.4",
-        "prettier": "^3.3.2",
+        "prettier": "3.3.3",
         "puppeteer": "^22.12.1",
         "sass": "^1.77.6",
         "start-server-and-test": "^2.0.4",
@@ -14307,10 +14307,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -29016,9 +29017,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jest-environment-puppeteer": "^10.0.1",
     "minimist": "^1.2.8",
     "nunjucks": "^3.2.4",
-    "prettier": "^3.3.2",
+    "prettier": "3.3.3",
     "puppeteer": "^22.12.1",
     "sass": "^1.77.6",
     "start-server-and-test": "^2.0.4",


### PR DESCRIPTION
## Description

`package.json` lists Prettier as `^3.3.2`. This means that different versions can be installed locally as that ran during CI, which always installs the latest version (currently v3.3.3).

This is [recommended by Prettier](https://prettier.io/docs/en/install#summary):

> Install an exact version of Prettier locally in your project. This makes sure that everyone in the project gets the exact same version of Prettier. Even a patch release of Prettier can result in slightly different formatting, so you wouldn’t want different team members using different versions and formatting each other’s changes back and forth.

This has caused issues recently, with a patch release changing how `box-shadow` rules get formatted.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
