### PR TITLE
Fix for border bottom on windows high-contrast issue, closes #1458

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -337,7 +337,7 @@ $_header-item-active-size: $nhsuk-focus-width;
   color: $color_nhsuk-white;
 
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    border: none;
+    border: 0;
   }
 
   @include nhsuk-print-hide;


### PR DESCRIPTION
## Description
Fix for issue: #1458 

Tested via browser stack, on white and blue nav.

With fix:
![image](https://github.com/user-attachments/assets/8c8bddbf-ab34-4317-b893-f4d4f7bb7d80)


## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
