### PR TITLE
Add syntax highlighting to fenced code blocks in readmes

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -5,12 +5,39 @@ module.exports = {
     '**/vendor/**',
 
     // Ignore CSS-in-JS (including dotfiles)
-    '**/?(.)*.{cjs,js,mjs}'
+    '**/?(.)*.{cjs,js,mjs}',
+
+    // Prevent CHANGELOG history changes
+    'CHANGELOG.md'
   ],
   overrides: [
     {
       customSyntax: 'postcss-markdown',
       files: ['**/*.md']
+    },
+    {
+      customSyntax: 'postcss-markdown',
+      files: ['**/coding-standards.md', '**/linting.md'],
+      rules: {
+        // Allow markdown `*.md` CSS bad examples
+        'block-no-empty': null,
+        'color-hex-length': null,
+        'declaration-block-single-line-max-declarations': null,
+        'length-zero-no-unit': null,
+        'rule-empty-line-before': null,
+        'selector-max-id': null,
+        'shorthand-property-no-redundant-values': null,
+
+        // Allow markdown `*.md` Sass bad examples
+        'scss/at-if-no-null': null,
+        'scss/at-import-no-partial-leading-underscore': null,
+        'scss/at-import-partial-extension': null,
+        'scss/at-mixin-pattern': null,
+        'scss/at-rule-conditional-no-parentheses': null,
+        'scss/load-no-partial-leading-underscore': null,
+        'scss/load-partial-extension': null,
+        'scss/operator-no-unspaced': null
+      }
     },
     {
       customSyntax: 'postcss-markdown',

--- a/docs/contributing/automated-testing.md
+++ b/docs/contributing/automated-testing.md
@@ -35,7 +35,7 @@ Docker is installed on the continuous integration service automatically but if y
 
 #### Run tests
 
-```
+```sh
 npm run test:visual
 ```
 
@@ -51,7 +51,7 @@ If you run tests frequently, your `tests/backstop/<timestamp>/` folder may have 
 
 To run a test on an individual scenario, pass a `--filter<scenarioLabelRegex>` argument to just run scenarios matching your scenario label.
 
-```shell
+```sh
 npm run test:visual -- --filter="Action link"
 ```
 
@@ -63,7 +63,7 @@ If you have made intentional visual changes, the reference bitmaps need to be up
 
 After running the tests (`npm run test:visual`) you can update the reference screenshots with:
 
-```shell
+```sh
 npm run test:visual:approve
 ```
 
@@ -71,7 +71,7 @@ npm run test:visual:approve
 
 If you want to add new tests you will need to add the test scenarios to the `backstop.js` file following the [scenario configuration guidelines](#tests-configuration). Once you have added the new tests you will need to update the reference bitmaps to include a reference for the new tests.
 
-```shell
+```sh
 npm run test:visual:ref
 ```
 

--- a/docs/contributing/automated-testing.md
+++ b/docs/contributing/automated-testing.md
@@ -51,7 +51,7 @@ If you run tests frequently, your `tests/backstop/<timestamp>/` folder may have 
 
 To run a test on an individual scenario, pass a `--filter<scenarioLabelRegex>` argument to just run scenarios matching your scenario label.
 
-```
+```shell
 npm run test:visual -- --filter="Action link"
 ```
 
@@ -63,7 +63,7 @@ If you have made intentional visual changes, the reference bitmaps need to be up
 
 After running the tests (`npm run test:visual`) you can update the reference screenshots with:
 
-```
+```shell
 npm run test:visual:approve
 ```
 
@@ -71,7 +71,7 @@ npm run test:visual:approve
 
 If you want to add new tests you will need to add the test scenarios to the `backstop.js` file following the [scenario configuration guidelines](#tests-configuration). Once you have added the new tests you will need to update the reference bitmaps to include a reference for the new tests.
 
-```
+```shell
 npm run test:visual:ref
 ```
 

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -239,13 +239,13 @@ When providing _content_ to a macro, say for a label or a button, we accept two 
 
 Example:
 
-```nunjucks
+```njk
 {{ insetText({
   "text": "You'll need to stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
 }) }}
 ```
 
-```nunjucks
+```njk
 {{ insetText({
   "html": "<p>If you drive you must tell the <a href='https://www.gov.uk/contact-the-dvla/' title='External website'>DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href='https://www.gov.uk/dizziness-and-driving' title='External website'>driving with vertigo</a></p>"
 }) }}

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -239,13 +239,13 @@ When providing _content_ to a macro, say for a label or a button, we accept two 
 
 Example:
 
-```
+```nunjucks
 {{ insetText({
   "text": "You'll need to stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
 }) }}
 ```
 
-```
+```nunjucks
 {{ insetText({
   "html": "<p>If you drive you must tell the <a href='https://www.gov.uk/contact-the-dvla/' title='External website'>DVLA</a> about your vertigo. Visit the GOV.UK website for more information on <a href='https://www.gov.uk/dizziness-and-driving' title='External website'>driving with vertigo</a></p>"
 }) }}

--- a/docs/contributing/linting.md
+++ b/docs/contributing/linting.md
@@ -12,13 +12,13 @@ We use the following rules when linting files:
 
 Bad:
 
-```
+```scss
 .selector {border: 0; padding: 0;}
 ```
 
 Good:
 
-```
+```scss
 .selector {
   border: 0;
   padding: 0;
@@ -29,7 +29,7 @@ Good:
 
 Bad:
 
-```
+```scss
 .selector {
   color: #005eb8;
 }
@@ -37,7 +37,7 @@ Bad:
 
 Good:
 
-```
+```scss
 .selector {
   color: $colour_nhsuk-blue;
 }
@@ -47,13 +47,13 @@ Good:
 
 Bad:
 
-```
+```scss
 $white: #FFF;
 ```
 
 Good:
 
-```
+```scss
 $white: #ffffff;
 ```
 
@@ -61,7 +61,7 @@ $white: #ffffff;
 
 Bad:
 
-```
+```scss
 .selector {
   border: none;
 }
@@ -69,7 +69,7 @@ Bad:
 
 Good:
 
-```
+```scss
 .selector {
   border: 0;
 }
@@ -79,17 +79,17 @@ Good:
 
 Bad:
 
-```
+```scss
 #content {
-  ...
+  // ...
 }
 ```
 
 Good:
 
-```
+```scss
 .nhsuk-wrapper {
-  ...
+  // ...
 }
 ```
 
@@ -97,31 +97,31 @@ Good:
 
 Bad:
 
-```
+```scss
 p {
   margin: 0;
   em {
-    ...
+    // ...
   }
 }
 a {
-  ...
+  // ...
 }
 ```
 
 Good:
 
-```
+```scss
 p {
   margin: 0;
 
   em {
-    ...
+    // ...
   }
 }
 
 a {
-  ...
+  // ...
 }
 ```
 
@@ -129,24 +129,24 @@ a {
 
 Bad:
 
-```
+```scss
 .nhsuk-breadcrumb {
-  ...
+  // ...
   &__item {
-    ...
+    // ...
   }
 }
 ```
 
 Good:
 
-```
+```scss
 .nhsuk-breadcrumb {
-  ...
+  // ...
 }
 
 .nhsuk-breadcrumb__item {
-  ...
+  // ...
 }
 ```
 
@@ -154,13 +154,13 @@ Good:
 
 Bad:
 
-```
+```scss
 @extend %contain-floats;
 ```
 
 Good:
 
-```
+```scss
 @include clearfix;
 ```
 
@@ -186,14 +186,14 @@ margin: 1px 2px 3px;
 
 Bad:
 
-```
+```scss
 @import "_foo.scss";
 @import "_bar/foo.scss";
 ```
 
 Good:
 
-```
+```scss
 @import "foo";
 @import "bar/foo";
 ```
@@ -202,7 +202,7 @@ Good:
 
 Bad:
 
-```
+```scss
 .foo {
   content:"bar";
 }
@@ -210,7 +210,7 @@ Bad:
 
 Good:
 
-```
+```scss
 .foo {
   content: "bar";
 }
@@ -220,7 +220,7 @@ Good:
 
 Bad:
 
-```
+```scss
 .selector {
   margin: 5px+15px;
 }
@@ -246,7 +246,7 @@ $bar: 2-1;
 
 Good:
 
-```
+```scss
 .selector {
   margin: 5px + 15px;
 }
@@ -274,7 +274,7 @@ $bar: 2 - 1;
 
 Bad:
 
-```
+```scss
 @function foo( $bar, $baz ) {
   @return $bar + $baz;
 }
@@ -282,7 +282,7 @@ Bad:
 
 Good:
 
-```
+```scss
 @function foo($bar, $baz) {
   @return $bar + $baz;
 }
@@ -292,7 +292,7 @@ Good:
 
 Bad:
 
-```
+```scss
 @mixin FONT_STACK() {
   font-family: $nhsuk-font-stack;
 }
@@ -300,7 +300,7 @@ Bad:
 
 Good:
 
-```
+```scss
 @mixin font-stack() {
   font-family: $nhsuk-font-stack;
 }
@@ -310,7 +310,7 @@ Good:
 
 Bad:
 
-```
+```scss
 .selector {
   margin: 0px;
 }
@@ -318,7 +318,7 @@ Bad:
 
 Good:
 
-```
+```scss
 .selector {
   margin: 0;
 }
@@ -328,7 +328,7 @@ Good:
 
 Bad:
 
-```
+```scss
 .selector {
   margin: 0
 }
@@ -338,7 +338,7 @@ $my-example-var: value
 
 Good:
 
-```
+```scss
 .selector {
   margin: 0;
 }
@@ -350,7 +350,7 @@ $my-example-var: value;
 
 Bad:
 
-```
+```scss
 .selector {
   font-size: 0.50em;
 }
@@ -358,7 +358,7 @@ Bad:
 
 Good:
 
-```
+```scss
 .selector {
   font-size: 0.5em;
 }

--- a/docs/contributing/linting.md
+++ b/docs/contributing/linting.md
@@ -221,14 +221,14 @@ Good:
 Bad:
 
 ```scss
-.selector {
+.selector-1 {
   margin: 5px+15px;
 }
 
 $foo: 1;
 $bar: 3;
 
-.selector {
+.selector-2 {
   margin: $foo+$bar+'px';
 }
 
@@ -247,14 +247,14 @@ $bar: 2-1;
 Good:
 
 ```scss
-.selector {
+.selector-1 {
   margin: 5px + 15px;
 }
 
 $foo: 1;
 $bar: 3;
 
-.selector {
+.selector-2 {
   margin: $foo + $bar + 'px';
 }
 
@@ -265,7 +265,7 @@ $bar: 2 - 1;
   $baz: 1;
 }
 
-@if ($foo != $bar) {
+@if $foo != $bar {
   $baz: 1;
 }
 ```

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -20,13 +20,13 @@ To run NHS.UK frontend locally you'll need to:
 
 You can clone the repository directly if you're a member of the [NHS.UK GitHub organisation](https://github.com/nhsuk/)
 
-```shell
+```sh
 git clone git@github.com:nhsuk/nhsuk-frontend.git nhsuk-frontend
 ```
 
 Otherwise you'll have to clone your own fork
 
-```shell
+```sh
 git clone https://github.com/[Username]/nhsuk-frontend.git nhsuk-frontend
 ```
 
@@ -38,11 +38,11 @@ We use [node package manager (npm)](https://docs.npmjs.com/getting-started/what-
 
 Whilst in the project directory you will need to install the dependencies listed in `package.json`
 
-```shell
+```sh
 cd nhsuk-frontend
 ```
 
-```shell
+```sh
 npm install
 ```
 
@@ -50,7 +50,7 @@ npm install
 
 This will build files, serve web pages and watch for changes when you save a file.
 
-```shell
+```sh
 npm start
 ```
 

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -20,13 +20,13 @@ To run NHS.UK frontend locally you'll need to:
 
 You can clone the repository directly if you're a member of the [NHS.UK GitHub organisation](https://github.com/nhsuk/)
 
-```
+```shell
 git clone git@github.com:nhsuk/nhsuk-frontend.git nhsuk-frontend
 ```
 
 Otherwise you'll have to clone your own fork
 
-```
+```shell
 git clone https://github.com/[Username]/nhsuk-frontend.git nhsuk-frontend
 ```
 
@@ -38,11 +38,11 @@ We use [node package manager (npm)](https://docs.npmjs.com/getting-started/what-
 
 Whilst in the project directory you will need to install the dependencies listed in `package.json`
 
-```
+```shell
 cd nhsuk-frontend
 ```
 
-```
+```shell
 npm install
 ```
 
@@ -50,7 +50,7 @@ npm install
 
 This will build files, serve web pages and watch for changes when you save a file.
 
-```
+```shell
 npm start
 ```
 

--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -48,7 +48,7 @@ If you require any of this functionality, you should [install using npm](/docs/i
 
    Add the following JavaScript to the top of the `<body>` section of your page template:
 
-   ```
+   ```html
    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
    ```
 

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -12,7 +12,7 @@ To use NHS.UK frontend in your projects with npm you must:
 
 4. (Optional) If you want to use our [Nunjucks](https://mozilla.github.io/nunjucks/) macros, you will need to install Nunjucks. [Nunjucks macros](https://mozilla.github.io/nunjucks/templating.html#macro) allows you to define reusable chunks of content. It is similar to a function in a programming language.
 
-   ```
+   ```shell
    npm install nunjucks --save
    ```
 
@@ -20,7 +20,7 @@ To use NHS.UK frontend in your projects with npm you must:
 
 Install the NHS.UK frontend package into your project:
 
-```
+```shell
 npm install nhsuk-frontend --save
 ```
 
@@ -60,7 +60,7 @@ You should include NHS.UK frontend JavaScript in your project to ensure that all
 
 Add the following JavaScript to the top of the `<body>` section of your page template:
 
-```
+```javascript
 document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 ```
 

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -12,7 +12,7 @@ To use NHS.UK frontend in your projects with npm you must:
 
 4. (Optional) If you want to use our [Nunjucks](https://mozilla.github.io/nunjucks/) macros, you will need to install Nunjucks. [Nunjucks macros](https://mozilla.github.io/nunjucks/templating.html#macro) allows you to define reusable chunks of content. It is similar to a function in a programming language.
 
-   ```shell
+   ```sh
    npm install nunjucks --save
    ```
 
@@ -20,7 +20,7 @@ To use NHS.UK frontend in your projects with npm you must:
 
 Install the NHS.UK frontend package into your project:
 
-```shell
+```sh
 npm install nhsuk-frontend --save
 ```
 
@@ -60,7 +60,7 @@ You should include NHS.UK frontend JavaScript in your project to ensure that all
 
 Add the following JavaScript to the top of the `<body>` section of your page template:
 
-```javascript
+```js
 document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 ```
 
@@ -86,7 +86,7 @@ You might wish to copy the file into your project or reference it straight from 
 
 If you're using a transpiler or bundler such as [Babel](https://babeljs.io/) or [Webpack](https://webpack.js.org/), you can use the ES6 import syntax to import components via modules into your main Javascript file.
 
-```javascript
+```js
 // Components
 import Checkboxes from 'nhsuk-frontend/packages/components/checkboxes/checkboxes.js';
 import Details from 'nhsuk-frontend/packages/components/details/details.js';

--- a/packages/components/action-link/README.md
+++ b/packages/components/action-link/README.md
@@ -24,7 +24,7 @@ Find out more about the action link component and when to use it in the [NHS dig
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/action-link/macro.njk' import actionLink %}
 
 {{ actionLink({

--- a/packages/components/action-link/README.md
+++ b/packages/components/action-link/README.md
@@ -24,7 +24,7 @@ Find out more about the action link component and when to use it in the [NHS dig
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/action-link/macro.njk' import actionLink %}
 
 {{ actionLink({

--- a/packages/components/back-link/README.md
+++ b/packages/components/back-link/README.md
@@ -23,7 +23,7 @@ Find out more about the back link component and when to use it in the [NHS digit
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/back-link/macro.njk' import backLink %}
 
 {{ backLink({
@@ -51,7 +51,7 @@ Find out more about the back link component and when to use it in the [NHS digit
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/back-link/macro.njk' import backLink %}
 
 {{ backLink({

--- a/packages/components/back-link/README.md
+++ b/packages/components/back-link/README.md
@@ -23,7 +23,7 @@ Find out more about the back link component and when to use it in the [NHS digit
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/back-link/macro.njk' import backLink %}
 
 {{ backLink({
@@ -51,7 +51,7 @@ Find out more about the back link component and when to use it in the [NHS digit
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/back-link/macro.njk' import backLink %}
 
 {{ backLink({

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -30,7 +30,7 @@ Find out more about the breadcrumb component and when to use it in the [NHS digi
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/breadcrumb/macro.njk' import breadcrumb %}
 
 {{ breadcrumb({

--- a/packages/components/breadcrumb/README.md
+++ b/packages/components/breadcrumb/README.md
@@ -30,7 +30,7 @@ Find out more about the breadcrumb component and when to use it in the [NHS digi
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/breadcrumb/macro.njk' import breadcrumb %}
 
 {{ breadcrumb({

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -20,7 +20,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -44,7 +44,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -69,7 +69,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -94,7 +94,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -119,7 +119,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -144,7 +144,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -167,7 +167,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({

--- a/packages/components/button/README.md
+++ b/packages/components/button/README.md
@@ -20,7 +20,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -44,7 +44,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -69,7 +69,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -94,7 +94,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -119,7 +119,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -144,7 +144,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({
@@ -167,7 +167,7 @@ Find out more about the button component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/button/macro.njk' import button %}
 
 {{ button({

--- a/packages/components/card/README.md
+++ b/packages/components/card/README.md
@@ -12,7 +12,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <div class="nhsuk-card">
   <div class="nhsuk-card__content">
     <h3 class="nhsuk-card__heading">If you need help now, but it’s not an emergency</h3>
@@ -23,7 +23,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -39,7 +39,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <div class="nhsuk-card nhsuk-card--clickable">
   <div class="nhsuk-card__content nhsuk-card__content--primary">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -53,7 +53,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -72,7 +72,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <div class="nhsuk-card nhsuk-card--clickable nhsuk-card--secondary">
   <div class="nhsuk-card__content nhsuk-card__content--secondary">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
@@ -85,7 +85,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
     {{ card({
@@ -104,7 +104,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <div class="nhsuk-card nhsuk-card--clickable ">
   <img class="nhsuk-card__img" src="https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg" alt="">
   <div class="nhsuk-card__content">
@@ -120,7 +120,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -139,7 +139,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <h2>Halves</h2>
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
@@ -274,7 +274,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 <h2>Halves</h2>
@@ -386,7 +386,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### HTML markup
 
-```
+```html
 <div class="nhsuk-card nhsuk-card--feature ">
   <div class="nhsuk-card__content
    nhsuk-card__content--feature ">
@@ -400,7 +400,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -439,7 +439,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -488,7 +488,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -536,7 +536,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({

--- a/packages/components/card/README.md
+++ b/packages/components/card/README.md
@@ -23,7 +23,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -53,7 +53,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -85,7 +85,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
     {{ card({
@@ -120,7 +120,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -274,7 +274,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 <h2>Halves</h2>
@@ -400,7 +400,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -439,7 +439,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -488,7 +488,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({
@@ -536,7 +536,7 @@ Find out more about the card component and when to use it in the [NHS digital se
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/card/macro.njk' import card %}
 
 {{ card({

--- a/packages/components/character-count/README.md
+++ b/packages/components/character-count/README.md
@@ -33,7 +33,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
@@ -78,7 +78,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
@@ -124,7 +124,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({

--- a/packages/components/character-count/README.md
+++ b/packages/components/character-count/README.md
@@ -33,7 +33,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
@@ -78,7 +78,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
@@ -124,7 +124,7 @@ Find out more about the character component and when to use it in the [NHS digit
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/character-count/macro.njk' import characterCount %}
 
 {{ characterCount({

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -47,7 +47,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -120,7 +120,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -188,7 +188,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -256,7 +256,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -331,7 +331,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -430,7 +430,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 {% from 'components/input/macro.njk' import input %}
 
@@ -578,7 +578,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 {% from 'components/input/macro.njk' import input %}
 

--- a/packages/components/checkboxes/README.md
+++ b/packages/components/checkboxes/README.md
@@ -47,7 +47,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -120,7 +120,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -188,7 +188,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -256,7 +256,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -331,7 +331,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
@@ -430,7 +430,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 {% from 'components/input/macro.njk' import input %}
 
@@ -578,7 +578,7 @@ Find out more about the checkboxes component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/checkboxes/macro.njk' import checkboxes %}
 {% from 'components/input/macro.njk' import input %}
 

--- a/packages/components/contents-list/README.md
+++ b/packages/components/contents-list/README.md
@@ -35,7 +35,7 @@ Find out more about the contents list component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/contents-list/macro.njk' import contentsList %}
 
 {{ contentsList({

--- a/packages/components/contents-list/README.md
+++ b/packages/components/contents-list/README.md
@@ -35,7 +35,7 @@ Find out more about the contents list component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/contents-list/macro.njk' import contentsList %}
 
 {{ contentsList({

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -55,7 +55,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -139,7 +139,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -225,7 +225,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -310,7 +310,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({

--- a/packages/components/date-input/README.md
+++ b/packages/components/date-input/README.md
@@ -55,7 +55,7 @@ Note: The `pattern` attribute is not valid HTML for inputs where the type attrib
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -139,7 +139,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -225,7 +225,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
@@ -310,7 +310,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/date-input/macro.njk' import dateInput %}
 
 {{ dateInput({

--- a/packages/components/details/README.md
+++ b/packages/components/details/README.md
@@ -40,7 +40,7 @@ For this component to be accessible and compatible with older browsers, include 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -122,7 +122,7 @@ Find out more about the expander component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -216,7 +216,7 @@ Find out more about the expander component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 <div class="nhsuk-expander-group">

--- a/packages/components/details/README.md
+++ b/packages/components/details/README.md
@@ -40,7 +40,7 @@ For this component to be accessible and compatible with older browsers, include 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -122,7 +122,7 @@ Find out more about the expander component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -216,7 +216,7 @@ Find out more about the expander component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/details/macro.njk' import details %}
 
 <div class="nhsuk-expander-group">

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -71,7 +71,7 @@ Find out more about the do and don't list component and when to use it in the [N
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/do-dont-list/macro.njk' import list %}
 
 {{ list({

--- a/packages/components/do-dont-list/README.md
+++ b/packages/components/do-dont-list/README.md
@@ -71,7 +71,7 @@ Find out more about the do and don't list component and when to use it in the [N
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/do-dont-list/macro.njk' import list %}
 
 {{ list({

--- a/packages/components/error-message/README.md
+++ b/packages/components/error-message/README.md
@@ -19,7 +19,7 @@ Find out more about the error message component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/error-message/macro.njk' import errorMessage %}
 
 {{ errorMessage({

--- a/packages/components/error-message/README.md
+++ b/packages/components/error-message/README.md
@@ -19,7 +19,7 @@ Find out more about the error message component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/error-message/macro.njk' import errorMessage %}
 
 {{ errorMessage({

--- a/packages/components/error-summary/README.md
+++ b/packages/components/error-summary/README.md
@@ -33,7 +33,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 
 {{ errorSummary({
@@ -103,7 +103,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 {% from 'components/input/macro.njk' import input %}
 
@@ -218,7 +218,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 {% from 'components/radios/macro.njk' import radios %}
 

--- a/packages/components/error-summary/README.md
+++ b/packages/components/error-summary/README.md
@@ -33,7 +33,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 
 {{ errorSummary({
@@ -103,7 +103,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 {% from 'components/input/macro.njk' import input %}
 
@@ -218,7 +218,7 @@ Find out more about the error summary component and when to use it in the [NHS d
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/error-summary/macro.njk' import errorSummary %}
 {% from 'components/radios/macro.njk' import radios %}
 

--- a/packages/components/fieldset/README.md
+++ b/packages/components/fieldset/README.md
@@ -22,7 +22,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
@@ -52,7 +52,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
@@ -111,7 +111,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 To add input fields inside the fieldset, use the `call` block.
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 {% from 'components/fieldset/macro.njk' import fieldset %}
 

--- a/packages/components/fieldset/README.md
+++ b/packages/components/fieldset/README.md
@@ -22,7 +22,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
@@ -52,7 +52,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
@@ -111,7 +111,7 @@ Find out more about the fieldset component and when to use it in the [NHS digita
 
 To add input fields inside the fieldset, use the `call` block.
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 {% from 'components/fieldset/macro.njk' import fieldset %}
 

--- a/packages/components/footer/README.md
+++ b/packages/components/footer/README.md
@@ -48,7 +48,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({
@@ -168,7 +168,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({
@@ -308,7 +308,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({

--- a/packages/components/footer/README.md
+++ b/packages/components/footer/README.md
@@ -48,7 +48,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({
@@ -168,7 +168,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({
@@ -308,7 +308,7 @@ Your copyright statement must reflect the ownership of your website or service. 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -104,7 +104,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -217,7 +217,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -287,7 +287,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -343,7 +343,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -378,7 +378,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -479,7 +479,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -603,7 +603,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -728,7 +728,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({

--- a/packages/components/header/README.md
+++ b/packages/components/header/README.md
@@ -104,7 +104,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -217,7 +217,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -287,7 +287,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -343,7 +343,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -378,7 +378,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -479,7 +479,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -603,7 +603,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
@@ -728,7 +728,7 @@ compiled JavaScript for all components `nhsuk.min.js` or the individual componen
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({

--- a/packages/components/hero/README.md
+++ b/packages/components/hero/README.md
@@ -25,7 +25,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({
@@ -62,7 +62,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({
@@ -89,7 +89,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({

--- a/packages/components/hero/README.md
+++ b/packages/components/hero/README.md
@@ -25,7 +25,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({
@@ -62,7 +62,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({
@@ -89,7 +89,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/hero/macro.njk' import hero %}
 
 {{ hero({

--- a/packages/components/hint/README.md
+++ b/packages/components/hint/README.md
@@ -18,7 +18,7 @@ Find out more about the hint component and when to use it in the [NHS digital se
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/hint/macro.njk' import hint %}
 
 {{ hint({

--- a/packages/components/hint/README.md
+++ b/packages/components/hint/README.md
@@ -18,7 +18,7 @@ Find out more about the hint component and when to use it in the [NHS digital se
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/hint/macro.njk' import hint %}
 
 {{ hint({

--- a/packages/components/images/README.md
+++ b/packages/components/images/README.md
@@ -24,7 +24,7 @@ Find out more about the images component and when to use it in the [NHS digital 
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/images/macro.njk' import image %}
 
 {{ image({

--- a/packages/components/images/README.md
+++ b/packages/components/images/README.md
@@ -24,7 +24,7 @@ Find out more about the images component and when to use it in the [NHS digital 
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/images/macro.njk' import image %}
 
 {{ image({

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -23,7 +23,7 @@ Find out more about the input component and when to use it in the [NHS digital s
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -58,7 +58,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -94,7 +94,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -137,7 +137,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -179,7 +179,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -218,7 +218,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -255,7 +255,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -293,7 +293,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -335,7 +335,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({

--- a/packages/components/input/README.md
+++ b/packages/components/input/README.md
@@ -23,7 +23,7 @@ Find out more about the input component and when to use it in the [NHS digital s
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -58,7 +58,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -94,7 +94,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -137,7 +137,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -179,7 +179,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -218,7 +218,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -255,7 +255,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -293,7 +293,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({
@@ -335,7 +335,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/input/macro.njk' import input %}
 
 {{ input({

--- a/packages/components/inset-text/README.md
+++ b/packages/components/inset-text/README.md
@@ -21,7 +21,7 @@ Find out more about the inset text component and when to use it in the [NHS digi
 
 If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
 
-```
+```nunjucks
 {% from 'components/inset-text/macro.njk' import insetText %}
 
 {{ insetText({

--- a/packages/components/inset-text/README.md
+++ b/packages/components/inset-text/README.md
@@ -21,7 +21,7 @@ Find out more about the inset text component and when to use it in the [NHS digi
 
 If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
 
-```nunjucks
+```njk
 {% from 'components/inset-text/macro.njk' import insetText %}
 
 {{ insetText({

--- a/packages/components/label/README.md
+++ b/packages/components/label/README.md
@@ -16,7 +16,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({
@@ -40,7 +40,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({
@@ -67,7 +67,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({

--- a/packages/components/label/README.md
+++ b/packages/components/label/README.md
@@ -16,7 +16,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({
@@ -40,7 +40,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({
@@ -67,7 +67,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/label/macro.njk' import label %}
 
 {{ label({

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -41,7 +41,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({
@@ -78,7 +78,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({
@@ -113,7 +113,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({

--- a/packages/components/pagination/README.md
+++ b/packages/components/pagination/README.md
@@ -41,7 +41,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({
@@ -78,7 +78,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({
@@ -113,7 +113,7 @@ Find out more about the pagination component and when to use it in the [NHS digi
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/pagination/macro.njk' import pagination %}
 
 {{ pagination({

--- a/packages/components/panel/README.md
+++ b/packages/components/panel/README.md
@@ -23,7 +23,7 @@ Find out more about the panel component and when to use it in the [NHS digital s
 
 ### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/panel/macro.njk' import panel %}
 
 {{ panel({

--- a/packages/components/panel/README.md
+++ b/packages/components/panel/README.md
@@ -23,7 +23,7 @@ Find out more about the panel component and when to use it in the [NHS digital s
 
 ### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/panel/macro.njk' import panel %}
 
 {{ panel({

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -41,7 +41,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -106,7 +106,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -172,7 +172,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -242,7 +242,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -315,7 +315,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -381,7 +381,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -443,7 +443,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -548,7 +548,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/radios/macro.njk' import radios %}
 {% from 'components/input/macro.njk' import input %}
 

--- a/packages/components/radios/README.md
+++ b/packages/components/radios/README.md
@@ -41,7 +41,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -106,7 +106,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -172,7 +172,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -242,7 +242,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -315,7 +315,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -381,7 +381,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -443,7 +443,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 
 {{ radios({
@@ -548,7 +548,7 @@ Find out more about the radios component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/radios/macro.njk' import radios %}
 {% from 'components/input/macro.njk' import input %}
 

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -27,7 +27,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/select/macro.njk' import select %}
 
 {{ select({
@@ -84,7 +84,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/select/macro.njk' import select %}
 
 {{ select({

--- a/packages/components/select/README.md
+++ b/packages/components/select/README.md
@@ -27,7 +27,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/select/macro.njk' import select %}
 
 {{ select({
@@ -84,7 +84,7 @@ Find out more about the select component and when to use it in the [NHS digital 
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/select/macro.njk' import select %}
 
 {{ select({

--- a/packages/components/summary-list/README.md
+++ b/packages/components/summary-list/README.md
@@ -74,7 +74,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({
@@ -201,7 +201,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({
@@ -292,7 +292,7 @@
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({

--- a/packages/components/summary-list/README.md
+++ b/packages/components/summary-list/README.md
@@ -74,7 +74,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({
@@ -201,7 +201,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({
@@ -292,7 +292,7 @@
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({

--- a/packages/components/tag/README.md
+++ b/packages/components/tag/README.md
@@ -20,7 +20,7 @@ Find out more about the tag component and when to use it in the [NHS digital ser
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/tag/macro.njk' import tag %}
 
 {{ tag({
@@ -42,7 +42,7 @@ See the full list of tag colours on the [NHS digital service manual](https://ser
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/tag/macro.njk' import tag %}
 
 {{ tag({

--- a/packages/components/tag/README.md
+++ b/packages/components/tag/README.md
@@ -20,7 +20,7 @@ Find out more about the tag component and when to use it in the [NHS digital ser
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/tag/macro.njk' import tag %}
 
 {{ tag({
@@ -42,7 +42,7 @@ See the full list of tag colours on the [NHS digital service manual](https://ser
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/tag/macro.njk' import tag %}
 
 {{ tag({

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -26,7 +26,7 @@ Find out more about the textarea component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({
@@ -64,7 +64,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({
@@ -99,7 +99,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```
+```nunjucks
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({

--- a/packages/components/textarea/README.md
+++ b/packages/components/textarea/README.md
@@ -26,7 +26,7 @@ Find out more about the textarea component and when to use it in the [NHS digita
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({
@@ -64,7 +64,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({
@@ -99,7 +99,7 @@ See [Autofilling form controls: the autocomplete attribute](https://html.spec.wh
 
 #### Nunjucks macro
 
-```nunjucks
+```njk
 {% from 'components/textarea/macro.njk' import textarea %}
 
 {{ textarea({


### PR DESCRIPTION
## Description

I noticed a lot of code blocks in the documentation don't have syntax highlighting enabled, so have gone through and added in the language where missing. This is not a user-facing change; it just improves the experience of reading documentation on github.

As a side effect, I noticed css examples in the linting guide themselves now get picked up by stylelint, so I've configured it to be a lot more liberal when processing this file.

## Screenshots

### scss
![Screenshot 2025-04-15 at 15 30 14](https://github.com/user-attachments/assets/2bb5912d-52f0-4fff-82e1-21c16f4003cb)

### nunjucks
![Screenshot 2025-04-15 at 15 30 37](https://github.com/user-attachments/assets/c14c56b9-fafd-489d-b250-d528bfed52ad)

### shell
(this one doesn't do much)
![Screenshot 2025-04-15 at 15 31 00](https://github.com/user-attachments/assets/bfa363e8-aaf9-47a8-a07c-1f61c194da2f)


## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry (not sure if this is relevant enough for an entry - if so please let me know how to format it)
