### PR TITLE
Update components to set a default `id` based on `name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This change was introduced in [pull request #1459: Add NHS.UK frontend browser s
 :wrench: **Fixes**
 
 - [#1463: Fix component nested Nunjucks macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1463)
+- [#1467: Update components to set a default `id` based on `name`](https://github.com/nhsuk/nhsuk-frontend/pull/1467)
 
 ## 10.0.0-internal.0 - 2 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
@@ -10,8 +10,8 @@ export const name = 'Character count'
 export const params = {
   id: {
     type: 'string',
-    required: true,
-    description: 'The id of the textarea.'
+    required: false,
+    description: 'The ID of the textarea. Defaults to the value of `name`.'
   },
   describedBy: {
     type: 'string',

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/template.njk
@@ -1,14 +1,16 @@
 {% from "nhsuk/components/textarea/macro.njk" import textarea %}
 {% from "nhsuk/components/hint/macro.njk" import hint %}
 
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="nhsuk-character-count" data-module="nhsuk-character-count"
 {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
 {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
 {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}>
   {{ textarea({
-    id: params.id,
+    id: id,
     name: params.name,
-    describedBy: params.id + '-info',
+    describedBy: id + '-info',
     rows: params.rows,
     spellcheck: params.spellcheck,
     value: params.value,
@@ -20,7 +22,7 @@
       classes: params.label.classes,
       isPageHeading: params.label.isPageHeading,
       attributes: params.label.attributes,
-      for: params.id
+      for: id
     },
     hint: params.hint,
     errorMessage: params.errorMessage,
@@ -28,7 +30,7 @@
   }) }}
   {{ hint({
     text: 'You can enter up to ' + (params.maxlength or params.maxwords) + (' words' if params.maxwords else ' characters'),
-    id: params.id + '-info',
+    id: id + '-info',
     classes: 'nhsuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}
 </div>

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/macro-options.mjs
@@ -10,8 +10,8 @@ export const name = 'Input'
 export const params = {
   id: {
     type: 'string',
-    required: true,
-    description: 'The id of the input.'
+    required: false,
+    description: 'The ID of the input. Defaults to the value of `name`.'
   },
   name: {
     type: 'string',

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -5,7 +5,9 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{%- set describedBy = "" -%}
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="nhsuk-form-group
 {%- if params.errorMessage %} nhsuk-form-group--error{% endif %}
 {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
@@ -15,10 +17,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | indent(2) | trim -}}
 {%- if params.hint %}
-  {%- set hintId = params.id + '-hint' if params.id %}
+  {%- set hintId = id + '-hint' if id %}
   {%- set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ hint({
     id: hintId,
@@ -29,7 +31,7 @@
   }) | indent(2) | trim -}}
 {% endif -%}
 {%- if params.errorMessage %}
-  {%- set errorId = params.id + '-error' %}
+  {%- set errorId = id + '-error' %}
   {%- set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ errorMessage({
     id: errorId,
@@ -46,7 +48,7 @@
     {% endif %}
     <input class="nhsuk-input
     {%- if params.classes %} {{ params.classes }}{% endif %}
-    {%- if params.errorMessage %} nhsuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+    {%- if params.errorMessage %} nhsuk-input--error{% endif %}" id="{{ id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
     {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
     {%- if params.value %} value="{{ params.value}}"{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
@@ -10,8 +10,8 @@ export const name = 'Select'
 export const params = {
   id: {
     type: 'string',
-    required: true,
-    description: 'Id for each select box.'
+    required: false,
+    description: 'The ID of the select. Defaults to the value of `name`.'
   },
   name: {
     type: 'string',

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
@@ -16,10 +16,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | indent(2) | trim }}
 {%- if params.hint %}
-  {%- set hintId = params.id + '-hint' %}
+  {%- set hintId = id + '-hint' %}
   {%- set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ hint({
     id: hintId,
@@ -30,7 +30,7 @@
   }) | indent(2) | trim }}
 {%- endif -%}
 {%- if params.errorMessage %}
-  {%- set errorId = params.id + '-error' %}
+  {%- set errorId = id + '-error' %}
   {%- set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ errorMessage({
     id: errorId,

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/macro-options.mjs
@@ -10,8 +10,8 @@ export const name = 'Textarea'
 export const params = {
   id: {
     type: 'string',
-    required: true,
-    description: 'The id of the textarea.'
+    required: false,
+    description: 'The ID of the textarea. Defaults to the value of `name`.'
   },
   name: {
     type: 'string',

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
@@ -5,7 +5,9 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{%- set describedBy = "" -%}
+{%- set id = params.id if params.id else params.name -%}
+
 <div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
   {{ label({
     html: params.label.html,
@@ -13,10 +15,10 @@
     classes: params.label.classes,
     isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
-    for: params.id
+    for: id
   }) | indent(2) | trim }}
 {%- if params.hint %}
-  {%- set hintId = params.id + '-hint' %}
+  {%- set hintId = id + '-hint' %}
   {%- set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ hint({
     id: hintId,
@@ -27,7 +29,7 @@
   }) | indent(2) | trim }}
 {%- endif %}
 {%- if params.errorMessage %}
-  {%- set errorId = params.id + '-error' %}
+  {%- set errorId = id + '-error' %}
   {%- set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ errorMessage({
     id: errorId,
@@ -38,7 +40,7 @@
 {%- endif %}
   <textarea class="nhsuk-textarea
   {%- if params.errorMessage %} nhsuk-textarea--error{% endif %}
-  {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="
+  {%- if params.classes %} {{ params.classes }}{% endif %}" id="{{ id }}" name="{{ params.name }}" rows="
   {%- if params.rows %} {{ params.rows }} {% else %}5{%endif %}"
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}


### PR DESCRIPTION
## Description

This PR adds the following Nunjucks line to a few missed components:

```njk
{%- set id = params.id if params.id else params.name -%}
```

Notably the [**Select** component](https://service-manual.nhs.uk/design-system/components/select) where it was only partially used

See this issue https://github.com/alphagov/govuk-frontend/issues/3497 for more information

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
