### PR TITLE
Add white and blue panel variants

### DIFF
--- a/app/components/panel/blue.njk
+++ b/app/components/panel/blue.njk
@@ -1,0 +1,26 @@
+{% set title = 'Panel - blue' %}
+{% from 'components/panel/macro.njk' import panel %}
+{% from 'components/button/macro.njk' import button %}
+
+{% extends 'example.njk' %}
+
+{% set panelHtml %}
+  <p class="nhsuk-body nhsuk-u-margin-bottom-6">Some text to explain what you are doing, and to check you’ve understood the consequences.</p>
+  {{ button({
+    text: "I understand, continue anyway",
+    href: "#",
+    classes: "nhsuk-button--reverse"
+  }) }}
+{% endset %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ panel({
+        titleText: "You are doing something unusual",
+        html: panelHtml,
+        classes: "nhsuk-panel--blue"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/components/panel/white.njk
+++ b/app/components/panel/white.njk
@@ -1,0 +1,23 @@
+{% set title = 'Panel - white' %}
+{% from 'components/panel/macro.njk' import panel %}
+{% from 'components/button/macro.njk' import button %}
+
+{% extends 'example.njk' %}
+
+{% set panelHtml %}
+  <p class="nhsuk-body nhsuk-u-margin-bottom-0">This is another short line of content.</p>
+{% endset %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ panel({
+        titleText: "This is a title",
+        headingLevel: 2,
+        headingClasses: "nhsuk-panel__title--s",
+        html: panelHtml,
+        classes: "nhsuk-panel--white"
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/pages/examples.njk
+++ b/app/pages/examples.njk
@@ -106,6 +106,8 @@
     <li><a href="../components/label/page-heading.html">Label as page heading</a></li>
     <li><a href="../components/pagination/index.html">Pagination</a></li>
     <li><a href="../components/panel/index.html">Panel</a></li>
+    <li><a href="../components/panel/blue.html">Panel - blue</a></li>
+    <li><a href="../components/panel/white.html">Panel - white</a></li>
     <li><a href="../components/radios/index.html">Radios</a></li>
     <li><a href="../components/radios/inline.html">Radios inline</a></li>
     <li><a href="../components/radios/disabled.html">Radios disabled</a></li>

--- a/packages/components/panel/_panel.scss
+++ b/packages/components/panel/_panel.scss
@@ -42,11 +42,26 @@ $nhsuk-border-width-panel: nhsuk-spacing(1);
   }
 }
 
+.nhsuk-panel--blue {
+  background-color: $color_nhsuk-blue;
+}
+
+.nhsuk-panel--white {
+  background-color: $color_nhsuk-white;
+  color: $color_nhsuk-black;
+  border-color: $color_nhsuk-blue;
+}
+
 .nhsuk-panel__title {
   @include nhsuk-typography-responsive(48);
   @include nhsuk-responsive-margin(5, "bottom");
 
   margin-top: 0;
+}
+
+.nhsuk-panel__title--s {
+  @include nhsuk-typography-responsive(22);
+  @include nhsuk-responsive-margin(4, "bottom");
 }
 
 .nhsuk-panel__title:last-child {

--- a/packages/components/panel/template.njk
+++ b/packages/components/panel/template.njk
@@ -5,7 +5,7 @@
 <div class="nhsuk-panel
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- nhsukAttributes(params.attributes) }}>
-  <h{{ headingLevel }} class="nhsuk-panel__title">
+  <h{{ headingLevel }} class="nhsuk-panel__title{% if params.headingClasses %} {{ params.headingClasses }}{% endif %}">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h{{ headingLevel }}>
   {% if caller or params.html or params.text %}


### PR DESCRIPTION
This adds 2 new variants of the Panel component, one with a solid blue background, and one with a white background but a blue border.

An additional `headingClasses` param is also added to enable a smaller title size class (`nhsuk-panel__title--s`).

## Blue panel

<img width="989" alt="Screenshot 2025-03-21 at 15 55 38" src="https://github.com/user-attachments/assets/d61b3604-4b9d-4c31-b882-36fceda6d5a5" />

This is intended for use when you need to stop users in a journey to tell them important information. This should be used vary sparingly, as there is some evidence that users can end up ignoring it, however it could work in some contexts, such as when shown after many regular pages with the off-white background.

The blue panel would be used with the [reversed Button variant](https://service-manual.nhs.uk/design-system/components/buttons#reverse-button) - which already mentions ‘interruption cards’ in the guidance.

See relevant threads for examples and discussion:

* [Stop users in a journey to tell them important information](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/241) on NHS design backlog
* [Interruption card](https://github.com/alphagov/govuk-design-system-backlog/issues/27) on GOVUK design backlog
* [Interruption card](https://design-patterns.service.justice.gov.uk/components/interruption-card/) in MoJ Design System

## White panel

<img width="1030" alt="Screenshot 2025-03-21 at 16 03 50" src="https://github.com/user-attachments/assets/2917424f-b8c0-49cb-ae56-69edd824d0db" />

This is intended for secondary content on the page, and would appear above the main content, such as an invitation to complete a survey, or to submit feedback about something you’ve just done.

It could be contain the upcoming new [Secondary button style](https://github.com/nhsuk/nhsuk-frontend/pull/1077).

See example: [Add feedback panel](https://github.com/NHSDigital/record-a-vaccination-prototype/pull/249):

<img width="601" alt="Screenshot 2025-03-21 at 16 10 50" src="https://github.com/user-attachments/assets/fff8eaae-ed8e-4cf5-806d-a69e6e6b817d" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
