### PR TITLE
WIP Initial implementation of the dl table view

### DIFF
--- a/packages/components/tables/_tables.scss
+++ b/packages/components/tables/_tables.scss
@@ -81,6 +81,38 @@
 /// 9. Hiding mobile specific header from desktop view
 /// 10. Adding a display block value due to IE 11 not having full flex support
 
+figure.nhsuk-table__list-view-container {
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  figcaption {
+    @include nhsuk-font($size: 22, $weight: bold);
+    text-align: left;
+  }
+
+  .nhsuk-table__list-view dl.nhsuk-table__row {
+    .nhsuk-table__cell {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+
+      padding: nhsuk-spacing(2) nhsuk-spacing(3) nhsuk-spacing(2) 0;
+
+      &:last-child {
+        border-bottom: 3px solid $color_nhsuk-grey-4;
+      }
+
+      dd {
+        margin-inline-start: 0;
+        box-sizing: border-box;
+      }
+      dt {
+        text-align: right;
+        box-sizing: border-box;
+      }
+    }
+  }
+}
+
 .nhsuk-table-responsive {
   margin-bottom: 0;
   width: 100%;
@@ -99,6 +131,7 @@
   }
 
   .nhsuk-table__body {
+
     .nhsuk-table-responsive__heading {
       font-weight: $nhsuk-font-bold;
       padding-right: nhsuk-spacing(3);
@@ -159,6 +192,24 @@
         display: table-cell;
       }
     }
+  }
+}
+
+@include mq($until: desktop) {
+  .nhsuk-table__list-view-container, .nhsuk-table__list-view-container dl.nhsuk-table__row {
+    display: block;
+  }
+  table.nhsuk-table-responsive{
+    display: none;
+  }
+}
+
+@include mq($from: desktop) {
+  .nhsuk-table__list-view-container, .nhsuk-table__list-view-container dl.nhsuk-table__row {
+    display: none;
+  }
+  table.nhsuk-table-responsive {
+    display: block;
   }
 }
 

--- a/packages/components/tables/template.njk
+++ b/packages/components/tables/template.njk
@@ -8,6 +8,26 @@
     <h{{ headingLevel }} class="nhsuk-table__heading-tab">{{ params.heading | safe }}</h{{ headingLevel }}>
   {%- endif %}
   {%- endif %}
+
+  <figure class="nhsuk-table__list-view-container nhsuk-table-responsive">
+    {%- if params.caption %}
+      <figcaption class="nhsuk-table__caption--m
+    {%- if params.captionClasses %} {{ params.captionClasses }}{% endif %}">{{ params.caption }}</figcaption>
+    {%- endif %}
+    <div class="nhsuk-table__body nhsuk-table__list-view">
+    {%- for row in params.rows %}
+      <dl class="nhsuk-table__row">
+        {%- for cell in row %}
+          <div class="nhsuk-table__cell{% if cell.format %} nhsuk-table__cell--{{ cell.format }}{% endif %}">
+            <dd class="nhsuk-table-responsive__heading">{{cell.header}} </dd>
+            <dt>{{ cell.html | safe if cell.html else cell.text }}</dt>
+          </div>
+        {%- endfor %}
+      </dl>
+    {%- endfor %}
+    </div>
+  </figure>
+
   <table {%- if params.responsive %} role="table"{% endif %} class="nhsuk-table{%- if params.responsive %}-responsive{% endif %}
   {%- if params.tableClasses %} {{ params.tableClasses }}{% endif %}"
   {{- nhsukAttributes(params.attributes) }}>

--- a/packages/core/elements/_table.scss
+++ b/packages/core/elements/_table.scss
@@ -25,7 +25,8 @@ thead {
 }
 
 th,
-td {
+td,
+.nhsuk-table__cell {
   @include nhsuk-typography-responsive(19);
   @include nhsuk-responsive-padding(3, "bottom");
   @include nhsuk-responsive-padding(4, "right");


### PR DESCRIPTION
## Description

This patch is an implementation of the markup-swapping fix for #1092 . It introduces a few new elements: since the `table` uses a `caption` and we need to preserve that, but `caption` isn't valid outside a `table`, the `dl` implementation uses `figure` and `figcaption` to do the same job.

In its current state it is a relatively close match for the previous look and feel across the breakpoints but I haven't done a pixel-scale comparison yet.  There's also a failing test, thus the `WIP` title.  I'll fix that shortly, but this is pushed now in case anyone wants to tell me this is completely wrong in some respect.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
