### PR TITLE
Add all links example page

### DIFF
--- a/app/components/all-links.njk
+++ b/app/components/all-links.njk
@@ -15,17 +15,23 @@
         </div>
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
-            <p><a href="#" class="nhsuk-link">Link</a></p>
+
+            {{ backLink({
+              href: "#",
+              text: "Back",
+              classes: "nhsuk-u-margin-bottom-4"
+            }) }}
+
+            <p><a href="#" class="nhsuk-link">Example link 1</a></p>
+
+            <p><a href="#" class="nhsuk-link">Example link 2</a></p>
 
             {{ actionLink({
               "text": "Action link",
               "href": "#"
             }) }}
 
-            {{ backLink({
-              href: "#",
-              text: "Back"
-            }) }}
+
           </div>
           <div class="nhsuk-grid-column-one-third">
 
@@ -46,19 +52,21 @@
         </div>
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
-            <p><a href="#" class="nhsuk-link">Link</a></p>
+            {{ backLink({
+              href: "#",
+              text: "Back",
+              classes: "nhsuk-u-margin-bottom-4"
+            }) }}
+
+            <p><a href="#" class="nhsuk-link">Example link 1</a></p>
+
+            <p><a href="#" class="nhsuk-link">Example link 2</a></p>
 
             {{ actionLink({
               "text": "Action link",
               "href": "#"
             }) }}
-
-            {{ backLink({
-              href: "#",
-              text: "Back"
-            }) }}
           </div>
-
         </div>
       </div>
     </section>
@@ -71,7 +79,20 @@
         </div>
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
-            <p><a href="#" class="nhsuk-link">Link</a></p>
+            {{ backLink({
+              href: "#",
+              text: "Back",
+              classes: "nhsuk-u-margin-bottom-4"
+            }) }}
+
+            <p><a href="#" class="nhsuk-link">Example link 1</a></p>
+
+            <p><a href="#" class="nhsuk-link">Example link 2</a></p>
+
+            {{ actionLink({
+              "text": "Action link",
+              "href": "#"
+            }) }}
           </div>
         </div>
       </div>

--- a/app/components/all-links.njk
+++ b/app/components/all-links.njk
@@ -1,0 +1,80 @@
+{% set title = 'Links' %}
+
+{% extends 'page.njk' %}
+
+{% block main %}
+  <main id="maincontent">
+    <section class="nhsuk-main-wrapper">
+      <div class="nhsuk-width-container">
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-two-thirds">
+            <h1 class="nhsuk-heading-xl">Links</h1>
+
+            <h2 class="nhsuk-heading-l">Page background</h2>
+          </div>
+        </div>
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-one-third">
+            <p><a href="#" class="nhsuk-link">Link</a></p>
+
+            {{ actionLink({
+              "text": "Action link",
+              "href": "#"
+            }) }}
+
+            {{ backLink({
+              href: "#",
+              text: "Back"
+            }) }}
+          </div>
+          <div class="nhsuk-grid-column-one-third">
+
+          </div>
+          <div class="nhsuk-grid-column-one-third">
+
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nhsuk-main-wrapper" style="background-color: #fff; color: #000;">
+      <div class="nhsuk-width-container">
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-two-thirds">
+            <h2 class="nhsuk-heading-l">White background</h2>
+          </div>
+        </div>
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-one-third">
+            <p><a href="#" class="nhsuk-link">Link</a></p>
+
+            {{ actionLink({
+              "text": "Action link",
+              "href": "#"
+            }) }}
+
+            {{ backLink({
+              href: "#",
+              text: "Back"
+            }) }}
+          </div>
+
+        </div>
+      </div>
+    </section>
+    <section class="nhsuk-main-wrapper" style="background-color: #d8dde0;">
+      <div class="nhsuk-width-container">
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-two-thirds">
+            <h2 class="nhsuk-heading-l">Grey background (used in footer)</h2>
+          </div>
+        </div>
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-one-third">
+            <p><a href="#" class="nhsuk-link">Link</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+{% endblock %}

