### PR TITLE
Throw `ElementError` for all missing elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Errors you might see include:
 - `SupportError` - when NHS.UK frontend is not supported in the current browser
 - `ElementError` - when component templates have missing or broken HTML elements
 
-This change was introduced in [pull request #1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459).
+This change was introduced in pull requests [#1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459) and [#1466: Throw `ElementError` for all missing elements](https://github.com/nhsuk/nhsuk-frontend/pull/1466).
 
 :wrench: **Fixes**
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -10,6 +10,9 @@ describe('Character count', () => {
   /** @type {HTMLTextAreaElement} */
   let $textarea
 
+  /** @type {HTMLElement} */
+  let $description
+
   beforeEach(() => {
     document.body.innerHTML = components.render('character-count', {
       context: {
@@ -29,6 +32,8 @@ describe('Character count', () => {
     $textarea = getByRole($root, 'textbox', {
       name: 'Can you provide more detail?'
     })
+
+    $description = document.querySelector(`#${$textarea.id}-info`)
 
     jest.spyOn($textarea, 'addEventListener')
   })
@@ -53,9 +58,20 @@ describe('Character count', () => {
       )
     })
 
-    it('should not throw with missing textarea', () => {
+    it('should throw with missing textarea', () => {
       $textarea.remove()
-      expect(() => initCharacterCounts()).not.toThrow()
+
+      expect(() => initCharacterCounts()).toThrow(
+        'CharacterCount: Form field (`.nhsuk-js-character-count`) not found'
+      )
+    })
+
+    it('should throw with missing count message', () => {
+      $description.remove()
+
+      expect(() => new CharacterCount($root)).toThrow(
+        'CharacterCount: Count message (`id="example-info"`) not found'
+      )
     })
 
     it('should not throw with empty body', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -1,4 +1,5 @@
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Character count component
@@ -18,7 +19,12 @@ export class CharacterCount extends Component {
         $textarea instanceof HTMLInputElement
       )
     ) {
-      return this
+      throw new ElementError({
+        component: CharacterCount,
+        element: $textarea,
+        expectedType: 'HTMLTextareaElement or HTMLInputElement',
+        identifier: 'Form field (`.nhsuk-js-character-count`)'
+      })
     }
 
     this.$textarea = $textarea
@@ -26,10 +32,18 @@ export class CharacterCount extends Component {
     this.$screenReaderCountMessage = null
     this.lastInputTimestamp = null
 
-    // Check for module
+    const fallbackLimitMessageId = `${this.$textarea.id}-info`
     const $fallbackLimitMessage = document.getElementById(
-      `${this.$textarea.id}-info`
+      fallbackLimitMessageId
     )
+
+    if (!$fallbackLimitMessage) {
+      throw new ElementError({
+        component: CharacterCount,
+        element: $fallbackLimitMessage,
+        identifier: `Count message (\`id="${fallbackLimitMessageId}"\`)`
+      })
+    }
 
     // Move the fallback count message to be immediately after the textarea
     // Kept for backwards compatibility

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -129,12 +129,14 @@ describe('Checkboxes', () => {
       }
     })
 
-    it('should not throw with missing checkboxes', () => {
+    it('should throw with missing checkboxes', () => {
       for (const $input of $inputs) {
         $input.remove()
       }
 
-      expect(() => initCheckboxes()).not.toThrow()
+      expect(() => initCheckboxes()).toThrow(
+        'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+      )
     })
 
     it('should not throw with empty body', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -1,5 +1,6 @@
 import { toggleConditionalInput } from '../../common.mjs'
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Checkboxes component
@@ -15,9 +16,12 @@ export class Checkboxes extends Component {
   constructor($root) {
     super($root)
 
-    const $inputs = this.$root.querySelectorAll('.nhsuk-checkboxes__input')
+    const $inputs = this.$root.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
-      return this
+      throw new ElementError({
+        component: Checkboxes,
+        identifier: 'Form inputs (`<input type="checkbox">`)'
+      })
     }
 
     this.$inputs = $inputs

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
@@ -16,6 +16,9 @@ describe('Header class', () => {
   let $navigation
 
   /** @type {HTMLElement} */
+  let $navigationList
+
+  /** @type {HTMLElement} */
   let $menuButton
 
   let listWidth = 0
@@ -67,6 +70,8 @@ describe('Header class', () => {
     $root = document.querySelector('.nhsuk-header')
 
     $navigation = getByRole($root, 'navigation')
+    $navigationList = getByRole($navigation, 'list')
+
     $menuButton = getByRole($root, 'button', {
       name: 'Browse More',
       hidden: true
@@ -124,14 +129,44 @@ describe('Header class', () => {
       )
     })
 
-    it('should not throw with missing navigation', () => {
+    it('should throw with missing navigation', () => {
       $navigation.remove()
-      expect(() => initHeader()).not.toThrow()
+
+      expect(() => initHeader()).toThrow(
+        'Header: Navigation (`<nav class="nhsuk-header__navigation">`) not found'
+      )
     })
 
-    it('should not throw with missing menu button', () => {
+    it('should throw with missing navigation list', () => {
+      $navigationList.remove()
+
+      expect(() => initHeader()).toThrow(
+        'Header: List (`<ul class="nhsuk-header__navigation-list">`) not found'
+      )
+    })
+
+    it('should throw with missing navigation list items', () => {
+      $navigationList.innerHTML = ''
+
+      expect(() => initHeader()).toThrow(
+        'Header: List items (`<li class="nhsuk-header__navigation-item">`) not found'
+      )
+    })
+
+    it('should throw with missing menu item', () => {
+      $menuButton.parentElement.remove()
+
+      expect(() => initHeader()).toThrow(
+        'Header: Menu item (`<li class="nhsuk-header__menu" hidden>`) not found'
+      )
+    })
+
+    it('should throw with missing menu button', () => {
       $menuButton.remove()
-      expect(() => initHeader()).not.toThrow()
+
+      expect(() => initHeader()).toThrow(
+        'Header: Menu button (`<button class="nhsuk-header__menu-toggle">`) not found'
+      )
     })
 
     it('should not throw with empty body', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -1,4 +1,5 @@
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Header component
@@ -10,29 +11,61 @@ export class Header extends Component {
   constructor($root) {
     super($root)
 
-    this.navigation = this.$root.querySelector('.nhsuk-header__navigation')
-    this.navigationList = this.$root.querySelector(
+    const $navigation = this.$root.querySelector('.nhsuk-header__navigation')
+    const $navigationList = this.$root.querySelector(
       '.nhsuk-header__navigation-list'
     )
-    this.navigationItems = this.$root.querySelectorAll(
-      '.nhsuk-header__navigation-item'
+
+    const $navigationItems = /** @type {NodeListOf<HTMLElement>} */ (
+      this.$root.querySelectorAll('.nhsuk-header__navigation-item')
     )
 
-    this.menu = this.$root.querySelector('.nhsuk-header__menu')
-    this.menuToggle = this.$root.querySelector('.nhsuk-header__menu-toggle')
+    const $menu = this.$root.querySelector('.nhsuk-header__menu')
+    const $menuToggle = this.$root.querySelector('.nhsuk-header__menu-toggle')
 
-    if (
-      !this.navigation ||
-      !this.navigationList ||
-      !this.navigationItems ||
-      !this.navigationItems.length ||
-      !this.menu ||
-      !this.menuToggle
-    ) {
-      return this
+    if (!$navigation || !($navigation instanceof HTMLElement)) {
+      throw new ElementError({
+        component: Header,
+        identifier: 'Navigation (`<nav class="nhsuk-header__navigation">`)'
+      })
     }
 
-    this.menuList = document.createElement('ul')
+    if (!$navigationList || !($navigationList instanceof HTMLElement)) {
+      throw new ElementError({
+        component: Header,
+        identifier: 'List (`<ul class="nhsuk-header__navigation-list">`)'
+      })
+    }
+
+    if (!$navigationItems || !$navigationItems.length) {
+      throw new ElementError({
+        component: Header,
+        identifier: 'List items (`<li class="nhsuk-header__navigation-item">`)'
+      })
+    }
+
+    if (!$menu || !($menu instanceof HTMLElement)) {
+      throw new ElementError({
+        component: Header,
+        identifier: 'Menu item (`<li class="nhsuk-header__menu" hidden>`)'
+      })
+    }
+
+    if (!$menuToggle || !($menuToggle instanceof HTMLButtonElement)) {
+      throw new ElementError({
+        component: Header,
+        identifier:
+          'Menu button (`<button class="nhsuk-header__menu-toggle">`)',
+        expectedType: 'HTMLButtonElement'
+      })
+    }
+
+    this.$navigation = $navigation
+    this.$navigationList = $navigationList
+    this.$navigationItems = $navigationItems
+    this.$menu = $menu
+    this.$menuToggle = $menuToggle
+    this.$menuList = document.createElement('ul')
 
     this.menuIsEnabled = false
     this.menuIsOpen = false
@@ -65,7 +98,7 @@ export class Header extends Component {
 
     // Reset and calculate widths on every resize
     this.breakpoints.forEach((breakpoint) => {
-      this.navigationList.insertBefore(breakpoint.element, this.menu)
+      this.$navigationList.insertBefore(breakpoint.element, this.$menu)
 
       // Calculate widths
       right += breakpoint.element.offsetWidth
@@ -73,7 +106,7 @@ export class Header extends Component {
     })
 
     // Reset space for menu button
-    this.width = this.navigationList.offsetWidth
+    this.width = this.$navigationList.offsetWidth
   }
 
   /**
@@ -82,7 +115,7 @@ export class Header extends Component {
   setupNavigation() {
     this.breakpoints = []
 
-    this.navigationItems.forEach((element) => {
+    this.$navigationItems.forEach((element) => {
       this.breakpoints.push({ element, right: 0 })
     })
 
@@ -94,13 +127,13 @@ export class Header extends Component {
    * Add the menu to the DOM
    */
   setupMenu() {
-    if (this.menuList.parentElement) {
+    if (this.$menuList.parentElement) {
       return
     }
 
-    this.menuList.classList.add('nhsuk-header__menu-list')
-    this.menuList.setAttribute('hidden', '')
-    this.menu.appendChild(this.menuList)
+    this.$menuList.classList.add('nhsuk-header__menu-list')
+    this.$menuList.setAttribute('hidden', '')
+    this.$menu.appendChild(this.$menuList)
   }
 
   /**
@@ -112,10 +145,10 @@ export class Header extends Component {
     }
 
     this.menuIsEnabled = true
-    this.menu.removeAttribute('hidden')
+    this.$menu.removeAttribute('hidden')
 
     // Add click listener to toggle menu
-    this.menuToggle.addEventListener('click', this.handleToggleMenu)
+    this.$menuToggle.addEventListener('click', this.handleToggleMenu)
   }
 
   /**
@@ -128,10 +161,10 @@ export class Header extends Component {
 
     this.closeMenu()
     this.menuIsEnabled = false
-    this.menu.setAttribute('hidden', '')
+    this.$menu.setAttribute('hidden', '')
 
     // Remove click listener from toggle menu
-    this.menuToggle.removeEventListener('click', this.handleToggleMenu)
+    this.$menuToggle.removeEventListener('click', this.handleToggleMenu)
   }
 
   /**
@@ -147,9 +180,9 @@ export class Header extends Component {
     }
 
     this.menuIsOpen = false
-    this.menuList.setAttribute('hidden', '')
-    this.menuToggle.setAttribute('aria-expanded', 'false')
-    this.navigation.style.removeProperty('border-bottom-width')
+    this.$menuList.setAttribute('hidden', '')
+    this.$menuToggle.setAttribute('aria-expanded', 'false')
+    this.$navigation.style.removeProperty('border-bottom-width')
 
     // Remove escape key listener to close menu
     document.removeEventListener('keydown', this.handleEscapeKey)
@@ -185,11 +218,11 @@ export class Header extends Component {
     }
 
     this.menuIsOpen = true
-    this.menuList.removeAttribute('hidden')
-    this.menuToggle.setAttribute('aria-expanded', 'true')
-    this.navigation.style.setProperty(
+    this.$menuList.removeAttribute('hidden')
+    this.$menuToggle.setAttribute('aria-expanded', 'true')
+    this.$navigation.style.setProperty(
       'border-bottom-width',
-      `${this.menuList.offsetHeight}px`
+      `${this.$menuList.offsetHeight}px`
     )
 
     // Add escape key listener to close menu
@@ -236,20 +269,20 @@ export class Header extends Component {
     this.enableMenu()
 
     // Subtract space for menu button
-    this.width -= this.menu.offsetWidth
+    this.width -= this.$menu.offsetWidth
 
     // Move items based on available width
     this.breakpoints.forEach((breakpoint) => {
       if (breakpoint.right > this.width) {
-        this.menuList.insertAdjacentElement('beforeend', breakpoint.element)
+        this.$menuList.insertAdjacentElement('beforeend', breakpoint.element)
       }
     })
 
     // Update menu height if open
     if (this.menuIsOpen) {
-      this.navigation.style.setProperty(
+      this.$navigation.style.setProperty(
         'border-bottom-width',
-        `${this.menuList.offsetHeight}px`
+        `${this.$menuList.offsetHeight}px`
       )
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
@@ -127,12 +127,14 @@ describe('Radios', () => {
       }
     })
 
-    it('should not throw with missing radios', () => {
+    it('should throw with missing radios', () => {
       for (const $input of $inputs) {
         $input.remove()
       }
 
-      expect(() => initRadios()).not.toThrow()
+      expect(() => initRadios()).toThrow(
+        'Radios: Form inputs (`<input type="radio">`) not found'
+      )
     })
 
     it('should not throw with empty body', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -1,5 +1,6 @@
 import { toggleConditionalInput } from '../../common.mjs'
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Radios component
@@ -15,9 +16,12 @@ export class Radios extends Component {
   constructor($root) {
     super($root)
 
-    const $inputs = this.$root.querySelectorAll('.nhsuk-radios__input')
+    const $inputs = this.$root.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
-      return this
+      throw new ElementError({
+        component: Radios,
+        identifier: 'Form inputs (`<input type="radio">`)'
+      })
     }
 
     this.$inputs = $inputs

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -57,9 +57,20 @@ describe('Skip link', () => {
       expect(() => initSkipLinks()).not.toThrow()
     })
 
-    it('should not throw with missing main content', () => {
+    it('should throw with missing hash fragment', () => {
+      $root.setAttribute('href', 'https://example.com')
+
+      expect(() => initSkipLinks()).toThrow(
+        'SkipLink: Target link (`href="https://example.com"`) hash fragment not found'
+      )
+    })
+
+    it('should throw with missing main content', () => {
       $main.remove()
-      expect(() => initSkipLinks()).not.toThrow()
+
+      expect(() => initSkipLinks()).toThrow(
+        'SkipLink: Target content (`id="maincontent"`) not found'
+      )
     })
 
     it('should not throw with empty body', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -2,6 +2,7 @@
 
 import { setFocus } from '../../common.mjs'
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Skip link component
@@ -20,14 +21,26 @@ export class SkipLink extends Component {
   constructor($root) {
     super($root)
 
-    const linkedElementId = this.$root.hash.split('#').pop()
-    const $linkedElement = linkedElementId
-      ? document.getElementById(linkedElementId)
-      : null
+    const hash = this.$root.hash
+    const href = this.$root.getAttribute('href') ?? ''
+
+    const linkedElementId = hash.split('#').pop()
+    if (!linkedElementId) {
+      throw new ElementError({
+        component: SkipLink,
+        identifier: `Target link (\`href="${href}"\`) hash fragment`
+      })
+    }
+
+    const $linkedElement = document.getElementById(linkedElementId)
 
     // Check for linked element
     if (!$linkedElement) {
-      return this
+      throw new ElementError({
+        component: SkipLink,
+        element: $linkedElement,
+        identifier: `Target content (\`id="${linkedElementId}"\`)`
+      })
     }
 
     /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -1,4 +1,5 @@
 import { Component } from '../../component.mjs'
+import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Tabs component
@@ -10,22 +11,40 @@ export class Tabs extends Component {
   constructor($root) {
     super($root)
 
-    const $tabs = this.$root.querySelectorAll('.nhsuk-tabs__tab')
-    const $tabList = this.$root.querySelector('.nhsuk-tabs__list')
-    const $tabListItems = this.$root.querySelectorAll('.nhsuk-tabs__list-item')
-
-    if (!$tabs.length || !$tabList || !$tabListItems.length) {
-      return this
+    const $tabs = this.$root.querySelectorAll('a.nhsuk-tabs__tab')
+    if (!$tabs.length) {
+      throw new ElementError({
+        component: Tabs,
+        identifier: 'Links (`<a class="nhsuk-tabs__tab">`)'
+      })
     }
 
     this.$tabs = $tabs
-    this.$tabList = $tabList
-    this.$tabListItems = $tabListItems
 
     // Save bound functions so we can remove event listeners during teardown
     this.boundTabClick = this.onTabClick.bind(this)
     this.boundTabKeydown = this.onTabKeydown.bind(this)
     this.boundOnHashChange = this.onHashChange.bind(this)
+
+    const $tabList = this.$root.querySelector('.nhsuk-tabs__list')
+    const $tabListItems = this.$root.querySelectorAll('.nhsuk-tabs__list-item')
+
+    if (!$tabList) {
+      throw new ElementError({
+        component: Tabs,
+        identifier: 'List (`<ul class="nhsuk-tabs__list">`)'
+      })
+    }
+
+    if (!$tabListItems.length) {
+      throw new ElementError({
+        component: Tabs,
+        identifier: 'List items (`<li class="nhsuk-tabs__list-item">`)'
+      })
+    }
+
+    this.$tabList = $tabList
+    this.$tabListItems = $tabListItems
 
     this.keys = {
       down: 40,


### PR DESCRIPTION
## Description

This PR follows https://github.com/nhsuk/nhsuk-frontend/pull/1459 and throws `ElementError` for all missing elements

We're following GOV.UK Frontend's lead with this, especially for services that don't use the Nunjucks components

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
