### PR TITLE
Support initial `aria-describedby` on all form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This change was introduced in [pull request #1459: Add NHS.UK frontend browser s
 
 - [#1463: Fix component nested Nunjucks macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1463)
 - [#1467: Update components to set a default `id` based on `name`](https://github.com/nhsuk/nhsuk-frontend/pull/1467)
+- [#1468: Support initial `aria-describedby` on all form fields](https://github.com/nhsuk/nhsuk-frontend/pull/1468)
 
 ## 10.0.0-internal.0 - 2 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
@@ -13,12 +13,6 @@ export const params = {
     required: false,
     description: 'The ID of the textarea. Defaults to the value of `name`.'
   },
-  describedBy: {
-    type: 'string',
-    required: false,
-    description:
-      'Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.'
-  },
   name: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
@@ -8,6 +8,12 @@ export const name = 'Checkboxes'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  describedBy: {
+    type: 'string',
+    required: false,
+    description:
+      'One or more element IDs to add to the input `aria-describedby` attribute without a fieldset, used to provide additional descriptive information for screenreader users.'
+  },
   fieldset: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -10,7 +10,10 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{%- set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" -%}
+{%- set describedBy = params.describedBy if params.describedBy else "" -%}
+{%- if params.fieldset.describedBy -%}
+  {% set describedBy = params.fieldset.describedBy %}
+{%- endif -%}
 
 {% set isConditional = false %}
 {% for item in params.items %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -6,11 +6,11 @@
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
-{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+{%- set idPrefix = params.idPrefix if params.idPrefix else params.name -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{%- set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" -%}
 
 {% set isConditional = false %}
 {% for item in params.items %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -6,7 +6,7 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
 
 {% if params.items %}
   {% set dateInputItems = params.items %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -5,7 +5,7 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{%- set describedBy = "" -%}
+{%- set describedBy = params.describedBy if params.describedBy else "" -%}
 {%- set id = params.id if params.id else params.name -%}
 
 <div class="nhsuk-form-group

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -6,11 +6,11 @@
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
-{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+{%- set idPrefix = params.idPrefix if params.idPrefix else params.name -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{%- set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" -%}
 
 {% set isConditional = false %}
 {% for item in params.items %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
@@ -63,6 +63,12 @@ export const params = {
     description:
       'If `true`, select box will be disabled. Use the `disabled` option on each individual item to only disable certain options.'
   },
+  describedBy: {
+    type: 'string',
+    required: false,
+    description:
+      'One or more element IDs to add to the `aria-describedby` attribute, used to provide additional descriptive information for screenreader users.'
+  },
   label: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
@@ -5,7 +5,7 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{%- set describedBy = "" -%}
+{%- set describedBy = params.describedBy if params.describedBy else "" -%}
 {%- set id = params.id if params.id else params.name -%}
 
 <div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
@@ -5,7 +5,7 @@
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{%- set describedBy = "" -%}
+{%- set describedBy = params.describedBy if params.describedBy else "" -%}
 {%- set id = params.id if params.id else params.name -%}
 
 <div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">


### PR DESCRIPTION
## Description

This PR adds a feature from GOV.UK Frontend to close https://github.com/nhsuk/nhsuk-frontend/issues/1348

* https://github.com/alphagov/govuk-frontend/pull/1347

### Components with fieldsets

The following components were documented to support `params.fieldset.describedBy` but it was missing:

* Checkboxes
* Radios
* Date input

### Documented but not supported

The following components were documented to support `params.describedBy` but it was missing:

* ~Character count~
* Textarea
* Text input

**Note:** Character count should not support `params.describedBy` as it must be set to the "count message" hint ID instead

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
