### PR TITLE
Update changelog following v9.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ This release stops Internet Explorer 11 and other older browsers from running NH
 
 :new: **New features**
 
-#### Reversed link style for breadcrumb and back link
-
-You can now use the breadcrumb and back link components on dark backgrounds by using the `.nhsuk-breadcrumb--reverse` and `.nhsuk-back-link--reverse` classes respectively. Added in [pull request #1335](https://github.com/nhsuk/nhsuk-frontend/pull/1335).
-
 #### New header with account section
 
 We’ve updated the header component to support account information and links. As part of this work we’ve also made some other improvements to the header, detailed below:
@@ -154,14 +150,32 @@ This change was introduced in [#1139: Remove 24px from typography scale](https:/
 
 :wrench: **Fixes**
 
-- [#1312: Review and fix inconsistent link styles](https://github.com/nhsuk/nhsuk-frontend/pull/1312)
+- [#1349: Add select component `value`, `disabled` and `formGroup` params](https://github.com/nhsuk/nhsuk-frontend/pull/1349)
+
+## 9.6.2 - 9 June 2025
+
+Note: This release was created from the `support/9.x` branch.
+
+:recycle: **Changes**
+
+#### Resolve inconsistent link styles
+
+We've completed a spring clean to resolve inconsistent link styles in [pull request #1312](https://github.com/nhsuk/nhsuk-frontend/pull/1312).
+
+Please carefully review all links in custom or modified components to make sure that your hover, focus and active styles do not conflict with the defaults.
+
+#### Reversed link style for breadcrumb and back link
+
+You can now use the breadcrumb and back link components on dark backgrounds by using the `.nhsuk-breadcrumb--reverse` and `.nhsuk-back-link--reverse` classes respectively. Added in [pull request #1335](https://github.com/nhsuk/nhsuk-frontend/pull/1335).
+
+:wrench: **Fixes**
+
 - [#1318: Consistent padding for card and expander](https://github.com/nhsuk/nhsuk-frontend/pull/1318)
 - [#1324: Show border on summary row cells with no action link](https://github.com/nhsuk/nhsuk-frontend/pull/1324)
 - [#1324: Increase spacing between paragraphs in summary list values](https://github.com/nhsuk/nhsuk-frontend/pull/1324)
 - [#1325: Ensure summary list keys are aligned across lists](https://github.com/nhsuk/nhsuk-frontend/pull/1325)
 - [#1325: Add `nhsuk-summary-list__row--no-border` modifier to remove border on an individual summary list row](https://github.com/nhsuk/nhsuk-frontend/pull/1325)
 - [#1346: Fix primary card chevron position without description](https://github.com/nhsuk/nhsuk-frontend/pull/1346)
-- [#1349: Add select component `value`, `disabled` and `formGroup` params](https://github.com/nhsuk/nhsuk-frontend/pull/1349)
 - [#1358: Fix spacing between button background and box shadow](https://github.com/nhsuk/nhsuk-frontend/pull/1358)
 
 ## 9.6.1 - 22 May 2025


### PR DESCRIPTION
## Description

This PR updates the changelog on `main` once we release v9.6.2 from `support/9.x`

* https://github.com/nhsuk/nhsuk-frontend/pull/1363

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
