### PR TITLE
Bugfix: don't have text aligned left in buttons in button group

### DIFF
--- a/packages/nhsuk-frontend-review/src/examples/button-group.njk
+++ b/packages/nhsuk-frontend-review/src/examples/button-group.njk
@@ -46,7 +46,10 @@
               <a href="#" class="nhsuk-link">Buy it</a>
 
               {{ button({
-                "text": "Use it"
+                "text": "Use it",
+                attributes: {
+                  style: "min-width: 150px;"
+                }
               }) }}
 
               {{ button({

--- a/packages/nhsuk-frontend/src/nhsuk/core/objects/_button-group.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/objects/_button-group.scss
@@ -84,7 +84,6 @@
       > .nhsuk-link,
       > a:not(.nhsuk-button) {
         margin-right: $horizontal-gap;
-        text-align: left;
       }
     }
   }


### PR DESCRIPTION
This only effects buttons where you've set a minimum width (eg because the text is quite short).

Fixes an accidental change in #1309.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
