### PR TITLE
Fix Gulp file copy encoding issue (again)

### DIFF
--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -12,6 +12,7 @@ import rename from 'gulp-rename'
  */
 export function copy(assetPath, { srcPath, destPath, output = {} }) {
   let stream = gulp.src(join(srcPath, assetPath), {
+    encoding: false,
     sourcemaps: true
   })
 
@@ -30,8 +31,6 @@ export function copy(assetPath, { srcPath, destPath, output = {} }) {
 
   return stream.pipe(
     gulp.dest(destPath, {
-      encoding: false,
-
       // Only add source maps for styles and scripts
       sourcemaps: (file) =>
         ['.css', '.js'].includes(file.extname) ? '.' : undefined


### PR DESCRIPTION
## Description

This PR moves Gulp `{ encoding: false }` to the correct place as part of https://github.com/nhsuk/nhsuk-frontend/issues/1237

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
