### PR TITLE
Add static spacing override classes

### DIFF
--- a/packages/core/utilities/_spacing.scss
+++ b/packages/core/utilities/_spacing.scss
@@ -46,7 +46,36 @@ $_spacing-directions: ("top", "right", "bottom", "left") !default;
   }
 }
 
+/// Generate static spacing override classes
+///
+/// Generate spacing override classes for the given property (e.g. margin)
+/// for each point in the non-responsive spacing scale.
+///
+/// @param {String} $property - Property to add spacing to (e.g. 'margin')
+///
+/// @example css
+///   .nhsuk-u-static-margin-4 {
+///      margin: 24px !important;
+///   }
+///
+@mixin _nhsuk-generate-static-spacing-overrides($property) {
+  @each $spacing-point in map-keys($nhsuk-spacing-points) {
+    .nhsuk-u-static-#{$property}-#{$spacing-point} {
+      #{$property}: nhsuk-spacing($spacing-point) !important;
+    }
+
+    @each $direction in $_spacing-directions {
+      .nhsuk-u-static-#{$property}-#{$direction}-#{$spacing-point} {
+        #{$property}-#{$direction}: nhsuk-spacing($spacing-point) !important;
+      }
+    }
+  }
+}
+
 @include govuk-exports("govuk/overrides/spacing") {
   @include _nhsuk-generate-spacing-overrides("margin");
   @include _nhsuk-generate-spacing-overrides("padding");
+
+  @include _nhsuk-generate-static-spacing-overrides("margin");
+  @include _nhsuk-generate-static-spacing-overrides("padding");
 }


### PR DESCRIPTION
## Description

Add spacing override classes (eg: nhsuk-u-static-margin-bottom-4) that use the static spacing scale rather than the [responsive spacing scale](https://service-manual.nhs.uk/design-system/styles/spacing#spacing-scale).

[Code taken from the govuk-frontend](https://github.com/alphagov/govuk-frontend/pull/2672)

[Static spacing guidance on the GOV.UK Design System](https://design-system.service.gov.uk/styles/spacing/#static-spacing)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
