### PR TITLE
Add bottom padding to `nhsuk-main-wrapper--l` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ We've configured our build tasks to use [Browserslist](https://browsersl.ist) fo
 - Changed JavaScript minifier from [`uglify-js`](https://www.npmjs.com/package/uglify-js) to [`terser`](https://www.npmjs.com/package/terser) with compatibility workarounds
 - Fixed JavaScript build to ensure Babel uses [Browserslist](https://browsersl.ist) configured browsers
 - Fixed JavaScript build to ensure only `nhsuk.min.js` is minified not `nhsuk.js`
+- Fixed bottom padding on the `nhsuk-main-wrapper--l` modifier class
 
 We've made fixes to NHS.UK frontend in the following pull requests:
 

--- a/packages/core/objects/_main-wrapper.scss
+++ b/packages/core/objects/_main-wrapper.scss
@@ -30,9 +30,11 @@
 }
 
 @mixin govuk-main-wrapper--l {
+  padding-bottom: nhsuk-spacing(6);
   padding-top: nhsuk-spacing(6);
 
   @include mq($from: tablet) {
+    padding-bottom: nhsuk-spacing(8);
     padding-top: nhsuk-spacing(8);
   }
 }


### PR DESCRIPTION
## Description

Added bottom padding to the `nhsuk-main-wrapper--l` modifier class.

It was using the bottom padding from the `nhsuk-main-wrapper` class, which is too small.

| Before | After |
| -------|-------|
| <img width="421" alt="Screenshot 2025-03-28 at 13 31 01" src="https://github.com/user-attachments/assets/bcf64f2f-0644-4388-a5d2-5a0ac68e2966" /> | <img width="428" alt="Screenshot 2025-03-28 at 13 30 32" src="https://github.com/user-attachments/assets/895d58dc-c8c7-4075-b27c-d6c46f6ee017" /> |

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
