### PR TITLE
Review hover styles within header component

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "sass:math";
 @use "../../core/objects" as *;
 @use "../../core/settings" as *;
@@ -5,7 +6,31 @@
 
 $_header-item-padding: 12px;
 $_header-link-padding: 2px;
-$_header-active-item-size: $nhsuk-focus-width;
+$_header-item-hover-color: $color_shade_nhsuk-blue-20;
+$_header-item-hover-color-reversed: nhsuk-tint($color_nhsuk-light-blue, 80%);
+$_header-item-active-color: $color_shade_nhsuk-blue-35;
+$_header-item-active-size: $nhsuk-focus-width;
+
+@mixin _header-link-style(
+  $link-color: $nhsuk-link-color,
+  $link-hover-color: $_header-item-hover-color,
+  $link-active-color: $_header-item-active-color
+) {
+  & {
+    color: $link-color;
+  }
+
+  @include nhsuk-link-style-visited($link-color);
+  @include nhsuk-link-style-hover($link-hover-color);
+  @include nhsuk-link-style-active($link-active-color);
+  @include nhsuk-link-style-focus;
+
+  &:focus,
+  &:focus:visited {
+    box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-color;
+    color: $nhsuk-focus-text-color;
+  }
+}
 
 ////
 /// Header component
@@ -34,6 +59,14 @@ $_header-active-item-size: $nhsuk-focus-width;
   &:has(.nhsuk-header__menu-list:not([hidden])) {
     border-bottom: nhsuk-spacing(1) solid $color_nhsuk-grey-4;
   }
