### PR TITLE
Change how we tell backstop what hostname to use

### DIFF
--- a/backstop.config.js
+++ b/backstop.config.js
@@ -1,6 +1,11 @@
+function amInContainer() {
+  const fs = require('fs');
+  return fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv')
+}
+
 const {
   HOSTNAME = '0.0.0.0', // Default via `npm start`
-  BASE_HOST = HOSTNAME === 'docker-desktop' ? 'host.docker.internal' : HOSTNAME,
+  BASE_HOST = amInContainer() ? 'host.docker.internal' : HOSTNAME,
   BASE_URL = `http://${BASE_HOST}:3000/nhsuk-frontend`
 } = process.env
 


### PR DESCRIPTION
## Description

When running under `podman` rather than `docker-desktop`, the `HOSTNAME` check in `backstop.config.js` incorrectly causes the `BASE_HOST` to be set to `localhost.localdomain` rather than `host.docker.internal`.  This means all the tests fail because it can't see the server.

On the assumption that what we really care about is whether backstop is running in a container or not, this patch adds a check which will reliably detect when the tests are running in either `podman` or `docker`, and correctly override the `HOSTNAME`.

Now it's possible that since I've changed how the `HOSTNAME` environment variable is processed that this has broken something, elsewhere, but I can't see anything setting it in such a way as to have a problem with this change.  Since we shouldn't be using Docker Desktop thanks to the licensing, this change becomes necessary to support the natural alternative.

All visual tests pass with this in place.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
