### PR TITLE
Fix styles for button as link :visited when :active and :focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This change was introduced in pull requests [#1459: Add NHS.UK frontend browser 
 - [#1467: Update components to set a default `id` based on `name`](https://github.com/nhsuk/nhsuk-frontend/pull/1467)
 - [#1468: Support initial `aria-describedby` on all form fields](https://github.com/nhsuk/nhsuk-frontend/pull/1468)
 - [#1469: Remove deprecated code and legacy feature detection](https://github.com/nhsuk/nhsuk-frontend/pull/1469)
+- [#1471: Fix styles for button as link :visited when :active and :focus](https://github.com/nhsuk/nhsuk-frontend/pull/1471)
 
 ## 10.0.0-internal.0 - 2 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
@@ -91,7 +91,8 @@ $button-padding-left-right: 16px;
   }
 
   // Remove button shadow when pressed
-  &:active {
+  &:active,
+  &:active:focus {
     box-shadow: none;
     background-color: $nhsuk-button-active-color;
     top: $button-shadow-size;
@@ -150,7 +151,8 @@ $button-padding-left-right: 16px;
   }
 
   // Set border for active state (no shadow)
-  &:active {
+  &:active,
+  &:active:focus {
     background-color: $nhsuk-secondary-button-active-color;
     border-color: $nhsuk-secondary-button-border-color;
     border-radius: $button-border-radius;
@@ -211,7 +213,8 @@ $button-padding-left-right: 16px;
     background-color: $nhsuk-reverse-button-hover-color;
   }
 
-  &:active {
+  &:active,
+  &:active:focus {
     background-color: $nhsuk-reverse-button-active-color;
   }
 }
@@ -225,7 +228,8 @@ $button-padding-left-right: 16px;
     background-color: $nhsuk-warning-button-hover-color;
   }
 
-  &:active {
+  &:active,
+  &:active:focus {
     background-color: $nhsuk-warning-button-active-color;
   }
 }
@@ -239,7 +243,8 @@ $button-padding-left-right: 16px;
     background-color: $nhsuk-login-button-hover-color;
   }
 
-  &:active {
+  &:active,
+  &:active:focus {
     background-color: $nhsuk-login-button-active-color;
   }
 }


### PR DESCRIPTION
## Description

To resolve #1372

There may be a smarter way, to not apply focus styles on active buttons, but I couldn't get that working and this seems to work.
 
## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
