### PR TITLE
Remove unnecessary `hidden` styles in header

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -421,10 +421,6 @@ $_header-link-padding: 2px;
   align-self: center;
   padding: 0 math.div($nhsuk-gutter-half, 2);
 
-  &[hidden] {
-    display: none;
-  }
-
   @include nhsuk-media-query($from: tablet) {
     padding: 0 $nhsuk-gutter-half;
   }
@@ -442,10 +438,6 @@ $_header-link-padding: 2px;
   text-align: center;
   text-decoration: none;
   vertical-align: top;
-
-  &[hidden] {
-    display: none;
-  }
 
   .nhsuk-icon__chevron-down {
     width: nhsuk-spacing(4);
@@ -474,10 +466,6 @@ $_header-link-padding: 2px;
   top: 100%;
   left: 0;
   @include nhsuk-print-hide;
-
-  &[hidden] {
-    display: none;
-  }
 
   @include nhsuk-media-query($until: tablet) {
     margin: 0 $nhsuk-gutter-half * -1;


### PR DESCRIPTION
## Description

Removes `display: none` styles for `hidden` attributes used in the header.

@colinrotherham Were these styles added for backwards compatibility reasons? The navigation works fine without them (and [support for `hidden` is pretty high](https://caniuse.com/hidden)).

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
