### PR TITLE
Remove 24px from typography scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ This change ensures consistency with other components, where `text` or `html` pa
 
 This change was made in [pull request #1259: Review legacy Nunjucks params](https://github.com/nhsuk/nhsuk-frontend/pull/1259).
 
-#### 24 point typography size removed
+#### Stop using `nhsuk-u-font-size-24` and '24' on the typography scale
 
 The point 24 (24px large screens, 20px small screens) on the typography scale has been removed, after previously being deprecated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ This change was made in [pull request #1259: Review legacy Nunjucks params](http
 
 #### Stop using deprecated 24 point on the typography scale
 
-The point 24 (24px large screens, 20px small screens) on the typography scale has been removed, after previously being deprecated.
+The point 24 (24px large screens, 20px small screens) on the typography scale has been removed, after previously being deprecated in [version 9.5.0](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.5.0).
 
 Use either point 22 or point 26 instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ This change ensures consistency with other components, where `text` or `html` pa
 
 This change was made in [pull request #1259: Review legacy Nunjucks params](https://github.com/nhsuk/nhsuk-frontend/pull/1259).
 
-#### Stop using `nhsuk-u-font-size-24` and '24' on the typography scale
+#### Stop using deprecated 24 point on the typography scale
 
 The point 24 (24px large screens, 20px small screens) on the typography scale has been removed, after previously being deprecated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,14 @@ This change ensures consistency with other components, where `text` or `html` pa
 
 This change was made in [pull request #1259: Review legacy Nunjucks params](https://github.com/nhsuk/nhsuk-frontend/pull/1259).
 
+#### 24 point typography size removed
+
+The point 24 (24px large screens, 20px small screens) on the typography scale has been removed, after previously being deprecated.
+
+Use either point 22 or point 26 instead.
+
+This change was introduced in [#1139: Remove 24px from typography scale](https://github.com/nhsuk/nhsuk-frontend/pull/1139)
+
 :wrench: **Fixes**
 
 - [#1312: Review and fix inconsistent link styles](https://github.com/nhsuk/nhsuk-frontend/pull/1312)

--- a/packages/core/settings/_typography.scss
+++ b/packages/core/settings/_typography.scss
@@ -85,38 +85,6 @@ $nhsuk-typography-scale: (
       line-height: 1.25
     )
   ),
-  24: (
-    null: (
-      font-size: 20px,
-      line-height: 28px
-    ),
-    tablet: (
-      font-size: 24px,
-      line-height: 31px
-    ),
-    print: (
-      font-size: 16pt,
-      line-height: 1.25
-    ),
-    deprecation: (
-      key: "nhsuk-typography-scale-24",
-      message: "24 on the typography scale is deprecated and will be removed in the next major version."
-    )
-  ),
-  _24: (
-    null: (
-      font-size: 20px,
-      line-height: 28px
-    ),
-    tablet: (
-      font-size: 24px,
-      line-height: 31px
-    ),
-    print: (
-      font-size: 16pt,
-      line-height: 1.25
-    )
-  ),
   22: (
     null: (
       font-size: 19px,


### PR DESCRIPTION
This removes the 24 point from the typography scale, after having previously deprecated it in #1294.

## Reasons for removing it

- 24px is not listed as font size in the [typography scale](https://service-manual.nhs.uk/design-system/styles/typography)
- The difference between 24px and 26px is slight, and having 3 sizes in the 22px - 26px range, reduces the contrast between heading sizes (which is why the medium heading size was increased from 24px to 26px last year).
- The 24px font size was only used for a few components, and these have now been updated:
  - Panel headings (feature card, panel table, warning callout, do and don’t lists)
  - Pagination
  - Panel
  - Lede text (`.nhsuk-lede-text`)
  - Large text (`.nhsuk-body-l`)
- Using 24px for panel headings means these don’t align with other headings on a page