### PR TITLE
Allow npm publish `@next` releases (with dry run)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,12 @@ jobs:
 
       - name: Publish npm package
         if: ${{ !contains(steps.get_version.outputs.VERSION, '-') }}
-        run: npm publish --workspace nhsuk-frontend --tag latest
+        run: npm publish --dry-run --workspace nhsuk-frontend --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish npm package (pre-release)
         if: ${{ contains(steps.get_version.outputs.VERSION, '-') }}
-        run: npm publish --workspace nhsuk-frontend --tag next
+        run: npm publish --dry-run --workspace nhsuk-frontend --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

This PR updates our GitHub Action **release.yml** to support two release types:

1. Latest release tagged `latest`
2. Next release tagged `next`

E.g. For early access to the nextl NHS.UK frontend v10 release:

```console
npm install nhsuk-frontend@next
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
