### PR TITLE
Update tasks to use `files.write()` helper

### DIFF
--- a/packages/nhsuk-frontend-review/tasks/assets.mjs
+++ b/packages/nhsuk-frontend-review/tasks/assets.mjs
@@ -2,24 +2,29 @@ import { join } from 'node:path'
 
 import * as config from '@nhsuk/frontend-config'
 import { files, task } from '@nhsuk/frontend-tasks'
+import gulp from 'gulp'
 
 /**
  * Copy NHS.UK frontend logos, icons and other assets into review app
  */
-export const copy = task.name('assets:copy', async () => {
+export const copy = gulp.parallel(
   /**
    * Copy NHS.UK frontend assets
    */
-  await files.copy('nhsuk/assets/**', {
-    srcPath: join(config.paths.pkg, 'dist'),
-    destPath: join(config.paths.app, 'dist/assets')
-  })
+  task.name("assets:copy 'pkg'", () =>
+    files.copy('nhsuk/assets/**', {
+      srcPath: join(config.paths.pkg, 'dist'),
+      destPath: join(config.paths.app, 'dist/assets')
+    })
+  ),
 
   /**
    * Copy review app assets
    */
-  await files.copy('assets/**', {
-    srcPath: join(config.paths.app, 'src'),
-    destPath: join(config.paths.app, 'dist/assets')
-  })
-})
+  task.name("assets:copy 'app'", () =>
+    files.copy('assets/**', {
+      srcPath: join(config.paths.app, 'src'),
+      destPath: join(config.paths.app, 'dist/assets')
+    })
+  )
+)

--- a/packages/nhsuk-frontend-review/tasks/html.mjs
+++ b/packages/nhsuk-frontend-review/tasks/html.mjs
@@ -1,10 +1,9 @@
-import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join, parse } from 'node:path'
+import { basename, dirname, join, parse } from 'node:path'
 
 import * as config from '@nhsuk/frontend-config'
 import { components, nunjucks } from '@nhsuk/frontend-lib'
 import { getListing } from '@nhsuk/frontend-lib/files.mjs'
-import { task } from '@nhsuk/frontend-tasks'
+import { files, task } from '@nhsuk/frontend-tasks'
 import { HtmlValidate, formatterFactory } from 'html-validate'
 import PluginError from 'plugin-error'
 
@@ -67,8 +66,10 @@ export const compile = task.name('html:render', async () => {
       )
 
       // Write example to disk
-      await mkdir(dirname(filePath), { recursive: true })
-      await writeFile(filePath, html)
+      await files.write(basename(filePath), {
+        destPath: dirname(filePath),
+        output: { contents: html }
+      })
     }
   }
 
@@ -82,8 +83,10 @@ export const compile = task.name('html:render', async () => {
     const filePath = join(config.paths.app, `dist/${dir}/${fileName}`)
 
     // Write page to disk
-    await mkdir(dirname(filePath), { recursive: true })
-    await writeFile(filePath, html)
+    await files.write(basename(filePath), {
+      destPath: dirname(filePath),
+      output: { contents: html }
+    })
   }
 })
 

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -52,7 +52,7 @@ export async function write(inputPath, { destPath, output = {} }) {
   }
 
   await mkdir(dirname(filePath), { recursive: true })
-  await writeFile(filePath, `${output.contents}\n`)
+  await writeFile(filePath, `${output.contents.trimEnd()}\n`)
 }
 
 /**

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -7,11 +7,11 @@ import rename from 'gulp-rename'
 /**
  * Copy asset
  *
- * @param {string} assetPath - File path to asset
+ * @param {string} inputPath - File path to asset
  * @param {AssetOptions} options - Asset options
  */
