### PR TITLE
Export type declarations ` *.d.mts` for NHS.UK frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ Errors you might see include:
 
 This change was introduced in pull requests [#1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459), [#1466: Throw `ElementError` for all missing elements](https://github.com/nhsuk/nhsuk-frontend/pull/1466) and [#1481: Prevent multiple initialisations of a single component instance](https://github.com/nhsuk/nhsuk-frontend/pull/1481).
 
+:new: **New features**
+
+- [#1464: Export type declarations ` *.d.mts` for NHS.UK frontend](https://github.com/nhsuk/nhsuk-frontend/pull/1464)
+
 :wrench: **Fixes**
 
 - [#1463: Fix component nested Nunjucks macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1463)

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -44,7 +44,9 @@
     "build": "concurrently npm:build:* --group --prefix none",
     "build:package": "gulp build --color",
     "build:types": "tsc --build --noEmit false --pretty tsconfig.json",
-    "watch": "gulp watch --color",
+    "watch": "concurrently npm:watch:* --group --prefix none",
+    "watch:package": "gulp watch --color",
+    "watch:types": "npm run build:types -- --preserveWatchOutput --watch",
     "release": "gulp release --color",
     "version": "echo $npm_package_version",
     "start": "npm run watch"

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -14,6 +14,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/nhsuk/index.d.mts",
       "sass": "./dist/nhsuk/index.scss",
       "import": "./dist/nhsuk/index.mjs",
       "require": "./dist/nhsuk/index.js",
@@ -30,6 +31,7 @@
   "main": "dist/nhsuk/index.js",
   "module": "dist/nhsuk/index.mjs",
   "sass": "dist/nhsuk/index.scss",
+  "types": "dist/nhsuk/index.d.mts",
   "files": [
     "dist",
     "src",
@@ -39,7 +41,9 @@
   "scripts": {
     "prebuild": "npm run clean",
     "clean": "del-cli dist/**",
-    "build": "gulp build --color",
+    "build": "concurrently npm:build:* --group --prefix none",
+    "build:package": "gulp build --color",
+    "build:types": "tsc --build --noEmit false --pretty tsconfig.json",
     "watch": "gulp watch --color",
     "release": "gulp release --color",
     "version": "echo $npm_package_version",

--- a/packages/nhsuk-frontend/tsconfig.json
+++ b/packages/nhsuk-frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "lib": ["ESNext", "DOM"],
+    "outDir": "./dist",
+    "rootDir": "./src",
     "strict": true,
     "target": "ES2015",
     "types": ["node", "typed-query-selector"]

--- a/packages/nhsuk-frontend/tsconfig.json
+++ b/packages/nhsuk-frontend/tsconfig.json
@@ -2,10 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "lib": ["ESNext", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",
+    "sourceMap": true,
     "strict": true,
     "target": "ES2015",
     "types": ["node", "typed-query-selector"]

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -103,7 +103,8 @@ export function compile(
       file: !output.preserveModules ? join(destPath, outputPath) : undefined,
 
       // Enable source maps
-      sourcemap: true
+      sourcemap: true,
+      sourcemapExcludeSources: !!output.preserveModules
     })
   })
 }

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -38,7 +38,8 @@ export function compile(inputPath, { srcPath, destPath, output = {} }) {
     map: /** @type {ProcessOptions['map']} */ ({
       annotation: true,
       inline: false,
-      prev: false
+      prev: false,
+      sourcesContent: false
     }),
 
     // Sass syntax support
@@ -73,6 +74,7 @@ export function compile(inputPath, { srcPath, destPath, output = {} }) {
 
         // Pass source maps to PostCSS
         options.map.prev = map
+        options.map.sourcesContent = true
       }
     }
 


### PR DESCRIPTION
## Description

This PR adds type declaration support for JavaScript code autocomplete (and type checking)

It helps massively when integrating our [`nhsuk-frontend` npm package](https://www.npmjs.com/package/nhsuk-frontend) with projects using TypeScript and React

<img width="529" alt="Code autocomplete" src="https://github.com/user-attachments/assets/a11244e8-2b94-434c-956b-46659ed06127" />

<br>
<br>

Closes https://github.com/nhsuk/nhsuk-frontend/issues/1464

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
