### PR TITLE
Add missing `scope` support to header

### DIFF
--- a/packages/components/header/header.js
+++ b/packages/components/header/header.js
@@ -272,7 +272,9 @@ class Header {
   }
 }
 
-module.exports = () => {
-  const $module = document.querySelector('.nhsuk-navigation')
+module.exports = (options = {}) => {
+  const $scope = options.scope || document
+  const $module = $scope.querySelector('.nhsuk-navigation')
+
   new Header($module)
 }

--- a/packages/components/header/header.jsdom.test.mjs
+++ b/packages/components/header/header.jsdom.test.mjs
@@ -147,6 +147,11 @@ describe('Header class', () => {
       document.body.innerHTML = ''
       expect(() => initHeader()).not.toThrow()
     })
+
+    it('should not throw with empty scope', () => {
+      const scope = document.createElement('div')
+      expect(() => initHeader({ scope })).not.toThrow()
+    })
   })
 
   describe('Menu button', () => {

--- a/packages/index.js
+++ b/packages/index.js
@@ -22,7 +22,7 @@ require('./polyfills.js')
  * @param {HTMLElement} scope
  */
 function initAll(scope) {
-  initHeader()
+  initHeader({ scope })
   initSkipLink()
   initButton({ scope })
   initCharacterCount({ scope })


### PR DESCRIPTION
## Description

This PR resolves missing `scope` for the header component

Closes https://github.com/nhsuk/nhsuk-frontend/issues/1270 together with https://github.com/nhsuk/nhsuk-frontend/pull/1277

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
