### PR TITLE
Prevent Playwright setup running on npm `postinstall`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Setup Playwright
         if: ${{ steps.changes.outputs.changes == 'true' }}
-        run: npm run postinstall
+        run: npm run prepare
 
       - name: Run backstop
         if: ${{ steps.changes.outputs.changes == 'true' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "nhsuk-frontend",
       "version": "9.4.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.26.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "^20.9.0 || ^22.11.0"
   },
   "scripts": {
-    "postinstall": "playwright install chromium --with-deps --only-shell",
+    "prepare": "playwright install chromium --with-deps --only-shell",
     "build": "gulp build docs:build --color --series",
     "prestart": "npm run build",
     "start": "gulp --color",


### PR DESCRIPTION
## Description

Fixes an issue in `nhsuk-frontend@9.4.0` where the `postinstall` script is incorrectly run:

```console
npm error command sh -c playwright install chromium --with-deps --only-shell
npm error sh: playwright: command not found
```

See follow up PR https://github.com/nhsuk/nhsuk-frontend/pull/1250 where `prepare` is replaced with separate npm scripts

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
