### PR TITLE
Add table cell modifier for missing data

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
@@ -179,3 +179,9 @@
 .nhsuk-table__cell--numeric {
   text-align: right;
 }
+
+// Cells which contain a short label to explain
+// why they are otherwise empty
+.nhsuk-table__cell--missing-reason {
+  color: $nhsuk-secondary-text-color;
+}

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/macro-options.mjs
@@ -360,6 +360,49 @@ export const examples = {
       ]
     }
   },
+  'with missing data reason': {
+    context: {
+      panel: false,
+      caption: 'Vaccinations given',
+      firstCellIsHeader: false,
+      head: [
+        {
+          text: 'Date'
+        },
+        {
+          text: 'Vaccine'
+        },
+        {
+          text: 'Product'
+        }
+      ],
+      rows: [
+        [
+          {
+            text: '10 July 2024'
+          },
+          {
+            text: 'COVID-19'
+          },
+          {
+            text: 'Spikevax JN.1'
+          }
+        ],
+        [
+          {
+            text: '6 September 2023'
+          },
+          {
+            text: 'RSV'
+          },
+          {
+            text: 'Not known',
+            classes: 'nhsuk-table__cell--missing-reason'
+          }
+        ]
+      ]
+    }
+  },
   'as a panel': {
     context: {
       panel: true,


### PR DESCRIPTION
This modifier makes the text dark grey for table cells which contain a short label explaining why the data is missing.

The [GOV.UK content guide for tables](https://www.gov.uk/guidance/content-design/tables) suggests not having empty cells in tables, but instead including a short label to explain why the data is missing:

> ![Screenshot 2025-07-07 at 14 41 15](https://github.com/user-attachments/assets/b53811c0-8a32-4d5a-b028-ac691e876194)

This pull requests adds a table cell modifier to make that text secondary colour (dark grey) so that it is easier to perceive as being different from the cells containing actual data.

## Screenshot

![Screenshot 2025-07-07 at 14 40 20](https://github.com/user-attachments/assets/97a6a2b1-a214-4ce0-95d3-3446aee9351b)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
