### PR TITLE
Hide header account area when printed

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -36,7 +36,7 @@ $_header-active-item-size: $nhsuk-focus-width;
   }
 
   @include nhsuk-media-query($media-type: print) {
-    color: $color_nhsuk-black;
+    color: $nhsuk-print-text-color;
   }
 }
 


### PR DESCRIPTION
## Description

Tiny fix to hide the account area when printing a page. Also updates a variable to be use the correct colour for printed text.

However, I note that the NHS logo has disappeared again, and the service name appears grey. I’ve been able to fix this in #1419, but it’s a bit hard/late to unpick the link styles again here!

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
