### PR TITLE
Fix text input with prefix/suffix focus and width 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ For consistency with other components, the following Nunjucks macro changes have
 
 This was added in [pull request #1257: Review and update `text`, `html` and `call` usage](https://github.com/nhsuk/nhsuk-frontend/pull/1257).
 
+:wrench: **Fixes**
+
+We've made fixes to NHS.UK frontend in the following pull requests:
+
+- [#1258: Fix text input with prefix/suffix focus and width](https://github.com/nhsuk/nhsuk-frontend/pull/1258)
+
 ## 9.4.1 - 22 April 2025
 
 :wrench: **Fixes**

--- a/packages/components/input/_input.scss
+++ b/packages/components/input/_input.scss
@@ -80,6 +80,10 @@
 .nhsuk-input__wrapper {
   display: flex;
 
+  .nhsuk-input {
+    flex: 0 1 auto;
+  }
+
   .nhsuk-input:focus {
     // Hack to stop focus style being overlapped by the suffix
     z-index: 1;
@@ -87,6 +91,11 @@
 
   @include mq($until: mobile) {
     display: block;
+
+    .nhsuk-input {
+      // Set max-width to override potential width override class on the input
+      max-width: 100%;
+    }
   }
 }
 
@@ -107,7 +116,6 @@
   @include nhsuk-font($size: 19);
 
   @include mq($until: mobile) {
-    max-width: 9.1ex;
     display: block;
     height: 100%;
     white-space: normal;

--- a/packages/components/input/_input.scss
+++ b/packages/components/input/_input.scss
@@ -80,6 +80,11 @@
 .nhsuk-input__wrapper {
   display: flex;
 
+  .nhsuk-input:focus {
+    // Hack to stop focus style being overlapped by the suffix
+    z-index: 1;
+  }
+
   @include mq($until: mobile) {
     display: block;
   }


### PR DESCRIPTION
## Description

Added fix to stop text input focus style being overlapped by the suffix.

| Before | After |
| -------|-------|
| <img width="266" alt="Screenshot 2025-04-24 at 10 28 23" src="https://github.com/user-attachments/assets/cf8a78b4-2d8f-403e-92c6-bcf5bc9745fb" /> | <img width="272" alt="Screenshot 2025-04-24 at 10 28 40" src="https://github.com/user-attachments/assets/215176dc-ff6d-4bdf-84d4-0555fadadf4f" /> |

Also added fix for input width (with prefix/suffix) on small screens.

| Before | After |
| -------|-------|
|  <img width="306" alt="Screenshot 2025-04-24 at 11 28 00" src="https://github.com/user-attachments/assets/1e819bc1-56fb-4e3f-9405-890633f201ce" /> |  <img width="308" alt="Screenshot 2025-04-24 at 11 27 29" src="https://github.com/user-attachments/assets/70aa289b-f10b-41a9-9336-a15638fe5ff4" />  |

[Code taken from GOV.UK frontend ](https://github.com/alphagov/govuk-frontend/blob/1bc5abe1e78a48f3672e740b65579084d32431bd/packages/govuk-frontend/src/govuk/components/input/_index.scss#L105C5-L108C6)

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
