### PR TITLE
Add missing `scope` support to skip link

### DIFF
--- a/packages/components/skip-link/skip-link.js
+++ b/packages/components/skip-link/skip-link.js
@@ -7,8 +7,9 @@ const { setFocus } = require('../../common')
  * when elected so the next focusable element is not at the jumped to area.
  */
 
-module.exports = () => {
-  const $module = document.querySelector('.nhsuk-skip-link')
+module.exports = (options = {}) => {
+  const $scope = options.scope || document
+  const $module = $scope.querySelector('.nhsuk-skip-link')
 
   // Check for skip link
   if (!$module || !($module instanceof HTMLAnchorElement)) {

--- a/packages/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/components/skip-link/skip-link.jsdom.test.mjs
@@ -60,6 +60,11 @@ describe('Skip link', () => {
       document.body.innerHTML = ''
       expect(() => initSkipLink()).not.toThrow()
     })
+
+    it('should not throw with empty scope', () => {
+      const scope = document.createElement('div')
+      expect(() => initSkipLink({ scope })).not.toThrow()
+    })
   })
 
   describe('Focus handling', () => {

--- a/packages/index.js
+++ b/packages/index.js
@@ -23,7 +23,7 @@ require('./polyfills.js')
  */
 function initAll(scope) {
   initHeader({ scope })
-  initSkipLink()
+  initSkipLink({ scope })
   initButton({ scope })
   initCharacterCount({ scope })
   initCheckboxes({ scope })


### PR DESCRIPTION
## Description

This PR resolves missing `scope` for the skip link component

Closes https://github.com/nhsuk/nhsuk-frontend/issues/1270 together with https://github.com/nhsuk/nhsuk-frontend/pull/1276

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