+
+  @include nhsuk-media-query($media-type: print) {
+    color: $nhsuk-print-text-color;
+  }
+}
+
+.nhsuk-header__logo {
+  color: inherit;
 
   @include nhsuk-media-query($media-type: print) {
     color: $nhsuk-print-text-color;
@@ -75,55 +108,25 @@ $_header-active-item-size: $nhsuk-focus-width;
   @include nhsuk-font(19, $line-height: 1.1);
 }
 
-.nhsuk-header__service-logo[href] {
-  display: inline-flex;
-
-  &:link,
-  &:visited {
-    color: $color_nhsuk-white;
-  }
-
-  // Add text underline on hover
-  &:not(:focus):hover {
-    text-decoration: underline;
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
-    .nhsuk-header__organisation-name,
-    .nhsuk-header__organisation-name-descriptor,
-    .nhsuk-header__service-name {
-      color: inherit;
-    }
-  }
-
-  &:focus {
-    .nhsuk-header__logo,
-    .nhsuk-header__organisation-name,
-    .nhsuk-header__organisation-name-descriptor,
-    .nhsuk-header__service-name {
-      color: $nhsuk-focus-text-color;
-    }
-  }
-}
-
-.nhsuk-header__service-logo,
+.nhsuk-header__service-logo[href],
 .nhsuk-header__service-name[href] {
-  @include nhsuk-link-style-white;
-
-  &:link {
-    text-decoration: none;
-  }
-
-  &:not(:focus):hover {
-    text-decoration: underline;
-  }
+  text-decoration: none;
+  @include _header-link-style(
+    $link-color: $nhsuk-reverse-text-color,
+    $link-hover-color: $_header-item-hover-color-reversed,
+    $link-active-color: $nhsuk-reverse-text-color
+  );
 
   @include nhsuk-media-query($media-type: print) {
     &::after {
       content: "";
     }
+  }
+}
+
+.nhsuk-header__service-logo[href] {
+  &:focus {
+    @include nhsuk-focused-box;
   }
 }
 
@@ -134,8 +137,10 @@ $_header-active-item-size: $nhsuk-focus-width;
   border: 1px solid $color_shade_nhsuk-blue-20;
   border-radius: $nhsuk-border-radius;
   flex-grow: 1;
+  overflow: hidden;
 
   .nhsuk-icon__user {
+    fill: currentcolor;
     height: 24px;
     width: 24px;
     flex-shrink: 0;
@@ -186,15 +191,21 @@ $_header-active-item-size: $nhsuk-focus-width;
 .nhsuk-header__account-link {
   display: flex;
   gap: nhsuk-spacing(2);
+  margin: nhsuk-spacing(-2) ($_header-item-padding * -1);
+  padding: nhsuk-spacing(2) $_header-item-padding;
   overflow-wrap: anywhere;
-  @include nhsuk-link-style-white;
+  @include _header-link-style(
+    $link-color: $nhsuk-reverse-text-color,
+    $link-hover-color: $_header-item-hover-color-reversed,
+    $link-active-color: $nhsuk-reverse-text-color
+  );
 }
 
 .nhsuk-header__account-button {
   background: none;
   border: 0;
-  padding: 0;
   cursor: pointer;
+  text-decoration: underline;
   @include nhsuk-font(16);
 }
 
@@ -273,13 +284,13 @@ $_header-active-item-size: $nhsuk-focus-width;
 
   &:hover,
   &:active {
-    background-color: $color_shade_nhsuk-blue-35;
+    background-color: $_header-item-hover-color;
     box-shadow: inset 0 0 0 1px $color_nhsuk-white;
     color: $color_nhsuk-white;
   }
 
   &:active {
-    background-color: $color_shade_nhsuk-blue-50;
+    background-color: $_header-item-active-color;
   }
 
   &:focus {
@@ -361,9 +372,15 @@ $_header-active-item-size: $nhsuk-focus-width;
   display: block;
   padding: nhsuk-spacing(3) $_header-link-padding;
   position: relative;
+  text-decoration: none;
   white-space: nowrap;
   @include nhsuk-font(16);
-  @include nhsuk-link-style-white;
+
+  @include _header-link-style(
+    $link-color: $nhsuk-reverse-text-color,
+    $link-hover-color: $nhsuk-reverse-text-color,
+    $link-active-color: $nhsuk-reverse-text-color
+  );
 
   // Visual indicator for navigation item uses a border on bottom edge
   &::before {
@@ -376,15 +393,11 @@ $_header-active-item-size: $nhsuk-focus-width;
     border: 0 solid currentcolor;
   }
 
-  // Visual indicator for current navigation
+  // Visual indicator for hovered and current navigation
   &:hover::before,
   &[aria-current="page"]::before,
   &[aria-current="true"]::before {
-    border-bottom-width: $_header-active-item-size;
-  }
-
-  &:focus {
-    box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-color;
+    border-bottom-width: $_header-item-active-size;
   }
 
   @include nhsuk-media-query($until: tablet) {
@@ -417,7 +430,6 @@ $_header-active-item-size: $nhsuk-focus-width;
   display: flex;
   margin: 0;
   text-align: center;
-  text-decoration: none;
   vertical-align: top;
 
   &[hidden] {
@@ -456,8 +468,7 @@ $_header-active-item-size: $nhsuk-focus-width;
   }
 
   .nhsuk-header__navigation-link {
-    @include nhsuk-link-style-default;
-    @include nhsuk-link-style-no-visited-state;
+    @include _header-link-style;
 
     // Visual indicator for navigation item uses a border on left edge
     &:hover::before,
@@ -468,7 +479,7 @@ $_header-active-item-size: $nhsuk-focus-width;
       bottom: 0;
       left: -$nhsuk-gutter;
       right: auto;
-      border-left-width: $_header-active-item-size;
+      border-left-width: $_header-item-active-size;
 
       // stylelint-disable-next-line max-nesting-depth
       @include nhsuk-media-query($until: desktop) {
@@ -504,22 +515,25 @@ $_header-active-item-size: $nhsuk-focus-width;
 .nhsuk-header--white {
   background-color: $color_nhsuk-white;
 
-  .nhsuk-header__container,
-  .nhsuk-header__logo {
+  .nhsuk-header__container {
     color: $color_nhsuk-blue;
   }
 
+  .nhsuk-header__service-name,
+  .nhsuk-header__organisation-name {
+    color: $color_nhsuk-black;
+  }
+
+  .nhsuk-header__service-logo[href],
+  .nhsuk-header__service-name[href],
+  .nhsuk-header__account-button,
+  .nhsuk-header__account-link {
+    @include _header-link-style;
+  }
+
   .nhsuk-header__service-logo[href] {
-    &:link,
-    &:visited {
-      color: $nhsuk-text-color;
-    }
-
-    @include nhsuk-link-style-active;
-
-    &:not(:focus):not(:active):hover,
-    &:not(:focus):not(:active):hover:visited {
-      color: $nhsuk-link-hover-color;
+    &:focus {
+      @include nhsuk-focused-box;
     }
   }
 
@@ -530,12 +544,6 @@ $_header-active-item-size: $nhsuk-focus-width;
 
   .nhsuk-header__account-item {
     outline-color: $color_nhsuk-grey-4;
-  }
-
-  .nhsuk-header__account-button,
-  .nhsuk-header__account-link {
-    @include nhsuk-link-style-default;
-    @include nhsuk-link-style-no-visited-state;
   }
 
   .nhsuk-header__search-input.nhsuk-input:not(:focus) {
@@ -551,23 +559,14 @@ $_header-active-item-size: $nhsuk-focus-width;
 
     &:hover,
     &:active {
-      background-color: $color_shade_nhsuk-blue-20;
-      border-color: $color_shade_nhsuk-blue-20;
+      background-color: $_header-item-hover-color;
+      border-color: $_header-item-hover-color;
       box-shadow: none;
     }
 
     &:active {
-      background-color: $color_shade_nhsuk-blue-50;
+      background-color: $_header-item-active-color;
     }
-  }
-
-  .nhsuk-header__organisation-name,
-  .nhsuk-header__service-name {
-    color: $color_nhsuk-black;
-  }
-
-  .nhsuk-header__organisation-name-descriptor {
-    color: $color_nhsuk-blue;
   }
 
   .nhsuk-header__navigation {
@@ -599,13 +598,7 @@ $_header-active-item-size: $nhsuk-focus-width;
   }
 
   .nhsuk-header__navigation-link {
-    @include nhsuk-link-style-default;
-    @include nhsuk-link-style-no-visited-state;
-  }
-
-  // Menu
-  .nhsuk-header__menu-toggle {
-    text-decoration: none;
+    @include _header-link-style;
   }
 }
 
@@ -624,6 +617,10 @@ $_header-active-item-size: $nhsuk-focus-width;
 
   .nhsuk-header__service-logo {
     display: block;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 
@@ -643,10 +640,6 @@ $_header-active-item-size: $nhsuk-focus-width;
 .nhsuk-header__organisation-name-descriptor {
   display: block;
   @include nhsuk-font(14, $weight: bold);
-
-  @include nhsuk-media-query($media-type: print) {
-    color: $color_nhsuk-blue;
-  }
 }
 
 .nhsuk-header__organisation-logo {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -30,6 +30,14 @@ $_header-item-active-size: $nhsuk-focus-width;
     box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-color;
     color: $nhsuk-focus-text-color;
   }
+
+  @include nhsuk-media-query($media-type: print) {
+    color: inherit;
+
+    &::after {
+      content: "";
+    }
+  }
 }
 
 ////
@@ -59,14 +67,6 @@ $_header-item-active-size: $nhsuk-focus-width;
   &:has(.nhsuk-header__menu-list:not([hidden])) {
     border-bottom: nhsuk-spacing(1) solid $color_nhsuk-grey-4;
   }
-
-  @include nhsuk-media-query($media-type: print) {
-    color: $nhsuk-print-text-color;
-  }
-}
-
-.nhsuk-header__logo {
-  color: inherit;
 
   @include nhsuk-media-query($media-type: print) {
     color: $nhsuk-print-text-color;
@@ -116,12 +116,6 @@ $_header-item-active-size: $nhsuk-focus-width;
     $link-hover-color: $_header-item-hover-color-reversed,
     $link-active-color: $nhsuk-reverse-text-color
   );
-
-  @include nhsuk-media-query($media-type: print) {
-    &::after {
-      content: "";
-    }
-  }
 }
 
 .nhsuk-header__service-logo[href] {
@@ -461,8 +455,6 @@ $_header-item-active-size: $nhsuk-focus-width;
   top: 100%;
   left: 0;
 
-  @include nhsuk-print-hide;
-
   &[hidden] {
     display: none;
   }
@@ -500,6 +492,8 @@ $_header-item-active-size: $nhsuk-focus-width;
       padding: 0 $nhsuk-gutter;
     }
   }
+
+  @include nhsuk-print-hide;
 
   @include nhsuk-media-query($from: tablet) {
     margin: 0;
@@ -627,10 +621,6 @@ $_header-item-active-size: $nhsuk-focus-width;
 .nhsuk-header__organisation-name {
   display: block;
   @include nhsuk-font(22, $weight: bold, $line-height: 1.1);
-
-  @include nhsuk-media-query($media-type: print) {
-    color: $nhsuk-print-text-color;
-  }
 }
 
 .nhsuk-header__organisation-name-split {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -396,6 +396,7 @@ $_header-active-item-size: $nhsuk-focus-width;
   }
 
   // Visual indicator for current navigation
+  &:hover::before,
   &[aria-current="page"]::before,
   &[aria-current="true"]::before {
     border-bottom-width: $_header-active-item-size;
@@ -478,6 +479,7 @@ $_header-active-item-size: $nhsuk-focus-width;
     @include nhsuk-link-style-no-visited-state;
 
     // Visual indicator for navigation item uses a border on left edge
+    &:hover::before,
     &[aria-current="page"]::before,
     &[aria-current="true"]::before {
       width: 0;

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -76,11 +76,7 @@ $_header-active-item-size: $nhsuk-focus-width;
 }
 
 .nhsuk-header__service-logo[href] {
-  @include nhsuk-link-image;
-
-  position: relative;
   display: inline-flex;
-  text-decoration: none;
 
   &:link,
   &:visited {
@@ -90,21 +86,6 @@ $_header-active-item-size: $nhsuk-focus-width;
   // Add text underline on hover
   &:not(:focus):hover {
     text-decoration: underline;
-  }
-
-  // Add SVG logo underline on hover
-  //
-  // It should be possible to add a box shadow directly to .nhsuk-header_logo
-  // however Safari doesn’t render anything beyond the bounding box of the SVG.
-  // By adding a pseudo element with the same dimensions, we style this instead.
-  &:has(svg):not(:focus):hover::before {
-    content: "";
-    border-bottom: 0.1rem solid currentcolor;
-    display: inline;
-    height: 40px;
-    position: absolute;
-    top: 0.2rem;
-    width: 100px;
   }
 
   &:hover,
@@ -633,7 +614,6 @@ $_header-active-item-size: $nhsuk-focus-width;
 .nhsuk-header--organisation {
   .nhsuk-header__logo {
     height: 24px;
-    margin-bottom: 6px;
     width: 60px;
 
     @include nhsuk-media-query($from: tablet) {
@@ -645,23 +625,9 @@ $_header-active-item-size: $nhsuk-focus-width;
   .nhsuk-header__service-logo {
     display: block;
   }
-
-  .nhsuk-header__service-logo[href] {
-    // Adjust SVG logo underline position
-    &:has(svg):not(:focus):hover::before {
-      height: 24px;
-      width: 60px;
-
-      @include nhsuk-media-query($from: tablet) {
-        height: 32px;
-        width: 80px;
-      }
-    }
-  }
 }
 
 .nhsuk-header__organisation-name {
-  color: $color_nhsuk-white;
   display: block;
   @include nhsuk-font(22, $weight: bold, $line-height: 1.1);
 
@@ -675,7 +641,6 @@ $_header-active-item-size: $nhsuk-focus-width;
 }
 
 .nhsuk-header__organisation-name-descriptor {
-  color: $color_nhsuk-white;
   display: block;
   @include nhsuk-font(14, $weight: bold);
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -118,10 +118,14 @@ $_header-item-active-size: $nhsuk-focus-width;
   );
 }
 
-.nhsuk-header__service-logo[href] {
-  &:focus {
-    @include nhsuk-focused-box;
-  }
+.nhsuk-header__service-logo[href]:hover .nhsuk-header__service-name,
+.nhsuk-header__service-name[href]:hover {
+  color: $nhsuk-reverse-text-color;
+  text-decoration: underline;
+}
+
+.nhsuk-header__service-logo[href]:focus {
+  @include nhsuk-focused-box;
 }
 
 /// Account
@@ -513,7 +517,6 @@ $_header-item-active-size: $nhsuk-focus-width;
     color: $color_nhsuk-blue;
   }
 
-  .nhsuk-header__service-name,
   .nhsuk-header__organisation-name {
     color: $color_nhsuk-black;
   }
@@ -523,6 +526,11 @@ $_header-item-active-size: $nhsuk-focus-width;
   .nhsuk-header__account-button,
   .nhsuk-header__account-link {
     @include _header-link-style;
+  }
+
+  .nhsuk-header__service-logo[href]:hover .nhsuk-header__service-name,
+  .nhsuk-header__service-name[href]:hover {
+    color: inherit;
   }
 
   .nhsuk-header__service-logo[href] {

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_colours.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_colours.scss
@@ -27,6 +27,7 @@ $color_nhsuk-yellow: #ffeb3b;
 
 /// Secondary colours
 
+$color_nhsuk-light-blue: #0072ce;
 $color_nhsuk-pale-yellow: #fff9c4;
 $color_nhsuk-warm-yellow: #ffb81c;
 $color_nhsuk-orange: #ed8b00;


### PR DESCRIPTION
## Description

This PR supersedes #1396, and doesn’t depend on (future) changes to global link styling.

***

## Background

The header is a tricky beast as we know, and one area its complexity continually reveals itself is different sub-components having different link behaviours, due in part to their individual contexts and trade-offs.

### Logo

The NHS logo is difficult to give a hover state to:
  - Safari inconsistently renders the current dark blue outline applied to the NHS logo SVG
  - Adding underlines or outlines to the NHS logo goes against identity guidelines

The logo may also be combined as a link with the service name:
  - A service name may be any length, potentially wrapping to 2 or more lines
  - Adding a background colour to a combined NHS logo and service name can look visually overbearing

The simplest, and most effective way to style these 2 elements, either linked as one or each separately:
  - Change the colour or background colour of the NHS logo
  - Add an underline to the service name

### Navigation

Navigation links don’t need to be underlined as there is sufficient context that they link to different parts of a site. When combined with current section indicators, underlines can add visual noise, adding to the number of rules and lines in the header component.

One way to add a hover effect to navigation links, is to repurpose the visual indicator used for current items.

### Account

As the account area can contain a mix of links and static text, here links need to be visually distinct from static text.

The best way to do this is to underline links.

### Links on blue or white backgrounds

As the default header is blue, and all text is white, the only way to distinguish a hover state using colour is to use a colour that is vibrant and distinct from blue or reduce its transparency.

The white header on the other hand (and the navigation overflow menu) allows for using a greater range of colours.

***

## Proposal

All this background is to underline (pun intended!) that there are no easy options, and a series of trade-offs need to be navigated (another!). This PR updates the hover states used in the header as follows.

### Links on blue vs links on white

Links on a blue background, for all states, are white. Hover states distinguished by other factors.

Links on a white background are NHS blue, with hover using a darker shade, and active using a darker shade still. These colours are reflected in the hover and active state of the search submit button.

In the future (or now?), we might want to align these hover and active colours with those used globally, but as the hover state is currently purple, it looks a little odd, especially as the NHS logo is recoloured on hover.

### Logo

On a blue background, the logo shape remains white but the letters of NHS logo go a darker shade of blue on hover, and darker still on active.

On a white background, the letters remain white, but the logo (and any organisation descriptor) share the darker blue hover and active colours used for white backgrounds.

The service name gets underlined on hover.

### Account

Links (and buttons) are shown underlined, which disappears on hover (using the global behaviour for link underlines on hover).

On a blue background the links remain white, but as elsewhere, on a grey background (for the white header variant), the darker blue hover and active colours are used.

### Navigation

Regardless of background colour, a navigation link gets a bottom border which shares the same colour as its corresponding label. There is no distinction between current and hover border styles, apart from the border on current items remaining persistent.

On a blue background, this means the bottom border remains white regardless of state.

On a white background, this means the bottom border, like the label, shares the the darker blue hover and active colours used on white backgrounds.

## Implementation notes

I stripped back all link styles, reviewed alternative approaches and tried to find the best overall option. In doing so, I was able to simplify a lot of the code in the header (667 lines versus the current 740). This was achieved by:

- ~~Re-using the pseudo element for current navigation items for the hover state, and cascading styles for this element across navigation states and navigation colour variants~~ Fixed in #1428
- ~~Simplifying the method used to keep the account area visually the same size as the search input (using a negative margin instead of another pseudo element ‘hack’)~~ Fixed in #1428
- Removing the pseudo element ‘hack’ to style the NHS logo SVG by instead only changing its background colour
- Using a local private mixin to style navigation links

This separate local private mixin is required because links are (typically) not underlined and the focus states require the bottom black border to be inset. If in the future the global link mixins change, we may be able to remove this local private mixin.

I think this PR solves a few things, not least removed dependencies on later changes while also rowing back on some of the complexity we’ve introduced, and applying consistency around link styling where that is relevant.

All of which to say… probably best demonstrated by looking at the review app. Hopefully this gives enough (maybe too much!) background to this change. 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
