### PR TITLE
Exit Jest dev server in `--watch` teardown

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -40,7 +40,7 @@ module.exports = {
   server: BASE_URL
     ? undefined
     : {
-        command: 'npx gulp docs:serve',
+        command: 'gulp docs:serve',
         port: PORT,
 
         // Skip when already running

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,8 @@ module.exports = {
     {
       displayName: 'Pupppeteer',
       globalSetup: 'jest-environment-puppeteer/setup',
-      globalTeardown: 'jest-environment-puppeteer/teardown',
+      globalTeardown:
+        '<rootDir>/tests/integration/puppeteer/environment/teardown.mjs',
       testEnvironment: 'jest-environment-puppeteer',
       testMatch: ['<rootDir>/tests/integration/puppeteer/**/*.test.js']
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "html-validate": "^9.4.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-environment-puppeteer": "^11.0.0",
         "jest-puppeteer": "^11.0.0",
         "nunjucks": "^3.2.4",
         "playwright": "^1.50.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "html-validate": "^9.4.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-environment-puppeteer": "^11.0.0",
     "jest-puppeteer": "^11.0.0",
     "nunjucks": "^3.2.4",
     "playwright": "^1.50.1",

--- a/tests/integration/puppeteer/environment/teardown.mjs
+++ b/tests/integration/puppeteer/environment/teardown.mjs
@@ -1,0 +1,11 @@
+import teardown from 'jest-environment-puppeteer/teardown'
+
+/**
+ * Close browser
+ *
+ * @param {import('jest').Config} jestConfig - Jest config
+ */
+export default (jestConfig) => {
+  // Close browser, stop server (also in watch mode)
+  return teardown({ ...jestConfig, watch: false })
+}


### PR DESCRIPTION
## Description

This PR is a workaround for [`jest --watch` skipping server exit](https://github.com/argos-ci/jest-puppeteer/blob/v11.0.0/packages/jest-environment-puppeteer/src/global-init.ts#L89-L92) on teardown

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
