### PR TITLE
Ensure colour of active reversed links remains visible

### DIFF
--- a/packages/core/tools/_links.scss
+++ b/packages/core/tools/_links.scss
@@ -72,7 +72,7 @@
   }
 
   &:active {
-    color: $nhsuk-link-active-color;
+    color: $color_nhsuk-grey-4;
   }
 }
 


### PR DESCRIPTION
## Description

When active, the reversed link fades into a dark background. This PR changes the active state for reversed links to be a lighter colour, though still a different colour from white.

| Before | After |
| - | - |
| <img width="200" alt="Screenshot of active link before change." src="https://github.com/user-attachments/assets/46aefdd7-4c0e-4f1f-a58d-8b5f76ad6c34" /> | <img width="200" alt="Screenshot of active link after change." src="https://github.com/user-attachments/assets/a15dbde1-7300-4e2e-9681-d523de8ad65e" /> |

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
