### PR TITLE
Add missing `account.items[].href` macro option for header component

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/header/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/macro-options.mjs
@@ -94,6 +94,12 @@ export const params = {
             description:
               'If `html` is set, this is not required. Text for the navigation item. If `html` is provided, the `text` argument will be ignored.'
           },
+          html: {
+            type: 'string',
+            required: true,
+            description:
+              'If `text` is set, this is not required. HTML for the navigation item. If `html` is provided, the `text` argument will be ignored.'
+          },
           current: {
             type: 'boolean',
             required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -120,9 +120,11 @@
           {#- Wrap active links in strong element so users who override colours
               or styles still have some indicator of the current nav item. -#}
           {%- if item.active or item.current -%}
-            <strong class="nhsuk-header__navigation-item-current-fallback">{{ item.text }}</strong>
+            <strong class="nhsuk-header__navigation-item-current-fallback">
+              {{- item.html | safe if item.html else item.text -}}
+            </strong>
           {%- else -%}
-            {{- item.text -}}
+            {{- item.html | safe if item.html else item.text -}}
           {%- endif -%}
         {% endset %}
         <li class="nhsuk-header__navigation-item {%- if item.active or item.current %} nhsuk-header__navigation-item--current{% endif %} {%- if item.classes %} {{ item.classes }}{% endif %}" {{- nhsukAttributes(item.attributes) }}>


### PR DESCRIPTION
## Description

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
