### PR TITLE
Fix Nunjucks code snippet typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ You can now add `classes` and `attributes` to table cells, for example using the
       {
         text: "aleksandrina.featherstonehaughwhitehead23@folkestonepharmacy.test.com",
         classes: "nhsuk-u-text-break-word"
-      },
+      }
     ]
   ]
 }) }}


### PR DESCRIPTION
## Description
Causes error if copy and pasted (as I just did!).

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
