### PR TITLE
Fix watch path to avoid `node_modules`

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -63,7 +63,7 @@ gulp.task(
 
 gulp.task('docs:watch', () =>
   Promise.all([
-    gulp.watch(['**/*.njk'], buildHTML),
+    gulp.watch(['app/**/*.njk', 'packages/**/*.njk'], buildHTML),
     gulp.watch(['dist/**/*.html']).on('change', browserSync.reload),
     gulp.watch(['dist/*.min.{css,css.map}'], copyCSS),
     gulp.watch(['dist/*.min.{js,js.map}'], copyJS),


### PR DESCRIPTION
## Description

This PR prevents `gulp watch` responding to `node_modules` changes

It was caused by [`npm workspace`](https://docs.npmjs.com/cli/v11/using-npm/workspaces) support in https://github.com/nhsuk/nhsuk-frontend/pull/1261 which makes **node_modules/nhsuk-frontend** a symlink

### Console output

Example console output when `**/*.njk` changes matched both:

```shell
'packages/components/**/*.njk' # source path
'node_modules/nhsuk-frontend/packages/components/**/*.njk' # symlink path
```

```console
[Browsersync] Serving files from: dist/app
[09:42:48] Finished 'serve' after 123 ms
[09:42:48] Finished 'docs:serve' after 124 ms
[09:42:48] Finished 'default' after 126 ms
[09:43:15] Starting 'buildHTML'...
[09:43:15] Finished 'buildHTML' after 364 ms
[09:43:16] Starting 'buildHTML'...
[09:43:16] Finished 'buildHTML' after 246 ms
[09:43:16] Starting 'buildHTML'...
[09:43:16] Finished 'buildHTML' after 158 ms
[09:43:17] Starting 'buildHTML'...
[09:43:17] Finished 'buildHTML' after 173 ms
[09:43:17] Starting 'buildHTML'...
[09:43:17] Finished 'buildHTML' after 169 ms
[09:43:17] Starting 'buildHTML'...
[09:43:18] Finished 'buildHTML' after 167 ms
[09:43:18] Starting 'buildHTML'...
[09:43:18] Finished 'buildHTML' after 153 ms
[09:43:18] Starting 'buildHTML'...
[09:43:18] Finished 'buildHTML' after 155 ms
[09:43:19] Starting 'buildHTML'...
[09:43:19] Finished 'buildHTML' after 156 ms
[09:43:19] Starting 'buildHTML'...
[09:43:19] Finished 'buildHTML' after 149 ms
[09:43:20] Starting 'buildHTML'...
[09:43:20] Finished 'buildHTML' after 179 ms
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
