### PR TITLE
Remove the -1 suffix from radio and checkbox IDs

### DIFF
--- a/packages/components/checkboxes/template.njk
+++ b/packages/components/checkboxes/template.njk
@@ -45,7 +45,7 @@
   <div class="nhsuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %} {%- if isConditional %} nhsuk-checkboxes--conditional{% endif -%}"
     {{- nhsukAttributes(params.attributes) }}>
     {% for item in params.items %}
-    {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
+    {% set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "")  %}
     {% set name = item.name if item.name else params.name %}
     {% set conditionalId = "conditional-" + id %}
     {% set hasHint = true if item.hint.text or item.hint.html %}

--- a/packages/components/radios/template.njk
+++ b/packages/components/radios/template.njk
@@ -46,7 +46,7 @@
   {%- if params.classes %} {{ params.classes }}{% endif %} {%- if isConditional %} nhsuk-radios--conditional{% endif -%}"
   {{- nhsukAttributes(params.attributes) }}>
     {%- for item in params.items %}
-    {%- set id = item.id if item.id else idPrefix + "-" + loop.index %}
+    {%- set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "") %}
     {% set conditionalId = "conditional-" + id %}
     {%- if item.divider %}
     <div class="nhsuk-radios__divider">{{ item.divider }}</div>


### PR DESCRIPTION
This follows the convention from GOV.UK Frontend and makes it slightly easier to link from error summaries to the first item, as you’d no longer have to remember the `-1` suffix.

This should probably be considered a breaking change though?

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
