### PR TITLE
Increase `misMatchThreshold` for smaller images

### DIFF
--- a/backstop.config.js
+++ b/backstop.config.js
@@ -69,7 +69,7 @@ module.exports = {
     headless: HEADLESS !== 'false'
   },
   fileNameTemplate: '{scenarioLabel}_{viewportLabel}',
-  misMatchThreshold: 0.3,
+  misMatchThreshold: 0.8,
   onBeforeScript: 'playwright/onBefore.js',
   onReadyScript: 'playwright/onReady.js',
   paths: {


### PR DESCRIPTION
Looks like recent GitHub Actions workflow runs are seeing a slight diff for SVG rendering

I've increased the diff percentage allowed to give us time to investigate other flags such as:

```console
--disable-partial-raster
--gpu-rasterization-msaa-sample-count
```

**Note:** Images are smaller since https://github.com/nhsuk/nhsuk-frontend/pull/1180 so makes sense to increase the threshold