### PR TITLE
Run full build before docs deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Build dist
-        run: npx gulp build
+      - name: Build
+        run: npm run build
 
       - name: Deploy GitHub pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build dist
-        run: npx gulp build
+      - name: Build
+        run: npm run build
 
       - name: Run linting
         run: npm run lint


### PR DESCRIPTION
## Description

This PR restores ~`npx gulp docs:build`~ `npm run build` before deployments

Otherwise the CSS and JS files aren't available to copy into `dist/app`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
