### PR TITLE
Update secondary button style

### DIFF
--- a/packages/components/button/_button.scss
+++ b/packages/components/button/_button.scss
@@ -7,12 +7,18 @@
  * 2. Fix unwanted button padding in Firefox.
  * 3. Use a pseudo element to expand the click target area to include the
  *    button's shadow as well, in case users try to click it.
+ * 4. Makes the secondary button that has a border the same height as the other 
+ *    buttons that don't have a border.
  */
 
 // Because the shadow (s0) is visually 'part of' the button, we need to reduce
 // the height of the button to compensate by adjusting its padding (s1) and
 // increase the bottom margin to include it (s1).
 $button-shadow-size: 4px;
+$button-border-width: 2px;
+$button-padding-top-bottom-desktop: 12px;
+$button-padding-top-bottom-mobile: nhsuk-spacing(2);
+$button-padding-left-right: nhsuk-spacing(3);
 
 .nhsuk-button {
   @include nhsuk-font(19);
@@ -29,17 +35,17 @@ $button-shadow-size: 4px;
   display: inline-block;
   font-weight: 600;
   margin-top: 0;
-  padding: 12px nhsuk-spacing(3); // s2
+  padding: $button-padding-top-bottom-desktop $button-padding-left-right; // s2
   position: relative;
   text-align: center;
   vertical-align: top;
   width: auto;
 
   @include mq($until: tablet) {
-    padding: nhsuk-spacing(2) nhsuk-spacing(3); // s2
+    padding: $button-padding-top-bottom-mobile $button-padding-left-right; // s2
   }
 
-  /* 2 */
+  /* 1 */
   &:link,
   &:visited,
   &:active,
@@ -48,7 +54,7 @@ $button-shadow-size: 4px;
     text-decoration: none;
   }
 
-  /* 3 */
+  /* 2 */
   &::-moz-focus-inner {
     border: 0;
     padding: 0;
@@ -80,7 +86,7 @@ $button-shadow-size: 4px;
     top: $button-shadow-size;
   }
 
-  /* 4 */
+  /* 3 */
   &::before {
     background: transparent;
     bottom: -($nhsuk-border-width-form-element + $button-shadow-size);
@@ -114,14 +120,26 @@ $button-shadow-size: 4px;
 
 .nhsuk-button--secondary {
   background-color: $nhsuk-secondary-button-color;
+  border: $button-border-width solid $nhsuk-secondary-button-border-color;
+  border-bottom: 0;
   box-shadow: 0 $button-shadow-size 0 $nhsuk-secondary-button-shadow-color;
+  color: $nhsuk-secondary-button-text-color;
+  padding-bottom: $button-padding-top-bottom-desktop + calc($button-border-width / 2); /* 4 */
+  padding-top: $button-padding-top-bottom-desktop + calc($button-border-width / 2); /* 4 */
+
+  @include mq($until: tablet) {
+    padding-bottom: $button-padding-top-bottom-mobile + calc($button-border-width / 2); /* 4 */
+    padding-top: $button-padding-top-bottom-mobile + calc($button-border-width / 2); /* 4 */
+  }
 
   &:hover {
-    background-color: darken($nhsuk-secondary-button-color, 10%);
+    background-color: $nhsuk-secondary-button-hover-color;
+    color: $nhsuk-secondary-button-text-color;
   }
 
   &:focus {
     background: $nhsuk-focus-color;
+    border-color: $nhsuk-focus-color;
     box-shadow: 0 $button-shadow-size 0 $nhsuk-focus-text-color;
     color: $nhsuk-focus-text-color;
     outline: $nhsuk-focus-width solid transparent;
@@ -129,9 +147,18 @@ $button-shadow-size: 4px;
 
   &:active {
     background: $nhsuk-secondary-button-active-color;
+    border-color: $nhsuk-secondary-button-border-color;
+    border-bottom: $button-border-width solid;
     box-shadow: none;
-    color: $nhsuk-button-text-color;
+    color: $nhsuk-secondary-button-text-color;
+    padding-bottom: $button-padding-top-bottom-desktop;  /* 4 */
+    padding-top: $button-padding-top-bottom-desktop;  /* 4 */
     top: $button-shadow-size;
+
+    @include mq($until: tablet) {
+      padding-bottom: $button-padding-top-bottom-mobile; /* 4 */
+      padding-top: $button-padding-top-bottom-mobile; /* 4 */
+    }
   }
 
   &.nhsuk-button--disabled {

--- a/packages/core/settings/_colours.scss
+++ b/packages/core/settings/_colours.scss
@@ -141,10 +141,12 @@ $nhsuk-button-hover-color: shade($nhsuk-button-color, 20%);
 $nhsuk-button-active-color: shade($nhsuk-button-color, 50%);
 $nhsuk-button-shadow-color: shade($nhsuk-button-color, 50%);
 
-$nhsuk-secondary-button-color: $color_nhsuk-grey-1;
-$nhsuk-secondary-button-hover-color: shade($nhsuk-secondary-button-color, 20%);
-$nhsuk-secondary-button-active-color: shade($nhsuk-secondary-button-color, 50%);
-$nhsuk-secondary-button-shadow-color: shade($nhsuk-secondary-button-color, 50%);
+$nhsuk-secondary-button-color: transparent;
+$nhsuk-secondary-button-border-color: $color_nhsuk-blue;
+$nhsuk-secondary-button-text-color: $color_nhsuk-blue;
+$nhsuk-secondary-button-hover-color: tint($nhsuk-secondary-button-border-color, 85%);
+$nhsuk-secondary-button-active-color: tint($nhsuk-secondary-button-border-color, 75%);
+$nhsuk-secondary-button-shadow-color: $nhsuk-secondary-button-border-color;
 
 $nhsuk-reverse-button-color: $color_nhsuk-white;
 $nhsuk-reverse-button-hover-color: shade($nhsuk-reverse-button-color, 20%);


### PR DESCRIPTION
## Description

A proposal to change the secondary button visual style.

### Current design

<img width="225" alt="Screenshot 2024-11-20 at 16 06 15" src="https://github.com/user-attachments/assets/e81a5651-91c6-4798-b895-e2bb94896c12">

### Proposed design

<img width="648" alt="secondary-button" src="https://github.com/user-attachments/assets/f7d1d7d6-b8a2-473e-8e98-01f821235d69">

## Supporting information

- [NHS App secondary button design hypothesis](https://github.com/nhsuk/nhsapp-frontend/issues/12#issuecomment-2385106820)
- [Manage vaccinations in schools service already using the new design](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1776)


## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
