### PR TITLE
Support form submission from header account items

### DIFF
--- a/app/components/header/header-account-custom-html.njk
+++ b/app/components/header/header-account-custom-html.njk
@@ -34,7 +34,7 @@
           html: '<a class="nhsuk-header__account-link" href="#">Notifications</a> <span class="app-count">8</span>'
         },
         {
-          href: "#",
+          action: "#",
           text: "Log out"
         }
       ]

--- a/app/components/header/header-account-logged-in.njk
+++ b/app/components/header/header-account-logged-in.njk
@@ -16,7 +16,7 @@
           icon: true
         },
         {
-          href: "#",
+          action: "#",
           text: "Log out"
         }
       ]

--- a/app/components/header/header-account-rbac.njk
+++ b/app/components/header/header-account-rbac.njk
@@ -27,7 +27,7 @@
           text: "Change role"
         },
         {
-          href: "#",
+          action: "#",
           text: "Log out"
         }
       ]

--- a/app/components/header/header-org-white-account.njk
+++ b/app/components/header/header-org-white-account.njk
@@ -22,7 +22,7 @@
           icon: true
         },
         {
-          href: "#",
+          action: "#",
           text: "Log out"
         }
       ]

--- a/app/components/header/header-service-name-with-account-search-nav.njk
+++ b/app/components/header/header-service-name-with-account-search-nav.njk
@@ -18,7 +18,7 @@
           icon: true
         },
         {
-          href: "#",
+          action: "#",
           text: "Log out"
         }
       ]

--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -123,10 +123,24 @@
   flex-grow: 0;
 }
 
+.nhsuk-header__account-button,
 .nhsuk-header__account-link {
   @include nhsuk-link-style-header;
   display: flex;
   gap: nhsuk-spacing(2);
+}
+
+.nhsuk-header__account-button {
+  @include nhsuk-font(16);
+  background: none;
+  border: 0;
+  padding: 0;
+  text-decoration: underline;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
 }
 
 /// Search

--- a/packages/components/header/template.njk
+++ b/packages/components/header/template.njk
@@ -13,11 +13,11 @@
 {% endset %}
 
 {% macro _accountItem(item) %}
-{% if item.icon %}
+{%- if item.icon -%}
 <svg class="nhsuk-icon nhsuk-icon__user" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
   <path d="M8 0c4.4 0 8 3.6 8 8s-3.6 8-8 8-8-3.6-8-8 3.6-8 8-8Zm0 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm-1.5 9h3a2.5 2.5 0 0 1 2.5 2.5V14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1.5A2.5 2.5 0 0 1 6.5 10ZM8 9C6.368 9 5 7.684 5 6s1.316-3 3-3c1.632 0 3 1.316 3 3S9.632 9 8 9"/>
 </svg>
-{% endif -%}
+{%- endif -%}
 {{- item.html | safe if item.html else item.text -}}
 {% endmacro %}
 
@@ -79,10 +79,16 @@
         <li class="nhsuk-header__account-item {%- if item.classes %} {{ item.classes }}{% endif %}">
         {% if item.href %}
           <a class="nhsuk-header__account-link" href="{{ item.href }}">
-            {{ _accountItem(item) }}
+            {{- _accountItem(item) -}}
           </a>
+        {% elif item.action %}
+          <form class="nhsuk-header__account-form" action="{{ item.action }}" method="{{ item.method or "post" }}">
+            <button class="nhsuk-header__account-button">
+              {{- _accountItem(item) -}}
+            </button>
+          </form>
         {% else %}
-          {{ _accountItem(item) }}
+          {{- _accountItem(item) -}}
         {% endif %}
         </li>
         {% endif %}


### PR DESCRIPTION
## Description

Some items in the header account area, but most likely any ‘Log out’ button, will require form submission rather than linking to a page.

This PR adds support for having button items (in addition to having a link or only text), and adds the following 2 options:

`[]item.action` – The form action, for example `"/log-out"`
`[]item.method` – The form method, optional and defaults to `"post"`

If you provide `item.action`, a button will be used instead. Using `item.href` will override any `item.action` parameter.

These options currently presume the presence of a surrounding `<form>`; perhaps we should add a `<form>` element if you use one or more `item.action` parameters?

The button is styled to look and behave like a link:

<p><img width="408" alt="Screenshot of header navigation with ‘Log out’ button styled as a link." src="https://github.com/user-attachments/assets/5fdd4bd9-325d-49f7-936b-7a470a8a86a0" /></p>

If this PR is accepted, we’d need to update the service manual guidance… and possibly add some information around when you might want to use a button instead of a link.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
