### PR TITLE
Remove empty meta description tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # NHS.UK frontend Changelog
 
-## 9.6.1 - 22 May 2025
+## Unreleased
 
 :wrench: **Fixes**
 
-- Removed empty meta description from default Nunjucks template ([Pull request #1316](https://github.com/nhsuk/nhsuk-frontend/pull/1316))
+We've made fixes to NHS.UK frontend in the following pull requests:
+
+- [#1316: Removed empty meta description from default Nunjucks template ](https://github.com/nhsuk/nhsuk-frontend/pull/1316)
 
 ## 9.6.0 - 20 May 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 We've made fixes to NHS.UK frontend in the following pull requests:
 
-- [#1316: Removed empty meta description from default Nunjucks template ](https://github.com/nhsuk/nhsuk-frontend/pull/1316)
+- [#1316: Removed empty meta description from default Nunjucks template](https://github.com/nhsuk/nhsuk-frontend/pull/1316)
 
 ## 9.6.0 - 20 May 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK frontend Changelog
 
-## Unreleased
+## 9.6.1 - 22 May 2025
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Removed empty meta description from default Nunjucks template ([Pull request #1316](https://github.com/nhsuk/nhsuk-frontend/pull/1316))
+
 ## 9.6.0 - 20 May 2025
 
 :new: **New features**

--- a/packages/template.njk
+++ b/packages/template.njk
@@ -9,7 +9,6 @@
     <title>{% block pageTitle %}NHS{% endblock %}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
 
     {% block headIcons %}
       <link rel="shortcut icon" href="{{ assetPath | default("/assets", true) }}/favicons/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
This shouldn’t be included by default. Services using the template can set meta descriptions (and any other meta tags) using the `head` block.