### PR TITLE
Fix test workflows to only run relevant tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Run tests
-      run: npm test
+      run: npm run jest:ci
 
   ui_tests:
     name: Visual regression tests
@@ -62,7 +62,5 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
-    - name: Run tests
-      run: npm test
     - name: Run backstop
       run: npm run backstop:ci


### PR DESCRIPTION
Realised when a code style test failed on another PR that all 3 jobs were unexpectedly failing because they all ran the code style checks, doh. 🤦 

This fixes that by only running the jest tests in the unit test jobs and only running the visually regression tests in that job.