### PR TITLE
Clarify changelog “Replace Sass mixins for grids” `$class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ If you are overriding any settings prefixed with `$mq-` in your application you 
 
 #### Replace Sass mixins for grids
 
-If you're using the `govuk-grid-column()` Sass mixin to create custom grid classes, you must replace it with the `nhsuk-grid-column()` mixin and remove the `$class` parameter.
+If you're using the `govuk-grid-column()` Sass mixin to create custom grid classes, you must replace it with the `nhsuk-grid-column()` mixin and set the `$class` parameter to `false`.
 
 Before:
 
@@ -158,7 +158,7 @@ After:
 
 ```scss
 .app-grid-column-one-quarter-at-desktop {
-  @include nhsuk-grid-column(one-quarter, $at: desktop);
+  @include nhsuk-grid-column(one-quarter, $at: desktop, $class: false);
 }
 ```
 


### PR DESCRIPTION
## Description

Clarify that the `nhsuk-grid-column()` Sass mixin needs `$class: false`

We will be removing `$class` in the next major release

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