--- a/app/components/all-links.njk
+++ b/app/components/all-links.njk
@@ -6,20 +6,21 @@
   <main id="maincontent">
     <section class="nhsuk-main-wrapper">
       <div class="nhsuk-width-container">
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
             <h1 class="nhsuk-heading-xl">Links</h1>
-
-            <h2 class="nhsuk-heading-l">Page background</h2>
+            <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">Page background</h2>
           </div>
         </div>
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
 
             {{ backLink({
-              href: "#",
-              text: "Back",
-              classes: "nhsuk-u-margin-bottom-4"
+              "text": "Back",
+              "classes": "nhsuk-u-margin-bottom-4",
+              "href": "#"
             }) }}
 
             <p><a href="#" class="nhsuk-link">Example link 1</a></p>
@@ -28,15 +29,9 @@
 
             {{ actionLink({
               "text": "Action link",
+              "classes": "nhsuk-u-margin-top-2",
               "href": "#"
             }) }}
-
-
-          </div>
-          <div class="nhsuk-grid-column-one-third">
-
-          </div>
-          <div class="nhsuk-grid-column-one-third">
 
           </div>
         </div>
@@ -45,17 +40,20 @@
 
     <section class="nhsuk-main-wrapper" style="background-color: #fff; color: #000;">
       <div class="nhsuk-width-container">
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
-            <h2 class="nhsuk-heading-l">White background</h2>
+            <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">White background</h2>
           </div>
         </div>
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
+
             {{ backLink({
-              href: "#",
-              text: "Back",
-              classes: "nhsuk-u-margin-bottom-4"
+              "text": "Back",
+              "classes": "nhsuk-u-margin-bottom-4",
+              "href": "#"
             }) }}
 
             <p><a href="#" class="nhsuk-link">Example link 1</a></p>
@@ -64,25 +62,31 @@
 
             {{ actionLink({
               "text": "Action link",
+              "classes": "nhsuk-u-margin-top-2",
               "href": "#"
             }) }}
+
           </div>
         </div>
       </div>
     </section>
+
     <section class="nhsuk-main-wrapper" style="background-color: #d8dde0;">
       <div class="nhsuk-width-container">
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
-            <h2 class="nhsuk-heading-l">Grey background (used in footer)</h2>
+            <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-6">Grey background (used in footer)</h2>
           </div>
         </div>
+
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-one-third">
+
             {{ backLink({
-              href: "#",
-              text: "Back",
-              classes: "nhsuk-u-margin-bottom-4"
+              "text": "Back",
+              "classes": "nhsuk-u-margin-bottom-4",
+              "href": "#"
             }) }}
 
             <p><a href="#" class="nhsuk-link">Example link 1</a></p>
@@ -91,10 +95,13 @@
 
             {{ actionLink({
               "text": "Action link",
+              "classes": "nhsuk-u-margin-top-2",
               "href": "#"
             }) }}
+
           </div>
         </div>
+
       </div>
     </section>
   </main>

--- a/app/index.njk
+++ b/app/index.njk
@@ -161,6 +161,10 @@
             text: "All button examples"
           },
           {
+            href: "components/all-links.html",
+            text: "All link examples"
+          },
+          {
             href: "components/typography.html",
             text: "Typography and spacing examples"
           }


### PR DESCRIPTION
Following #1283 which added a page showing all the button variants on different background colours, this adds a page showing all the link variants on different background colours.

A blue background variant (with white link text) will be added in #1269.

In future we’ll ideally add examples showing visited, hover and active link styles - but that will need extra CSS to fake the pseudo-classes, like this: https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend-review/postcss.config.mjs#L16-L21

## Screenshot

![localhost_3000_nhsuk-frontend_components_all-links html (2)](https://github.com/user-attachments/assets/c3c4d77c-0ec0-4123-a388-a7018c585348)


