### PR TITLE
Document details component `summaryText` and `summaryHtml` macro options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ This change ensures consistency with other components, where `text` or `html` pa
 }) }}
 ```
 
-This change was made in [pull request #1259: Review legacy Nunjucks params](https://github.com/nhsuk/nhsuk-frontend/pull/1259).
+This change was made in pull requests [#1259: Review legacy Nunjucks params](https://github.com/nhsuk/nhsuk-frontend/pull/1259) and [#1398: Document details component `summaryText` and `summaryHtml` macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1398).
 
 #### Stop using deprecated 24 point on the typography scale
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/macro-options.json
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/macro-options.json
@@ -1,15 +1,27 @@
 [
   {
+    "name": "summaryText",
+    "type": "string",
+    "required": true,
+    "description": "If `summmaryHtml` is set, this is not required. Text to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` option will be ignored."
+  },
+  {
+    "name": "summaryHtml",
+    "type": "string",
+    "required": true,
+    "description": "If `summmaryText` is set, this is not required. HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` option will be ignored."
+  },
+  {
     "name": "text",
     "type": "string",
     "required": true,
-    "description": "Text to be displayed on the details component."
+    "description": "If `html` is set, this is not required. Text to use within the disclosed part of the details element. If `html` is provided, the `text` option will be ignored."
   },
   {
     "name": "html",
     "type": "string",
     "required": true,
-    "description": "HTML content to be displayed within the details component."
+    "description": "If `text` is set, this is not required. HTML to use within the disclosed part of the details element. If `html` is provided, the `text` option will be ignored."
   },
   {
     "name": "id",


### PR DESCRIPTION
## Description

This PR documents the macro options for `summaryText` and `summaryHtml` added in:

* https://github.com/nhsuk/nhsuk-frontend/pull/1259

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
