### PR TITLE
Restore package version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_PACKAGE_VERSION: ${GITHUB_REF_NAME/v/}
 
     steps:
       - name: Checkout
@@ -36,8 +35,14 @@ jobs:
       - name: Run tests
         run: npm test --ignore-scripts
 
+      - name: Get package version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+
       - name: Create release artifact
         run: npm run release --workspace nhsuk-frontend
+        env:
+          NPM_PACKAGE_VERSION: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Create release
         id: create_release
@@ -46,25 +51,25 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           draft: false
-          prerelease: ${{ contains(env.NPM_PACKAGE_VERSION, '-') }}
+          prerelease: ${{ contains(steps.get_version.outputs.VERSION, '-') }}
 
       - name: Upload release asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/nhsuk-frontend-${{ env.NPM_PACKAGE_VERSION }}.zip
-          asset_name: nhsuk-frontend-${{ env.NPM_PACKAGE_VERSION }}.zip
+          asset_path: ./dist/nhsuk-frontend-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: nhsuk-frontend-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/zip
 
       - name: Publish npm package
-        if: ${{ !contains(env.NPM_PACKAGE_VERSION, '-') }}
+        if: ${{ !contains(steps.get_version.outputs.VERSION, '-') }}
         run: npm publish --dry-run --workspace nhsuk-frontend --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish npm package (pre-release)
-        if: ${{ contains(env.NPM_PACKAGE_VERSION, '-') }}
+        if: ${{ contains(steps.get_version.outputs.VERSION, '-') }}
         run: npm publish --dry-run --workspace nhsuk-frontend --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

The previous changes in https://github.com/nhsuk/nhsuk-frontend/pull/1430 didn't set the release filename correctly

This PR restores the previous `outputs.VERSION` output but sets it to `env.NPM_PACKAGE_VERSION`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