-export function copy(assetPath, { srcPath, destPath, output = {} }) {
-  let stream = gulp.src(join(srcPath, assetPath), {
+export function copy(inputPath, { srcPath, destPath, output = {} }) {
+  let stream = gulp.src(join(srcPath, inputPath), {
     encoding: false,
     sourcemaps: true
   })
@@ -41,11 +41,11 @@ export function copy(assetPath, { srcPath, destPath, output = {} }) {
 /**
  * Write file task
  *
- * @param {string} assetPath - File path to asset
+ * @param {string} inputPath - File path to asset
  * @param {Pick<AssetOptions, "destPath" | "output">} options - Asset options
  */
-export async function write(assetPath, { destPath, output = {} }) {
-  const filePath = join(destPath, assetPath)
+export async function write(inputPath, { destPath, output = {} }) {
+  const filePath = join(destPath, inputPath)
 
   if (!output.contents) {
     throw new Error("Option 'contents' required")

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -13,11 +13,11 @@ import { rollup } from 'rollup'
 /**
  * Compile JavaScript task
  *
- * @param {string} assetPath
+ * @param {string} inputPath
  * @param {CompileScriptsOptions} entry
  */
 export function compile(
-  assetPath,
+  inputPath,
   {
     srcPath,
     destPath,
@@ -25,7 +25,8 @@ export function compile(
     output = {} // Rollup output options
   }
 ) {
-  const { name } = parse(assetPath)
+  const { dir, name } = parse(inputPath)
+  const outputPath = output.file ?? join(dir, `${name}.bundle.js`)
 
   return task.name('scripts:compile', async () => {
     const bundle = await rollup({
@@ -34,7 +35,7 @@ export function compile(
       /**
        * Input path
        */
-      input: join(srcPath, assetPath),
+      input: join(srcPath, inputPath),
 
       /**
        * Input plugins
@@ -100,9 +101,7 @@ export function compile(
       dir: output.preserveModules ? destPath : undefined,
 
       // Write to file when bundling
-      file: !output.preserveModules
-        ? join(destPath, output.file ?? `${name}.bundle.js`)
-        : undefined,
+      file: !output.preserveModules ? join(destPath, outputPath) : undefined,
 
       // Enable source maps
       sourcemap: true

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { basename, dirname, join, parse, relative } from 'node:path'
+import { join, parse, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { paths } from '@nhsuk/frontend-config'
@@ -13,11 +13,12 @@ import { compileAsync } from 'sass-embedded'
 /**
  * Compile Sass task
  *
- * @param {string} assetPath
+ * @param {string} inputPath
  * @param {CompileStylesOptions} entry
  */
-export function compile(assetPath, { srcPath, destPath, output = {} }) {
-  const { name } = parse(assetPath)
+export function compile(inputPath, { srcPath, destPath, output = {} }) {
+  const { dir, name } = parse(inputPath)
+  const outputPath = output.file ?? join(dir, `${name}.css`)
 
   /**
    * Configure PostCSS
@@ -25,8 +26,8 @@ export function compile(assetPath, { srcPath, destPath, output = {} }) {
    * @satisfies {ProcessOptions}
    */
   const options = {
-    from: join(srcPath, assetPath),
-    to: join(destPath, output.file ?? `${name}.css`),
+    from: join(srcPath, inputPath),
+    to: join(destPath, outputPath),
 
     /**
      * Always generate source maps for either:
@@ -90,14 +91,14 @@ export function compile(assetPath, { srcPath, destPath, output = {} }) {
     })
 
     // Write to files
-    await files.write(basename(options.to), {
-      destPath: dirname(options.to),
+    await files.write(outputPath, {
+      destPath,
       output: { contents: result.css }
     })
 
     if (result.map) {
-      await files.write(basename(`${options.to}.map`), {
-        destPath: dirname(options.to),
+      await files.write(`${outputPath}.map`, {
+        destPath,
         output: { contents: result.map.toString() }
       })
     }

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -1,9 +1,9 @@
-import { readFile, mkdir, writeFile } from 'node:fs/promises'
-import { dirname, join, parse, relative } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { basename, dirname, join, parse, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { paths } from '@nhsuk/frontend-config'
-import { task } from '@nhsuk/frontend-tasks'
+import { files, task } from '@nhsuk/frontend-tasks'
 import postcss from 'postcss'
 // eslint-disable-next-line import/default
 import postcssrc from 'postcss-load-config'
@@ -90,11 +90,16 @@ export function compile(assetPath, { srcPath, destPath, output = {} }) {
     })
 
     // Write to files
-    await mkdir(dirname(options.to), { recursive: true })
-    await writeFile(options.to, result.css)
+    await files.write(basename(options.to), {
+      destPath: dirname(options.to),
+      output: { contents: result.css }
+    })
 
     if (result.map) {
-      await writeFile(`${options.to}.map`, result.map.toString())
+      await files.write(basename(`${options.to}.map`), {
+        destPath: dirname(options.to),
+        output: { contents: result.map.toString() }
+      })
     }
   })
 }


### PR DESCRIPTION
## Description

This PR updates older Gulp tasks to use the `files.write()` helper as part of https://github.com/nhsuk/nhsuk-frontend/issues/1237

I've also updated tasks to show a clear `inputPath` versus `outputPath` before calling `files.write()`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
