### PR TITLE
Use npm ci to install dependencies for testing

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,8 +16,8 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
-      run: npm install
-  
+      run: npm ci
+
     - name: Sonar analysis
       uses: sonarsource/sonarcloud-github-action@master
       with:


### PR DESCRIPTION
> [`npm ci`](https://docs.npmjs.com/cli/v10/commands/npm-ci) is similar to [npm install](https://docs.npmjs.com/cli/v10/commands/npm-install), except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.