### PR TITLE
Fix component nested Nunjucks macro options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Errors you might see include:
 
 This change was introduced in [pull request #1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459).
 
+:wrench: **Fixes**
+
+- [#1463: Fix component nested Nunjucks macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1463)
+
 ## 10.0.0-internal.0 - 2 July 2025
 
 This release introduces some breaking changes to file paths, full width buttons on mobile, the header component and others.

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
@@ -56,75 +56,77 @@ export const params = {
     required: true,
     description: 'Array of checkbox items objects.',
     params: {
-      'text': {
+      text: {
         type: 'string',
         required: true,
         description:
           'If `html` is set, this is not required. Text to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.'
       },
-      'html': {
+      html: {
         type: 'string',
         required: true,
         description:
           'If `text` is set, this is not required. HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.'
       },
-      'id': {
+      id: {
         type: 'string',
         required: false,
         description:
           'Specific id attribute for the checkbox item. If omitted, then component global `idPrefix` option will be applied.'
       },
-      'name': {
+      name: {
         type: 'string',
         required: false,
         description:
           'Specific name for the checkbox item. If omitted, then component global `name` string will be applied.'
       },
-      'label': {
+      label: {
         type: 'object',
         required: false,
         description: 'Options for the label component.',
         isComponent: true
       },
-      'value': {
+      value: {
         type: 'string',
         required: true,
         description: 'Value for the checkbox input.'
       },
-      'divider': {
+      divider: {
         type: 'string',
         required: true,
         description:
           "Optional divider text to separate checkbox items, for example the text `'or'`."
       },
-      'hint': {
+      hint: {
         type: 'object',
         required: false,
         description: 'Provide hint to each checkbox item.',
         isComponent: true
       },
-      'checked': {
+      checked: {
         type: 'boolean',
         required: false,
         description: 'If true, checkbox will be checked.'
       },
-      'conditional': {
-        type: 'boolean',
+      conditional: {
+        type: 'object',
         required: false,
         description:
-          'If true, content provided will be revealed when the item is checked.'
+          'Provide additional content to reveal when the checkbox is checked.',
+        params: {
+          html: {
+            type: 'string',
+            description: 'The HTML to reveal when the checkbox is checked.',
+            required: true
+          }
+        }
       },
-      'conditional.html': {
-        type: 'string',
-        required: false,
-        description: 'Provide content for the conditional reveal.'
-      },
-      'disabled': {
+      disabled: {
         type: 'boolean',
         required: false,
         description: 'If true, checkbox will be disabled.'
       },
-      'attributes': {
+      attributes: {
         type: 'object',
         required: false,
         description:

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
@@ -63,62 +63,64 @@ export const params = {
     required: true,
     description: 'Array of radio items objects.',
     params: {
-      'text': {
+      text: {
         type: 'string',
         required: true,
         description:
           'If `html` is set, this is not required. Text to use within each radio item label. If `html` is provided, the `text` argument will be ignored.'
       },
-      'html': {
+      html: {
         type: 'string',
         required: true,
         description:
           'If `text` is set, this is not required. HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.'
       },
-      'id': {
+      id: {
         type: 'string',
         required: false,
         description:
           'Specific id attribute for the radio item. If omitted, then `idPrefix` string will be applied.'
       },
-      'label': {
+      label: {
         type: 'object',
         required: false,
         description: 'Options for the label component.',
         isComponent: true
       },
-      'value': {
+      value: {
         type: 'string',
         required: true,
         description: 'Value for the radio input.'
       },
-      'hint': {
+      hint: {
         type: 'object',
         required: false,
         description: 'Provide hint to each radio item.',
         isComponent: true
       },
-      'divider': {
+      divider: {
         type: 'string',
         required: false,
         description:
           "Divider text to separate radio items, for example the text `'or'`."
       },
-      'checked': {
+      checked: {
         type: 'boolean',
         required: false,
         description: 'If true, radio will be checked.'
       },
-      'conditional': {
-        type: 'string',
+      conditional: {
+        type: 'object',
         required: false,
         description:
-          'If true, content provided will be revealed when the item is checked.'
-      },
-      'conditional.html': {
-        type: 'html',
-        required: false,
-        description: 'Provide content for the conditional reveal.'
+          'Provide additional content to reveal when the radio is checked.',
+        params: {
+          html: {
+            type: 'string',
+            description: 'The HTML to reveal when the radio is checked.',
+            required: true
+          }
+        }
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/summary-list/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/summary-list/macro-options.mjs
@@ -12,78 +12,105 @@ export const params = {
   rows: {
     type: 'array',
     required: true,
-    description: 'Array of row item objects.',
+    description: 'The rows within the summary list component.',
     params: {
-      'classes': {
+      classes: {
         type: 'string',
         required: false,
         description: 'Classes to add to the row `div`.'
       },
-      'key.text': {
-        type: 'string',
+      key: {
+        type: 'object',
         required: true,
         description:
-          'If `html` is set, this is not required. Text to use within the each key. If `html` is provided, the `text` argument will be ignored.'
-      },
-      'key.html': {
-        type: 'string',
-        required: true
-      },
-      'key.classes': {
-        type: 'string',
-        required: false,
-        description: 'Classes to add to the key wrapper.'
-      },
-      'value.text': {
-        type: 'string',
-        required: true,
-        description:
-          'If `html` is set, this is not required. Text to use within the each value. If `html` is provided, the `text` argument will be ignored.'
-      },
-      'value.html': {
-        type: 'string',
-        required: true,
-        description:
-          'If `text` is set, this is not required. HTML to use within the each value. If `html` is provided, the `text` argument will be ignored.'
-      },
-      'value.classes': {
-        type: 'string',
-        required: false,
-        description: 'Classes to add to the value wrapper.'
-      },
-      'actions.classes': {
-        type: 'string',
-        required: false,
-        description: 'Classes to add to the actions wrapper.'
-      },
-      'actions.items': {
-        type: 'array',
-        required: false,
-        description: 'Array of action item objects.',
+          'The reference content (key) for each row item in the summary list component.',
         params: {
-          href: {
-            type: 'string',
-            required: true,
-            description:
-              'The value of the link href attribute for an action item.'
-          },
           text: {
             type: 'string',
             required: true,
             description:
-              'If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` argument will be ignored.'
+              'If `html` is set, this is not required. Text to use within each key. If `html` is provided, the `text` option will be ignored.'
           },
           html: {
             type: 'string',
             required: true,
             description:
-              'If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` argument will be ignored.'
+              'If `text` is set, this is not required. HTML to use within each key. If `html` is provided, the `text` option will be ignored.'
           },
-          visuallyHiddenText: {
+          classes: {
             type: 'string',
             required: false,
+            description: 'Classes to add to the key wrapper.'
+          }
+        }
+      },
+      value: {
+        type: 'object',
+        required: true,
+        description:
+          'The value for each row item in the summary list component.',
+        params: {
+          text: {
+            type: 'string',
+            required: true,
             description:
-              'Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use `html` for more complicated scenarios.'
+              'If `html` is set, this is not required. Text to use within each value. If `html` is provided, the `text` option will be ignored.'
+          },
+          html: {
+            type: 'string',
+            required: true,
+            description:
+              'If `text` is set, this is not required. HTML to use within each value. If `html` is provided, the `text` option will be ignored.'
+          },
+          classes: {
+            type: 'string',
+            required: false,
+            description: 'Classes to add to the value wrapper.'
+          }
+        }
+      },
+      actions: {
+        type: 'object',
+        required: false,
+        description:
+          'The action link content for each row item in the summary list component.',
+        params: {
+          items: {
+            type: 'array',
+            required: false,
+            description:
+              'The action link items within the row item of the summary list component.',
+            params: {
+              href: {
+                type: 'string',
+                required: true,
+                description:
+                  "The value of the link's `href` attribute for an action item."
+              },
+              text: {
+                type: 'string',
+                required: true,
+                description:
+                  'If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` option will be ignored.'
+              },
+              html: {
+                type: 'string',
+                required: true,
+                description:
+                  'If `text` is set, this is not required. HTML to use within each action item. If `html` is provided, the `text` option will be ignored.'
+              },
+              visuallyHiddenText: {
+                type: 'string',
+                required: false,
+                description:
+                  'Actions rely on context from the surrounding content so may require additional accessible text. Text supplied to this option is appended to the end. Use `html` for more complicated scenarios.'
+              }
+            }
+          },
+          classes: {
+            type: 'string',
+            required: false,
+            description: 'Classes to add to the actions wrapper.'
           }
         }
       }
@@ -92,13 +119,13 @@ export const params = {
   classes: {
     type: 'string',
     required: false,
-    description: 'Classes to add to the summary list container.'
+    description: 'Classes to add to the container.'
   },
   attributes: {
     type: 'object',
     required: false,
     description:
-      'HTML attributes (for example data attributes) to add to the summary list container.'
+      'HTML attributes (for example data attributes) to add to the container.'
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes some macro options that should be represented as nested objects:

```console
'actions.classes'
'actions.items'
'conditional.html'
'key.html'
'key.text'
'value.classes'
'value.html'
'value.text'
```

It improves the **Nunjucks macro options** documentation for checkboxes, radios and summary list

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
