### PR TITLE
Update changelog with `transactionalService` option rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,11 @@ These changes were introduced in [pull request #1327: Add class `.nhsuk-frontend
 
 If you’re using the `header` Nunjucks macro in your service, you must:
 
-- Rename the `transactionalService` option to the new `service` option.
+- Rename the `transactionalService` option to the new `service` option, and remove the boolean `transactional` option.
 - Replace the `primaryLinks` option with the nested `navigation.items` option, using `text` and `href` instead of `label` and `url`.
 - Replace the `searchAction` option with the nested `search.action` option.
 - Replace the `searchInputName` option with the nested `search.name` option.
-- Remove the boolean `showNav`, `showSearch` and `transactional` options from the header component as respective parts of the header are shown automatically when `navigation.items` or `search` options are provided.
+- Remove the boolean `showNav` and `showSearch` options. The respective parts of the header are now shown automatically when `navigation.items` or `search` options are provided.
 - Remove the `.nhsuk-header__navigation-list--left-aligned` modifier class, navigation items are now aligned left by default.
 
 To restore the previous justified alignment, where navigation items appeared evenly spaced out, add the new `nhsuk-header__navigation--justified` modifier class to the nested `navigation.classes` option.


### PR DESCRIPTION
## Description

Spotted an CHANGELOG issue in https://github.com/nhsuk/nhsuk-frontend/pull/1058

The option `transactionalService` needs renaming not removing

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
