### PR TITLE
Add .slugignore file

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,8 @@
+# This file contains references to folders and files that are not
+# necessary to run the review app. It’s used by Heroku.
+#
+# See https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore
+
+# Don't include the folder of reference images for tests
+tests/backstop/bitmaps_reference
+


### PR DESCRIPTION
This adds a `.slugignore` file and includes the reference images for the visual regression tests, so that the preview app can be deployed on Heroku (hopefully).