### PR TITLE
Fix for reverse button in hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ After:
 We've made fixes to NHS.UK frontend in the following pull requests:
 
 - [#1258: Fix text input with prefix/suffix focus and width](https://github.com/nhsuk/nhsuk-frontend/pull/1258)
+- [#1292: Fix for reverse buttons within Hero components](https://github.com/nhsuk/nhsuk-frontend/pull/1292)
 
 ## 9.4.1 - 22 April 2025
 

--- a/app/components/hero/hero-with-html.njk
+++ b/app/components/hero/hero-with-html.njk
@@ -13,7 +13,8 @@
 
     {{ button({
       text: "Sign up",
-      classes: "nhsuk-button--reverse"
+      classes: "nhsuk-button--reverse",
+      href: "#"
     }) }}
   {% endcall %}
 {% endblock %}

--- a/packages/components/button/_index.scss
+++ b/packages/components/button/_index.scss
@@ -186,7 +186,10 @@ $button-padding-left-right: 16px;
   background-color: $nhsuk-secondary-button-white-background-color;
 }
 
-.nhsuk-button--reverse {
+// The .nhsuk-hero selector is needed here to override the
+// default white text for links within the hero component.
+.nhsuk-button--reverse,
+.nhsuk-hero .nhsuk-button--reverse {
   background-color: $nhsuk-reverse-button-color;
 
   &,

--- a/packages/components/button/_index.scss
+++ b/packages/components/button/_index.scss
@@ -186,10 +186,7 @@ $button-padding-left-right: 16px;
   background-color: $nhsuk-secondary-button-white-background-color;
 }
 
-// The .nhsuk-hero selector is needed here to override the
-// default white text for links within the hero component.
-.nhsuk-button--reverse,
-.nhsuk-hero .nhsuk-button--reverse {
+.nhsuk-button--reverse {
   background-color: $nhsuk-reverse-button-color;
 
   &,

--- a/packages/components/hero/_index.scss
+++ b/packages/components/hero/_index.scss
@@ -18,7 +18,7 @@
 
   @include print-color($nhsuk-print-text-color);
 
-  a {
+  a:not(.nhsuk-button) {
     @include nhsuk-link-style-white;
   }
 

--- a/packages/components/hero/_index.scss
+++ b/packages/components/hero/_index.scss
@@ -18,6 +18,7 @@
 
   @include print-color($nhsuk-print-text-color);
 
+  .nhsuk-link,
   a:not(.nhsuk-button) {
     @include nhsuk-link-style-white;
   }


### PR DESCRIPTION
The reverse button in the Hero component was being styled as white-on-white when the button was using a link tag instead of a button tag:

<img width="814" alt="Screenshot 2025-05-12 at 13 58 34" src="https://github.com/user-attachments/assets/b898126b-922c-497c-bbe4-97351cc09da1" />

This was due to a conflict with the default link style in the Hero component.

This fixes that by only applying the default link style to links which do not contain the `.nhsuk-button` class.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
