### PR TITLE
Remove deprecated code and legacy feature detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 You must make the following changes when you migrate to this release, or your service might break.
 
+#### Check that tabs components work as expected
+
+The tabs component no longer triggers the `tab.show` and `tab.hide` custom events. [Get in touch](https://service-manual.nhs.uk/get-in-touch) if you need to continue using these events.
+
+This change was introduced in [pull request #1469: Remove deprecated code and legacy feature detection](https://github.com/nhsuk/nhsuk-frontend/pull/1469).
+
 #### Check that details components work as expected
 
 The details component no longer uses JavaScript, and is no longer polyfilled in older browsers.
@@ -37,6 +43,7 @@ This change was introduced in pull requests [#1459: Add NHS.UK frontend browser 
 - [#1463: Fix component nested Nunjucks macro options](https://github.com/nhsuk/nhsuk-frontend/pull/1463)
 - [#1467: Update components to set a default `id` based on `name`](https://github.com/nhsuk/nhsuk-frontend/pull/1467)
 - [#1468: Support initial `aria-describedby` on all form fields](https://github.com/nhsuk/nhsuk-frontend/pull/1468)
+- [#1469: Remove deprecated code and legacy feature detection](https://github.com/nhsuk/nhsuk-frontend/pull/1469)
 
 ## 10.0.0-internal.0 - 2 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/common.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common.jsdom.test.mjs
@@ -1,8 +1,52 @@
 import {
+  getFragmentFromUrl,
   isSupported,
   toggleAttribute,
   toggleConditionalInput
 } from './common.mjs'
+
+describe('getFragmentFromUrl util', () => {
+  it.each([
+    {
+      url: 'https://www.nhs.uk/#content',
+      fragment: 'content'
+    },
+    {
+      url: 'https://www.nhs.uk/example/#content',
+      fragment: 'content'
+    },
+    {
+      url: 'https://www.nhs.uk/example/?keywords=123#content',
+      fragment: 'content'
+    },
+    {
+      url: '/#content',
+      fragment: 'content'
+    },
+    {
+      url: '/example/#content',
+      fragment: 'content'
+    },
+    {
+      url: '/?keywords=123#content',
+      fragment: 'content'
+    },
+    {
+      url: '#content',
+      fragment: 'content'
+    },
+    {
+      url: '/',
+      fragment: undefined
+    },
+    {
+      url: '',
+      fragment: undefined
+    }
+  ])("returns '$fragment' for '$url'", ({ url, fragment }) => {
+    expect(getFragmentFromUrl(url)).toBe(fragment)
+  })
+})
 
 describe('isSupported util', () => {
   it('returns true if the nhsuk-frontend-supported class is set', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/common.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common.mjs
@@ -1,4 +1,21 @@
 /**
+ * Get hash fragment from URL
+ *
+ * Extract the hash fragment (everything after the hash) from a URL,
+ * but not including the hash symbol
+ *
+ * @param {string} url - URL
+ * @returns {string | undefined} Fragment from URL, without the hash
+ */
+export function getFragmentFromUrl(url) {
+  if (!url.includes('#')) {
+    return undefined
+  }
+
+  return url.split('#').pop()
+}
+
+/**
  * Toggle a boolean attribute on a HTML element
  *
  * @param {HTMLElement} element

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -1,6 +1,5 @@
 import { Component } from '../../component.mjs'
 
-const KEY_SPACE = 32
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
 
 /**
@@ -33,16 +32,16 @@ export class Button extends Component {
    * @param {KeyboardEvent} event - Keydown event
    */
   handleKeyDown(event) {
-    // get the target element
+    const target = event.target
 
-    const { target } = event
-    // if the element has a role='button' and the pressed key is a space, we'll simulate a click
-    if (
-      target.getAttribute('role') === 'button' &&
-      event.keyCode === KEY_SPACE
-    ) {
+    // Handle space bar only
+    if (event.key !== ' ') {
+      return
+    }
+
+    // Handle elements with [role="button"] only
+    if (target.getAttribute('role') === 'button') {
       event.preventDefault()
-      // trigger the target's click event
       target.click()
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -210,7 +210,7 @@ export class CharacterCount extends Component {
     if (this.isOverThreshold()) {
       $screenReaderCountMessage.removeAttribute('aria-hidden')
     } else {
-      $screenReaderCountMessage.setAttribute('aria-hidden', true)
+      $screenReaderCountMessage.setAttribute('aria-hidden', 'true')
     }
 
     // Update message

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -99,17 +99,13 @@ export class CharacterCount extends Component {
     this.bindChangeEvents()
 
     // When the page is restored after navigating 'back' in some browsers the
-    // state of the character count is not restored until *after* the DOMContentLoaded
-    // event is fired, so we need to manually update it after the pageshow event
-    // in browsers that support it.
-    if ('onpageshow' in window) {
-      window.addEventListener('pageshow', this.updateCountMessage.bind(this))
-    } else {
-      window.addEventListener(
-        'DOMContentLoaded',
-        this.updateCountMessage.bind(this)
-      )
-    }
+    // state of form controls is not restored until *after* the DOMContentLoaded
+    // event is fired, so we need to sync after the pageshow event.
+    window.addEventListener('pageshow', () => this.updateCountMessage())
+
+    // Although we've set up handlers to sync state on the pageshow event, init
+    // could be called after those events have fired, for example if they are
+    // added to the page dynamically, so update now too.
     this.updateCountMessage()
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -123,7 +123,7 @@ describe('Checkboxes', () => {
 
       for (const $input of $inputs) {
         expect($input.addEventListener).toHaveBeenCalledWith(
-          'change',
+          'click',
           expect.any(Function)
         )
       }

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -38,7 +38,7 @@ export class Checkboxes extends Component {
 
     // Attach handleClick as click to inputs
     this.$inputs.forEach((checkboxButton) => {
-      checkboxButton.addEventListener('change', this.handleClick.bind(this))
+      checkboxButton.addEventListener('click', this.handleClick.bind(this))
     })
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -28,17 +28,8 @@ export class Checkboxes extends Component {
 
     // When the page is restored after navigating 'back' in some browsers the
     // state of form controls is not restored until *after* the DOMContentLoaded
-    // event is fired, so we need to sync after the pageshow event in browsers
-    // that support it.
-    if ('onpageshow' in window) {
-      window.addEventListener('pageshow', () =>
-        this.syncAllConditionalReveals()
-      )
-    } else {
-      window.addEventListener('DOMContentLoaded', () =>
-        this.syncAllConditionalReveals()
-      )
-    }
+    // event is fired, so we need to sync after the pageshow event.
+    window.addEventListener('pageshow', () => this.syncAllConditionalReveals())
 
     // Although we've set up handlers to sync state on the pageshow or
     // DOMContentLoaded event, init could be called after those events have fired,

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -1,3 +1,4 @@
+import { getFragmentFromUrl } from '../../common.mjs'
 import { Component } from '../../component.mjs'
 
 /**
@@ -94,7 +95,12 @@ export class ErrorSummary extends Component {
       return false
     }
 
-    const input = document.querySelector(target.hash)
+    const inputId = getFragmentFromUrl(target.href)
+    if (!inputId) {
+      return false
+    }
+
+    const input = document.getElementById(inputId)
     if (!input) {
       return false
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/macro-options.mjs
@@ -104,7 +104,6 @@ export const examples = {
       html: outdent`
         <p class="nhsuk-body-l">This is some more content which explains the product or service.</p>
         ${components.render('button', {
-          layout: 'layouts/example-full-width.njk',
           context: {
             text: 'Sign up',
             classes: 'nhsuk-button--reverse',

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -28,17 +28,8 @@ export class Radios extends Component {
 
     // When the page is restored after navigating 'back' in some browsers the
     // state of form controls is not restored until *after* the DOMContentLoaded
-    // event is fired, so we need to sync after the pageshow event in browsers
-    // that support it.
-    if ('onpageshow' in window) {
-      window.addEventListener('pageshow', () =>
-        this.syncAllConditionalReveals()
-      )
-    } else {
-      window.addEventListener('DOMContentLoaded', () =>
-        this.syncAllConditionalReveals()
-      )
-    }
+    // event is fired, so we need to sync after the pageshow event.
+    window.addEventListener('pageshow', () => this.syncAllConditionalReveals())
 
     // Although we've set up handlers to sync state on the pageshow or
     // DOMContentLoaded event, init could be called after those events have fired,

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-extraneous-class */
 
-import { setFocus } from '../../common.mjs'
+import { getFragmentFromUrl, setFocus } from '../../common.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -24,7 +24,7 @@ export class SkipLink extends Component {
     const hash = this.$root.hash
     const href = this.$root.getAttribute('href') ?? ''
 
-    const linkedElementId = hash.split('#').pop()
+    const linkedElementId = getFragmentFromUrl(hash)
     if (!linkedElementId) {
       throw new ElementError({
         component: SkipLink,

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -127,7 +127,7 @@ export class Tabs extends Component {
     this.$tabList.removeAttribute('role')
 
     this.$tabListItems.forEach(($item) => {
-      $item.removeAttribute('role', 'presentation')
+      $item.removeAttribute('role')
     })
 
     this.$tabs.forEach(($tab) => {
@@ -305,13 +305,13 @@ export class Tabs extends Component {
 
   unhighlightTab($tab) {
     $tab.setAttribute('aria-selected', 'false')
-    $tab.parentNode.classList.remove('nhsuk-tabs__list-item--selected')
+    $tab.parentElement.classList.remove('nhsuk-tabs__list-item--selected')
     $tab.setAttribute('tabindex', '-1')
   }
 
   highlightTab($tab) {
     $tab.setAttribute('aria-selected', 'true')
-    $tab.parentNode.classList.add('nhsuk-tabs__list-item--selected')
+    $tab.parentElement.classList.add('nhsuk-tabs__list-item--selected')
     $tab.setAttribute('tabindex', '0')
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -1,3 +1,4 @@
+import { getFragmentFromUrl } from '../../common.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -177,7 +178,7 @@ export class Tabs extends Component {
 
   setAttributes($tab) {
     // set tab attributes
-    const panelId = Tabs.getHref($tab).slice(1)
+    const panelId = getFragmentFromUrl($tab.href)
     $tab.setAttribute('id', `tab_${panelId}`)
     $tab.setAttribute('role', 'tab')
     $tab.setAttribute('aria-controls', panelId)
@@ -230,7 +231,7 @@ export class Tabs extends Component {
     const { id } = $panel
     $panel.id = ''
     this.changingHash = true
-    window.location.hash = Tabs.getHref($tab).slice(1)
+    window.location.hash = id
     $panel.id = id
   }
 
@@ -284,8 +285,8 @@ export class Tabs extends Component {
   }
 
   getPanel($tab) {
-    const $panel = this.$root.querySelector(Tabs.getHref($tab))
-    return $panel
+    const panelId = getFragmentFromUrl($tab.href)
+    return this.$root.querySelector(`#${panelId}`)
   }
 
   showPanel($tab) {
@@ -314,15 +315,6 @@ export class Tabs extends Component {
     return this.$root.querySelector(
       '.nhsuk-tabs__list-item--selected .nhsuk-tabs__tab'
     )
-  }
-
-  // this is because IE doesn't always return the actual value but a relative full path
-  // should be a utility function most prob
-  // http://labs.thesedays.com/blog/2010/01/08/getting-the-href-value-with-jquery-in-ie/
-  static getHref($tab) {
-    const href = $tab.getAttribute('href')
-    const hash = href.slice(href.indexOf('#'), href.length)
-    return hash
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -47,13 +47,6 @@ export class Tabs extends Component {
     this.$tabList = $tabList
     this.$tabListItems = $tabListItems
 
-    this.keys = {
-      down: 40,
-      left: 37,
-      right: 39,
-      up: 38
-    }
-
     this.jsHiddenClass = 'nhsuk-tabs__panel--hidden'
 
     if (typeof window.matchMedia === 'function') {
@@ -235,20 +228,23 @@ export class Tabs extends Component {
     $panel.id = id
   }
 
-  onTabKeydown(e) {
-    switch (e.keyCode) {
-      case this.keys.left:
-      case this.keys.up:
+  onTabKeydown(event) {
+    switch (event.key) {
+      // 'Left', 'Right', 'Up' and 'Down' required for Edge 16 support.
+      case 'ArrowLeft':
+      case 'ArrowUp':
+      case 'Left':
+      case 'Up':
         this.activatePreviousTab()
-        e.preventDefault()
+        event.preventDefault()
         break
-      case this.keys.right:
-      case this.keys.down:
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'Right':
+      case 'Down':
         this.activateNextTab()
-        e.preventDefault()
+        event.preventDefault()
         break
-
-      default:
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -55,9 +55,6 @@ export class Tabs extends Component {
 
     this.jsHiddenClass = 'nhsuk-tabs__panel--hidden'
 
-    this.showEvent = new CustomEvent('tab.show')
-    this.hideEvent = new CustomEvent('tab.hide')
-
     if (typeof window.matchMedia === 'function') {
       this.setupResponsiveChecks()
     } else {
@@ -294,13 +291,11 @@ export class Tabs extends Component {
   showPanel($tab) {
     const $panel = this.getPanel($tab)
     $panel.classList.remove(this.jsHiddenClass)
-    $panel.dispatchEvent(this.showEvent)
   }
 
   hidePanel(tab) {
     const $panel = this.getPanel(tab)
     $panel.classList.add(this.jsHiddenClass)
-    $panel.dispatchEvent(this.hideEvent)
   }
 
   unhighlightTab($tab) {


### PR DESCRIPTION
## Description

Following https://github.com/nhsuk/nhsuk-frontend/issues/1236, this PR removes various features no longer needed, for example:

* Add common helper `getFragmentFromUrl()` to replace `SkipLink.getHref()` IE workaround
* Skip unnecessary [`pageshow` feature](https://caniuse.com/mdn-api_window_pageshow_event) detection for IE8–10
* Remove [deprecated `event.keyCode`](https://caniuse.com/mdn-api_keyboardevent_keycode)
* Remove tab component unused custom events

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
