### PR TITLE
Fix missing `attributes` option on form groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This change was introduced in pull requests [#1459: Add NHS.UK frontend browser 
 - [#1467: Update components to set a default `id` based on `name`](https://github.com/nhsuk/nhsuk-frontend/pull/1467)
 - [#1468: Support initial `aria-describedby` on all form fields](https://github.com/nhsuk/nhsuk-frontend/pull/1468)
 - [#1469: Remove deprecated code and legacy feature detection](https://github.com/nhsuk/nhsuk-frontend/pull/1469)
+- [#1474: Fix missing `attributes` option on form groups](https://github.com/nhsuk/nhsuk-frontend/pull/1474)
 
 ## 10.0.0-internal.0 - 2 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/macro-options.mjs
@@ -58,6 +58,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
@@ -43,6 +43,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -94,7 +94,8 @@
   </div>
 {% endset -%}
 
-<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- nhsukAttributes(params.formGroup.attributes) }}>
 {% if params.fieldset %}
   {% call fieldset({
     describedBy: describedBy,

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/macro-options.mjs
@@ -108,6 +108,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -79,7 +79,8 @@
   </div>
 {%- endset -%}
 
-<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %}  {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %}  {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- nhsukAttributes(params.formGroup.attributes) }}>
 {% if params.fieldset %}
 {#- We override the fieldset's role to 'group' because otherwise JAWS does not
     announce the description for a fieldset comprised of text inputs, but

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/macro-options.mjs
@@ -79,6 +79,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -10,7 +10,8 @@
 
 <div class="nhsuk-form-group
   {%- if params.errorMessage %} nhsuk-form-group--error{% endif %}
-  {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- nhsukAttributes(params.formGroup.attributes) }}>
   {{ label({
     html: params.label.html,
     text: params.label.text,

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -9,8 +9,8 @@
 {%- set id = params.id if params.id else params.name -%}
 
 <div class="nhsuk-form-group
-{%- if params.errorMessage %} nhsuk-form-group--error{% endif %}
-{%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+  {%- if params.errorMessage %} nhsuk-form-group--error{% endif %}
+  {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
   {{ label({
     html: params.label.html,
     text: params.label.text,

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
@@ -38,6 +38,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -88,7 +88,8 @@
   </div>
 {% endset -%}
 
-<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- nhsukAttributes(params.formGroup.attributes) }}>
 {% if params.fieldset %}
   {% call fieldset({
     describedBy: describedBy,

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
@@ -99,6 +99,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/macro-options.mjs
@@ -65,6 +65,12 @@ export const params = {
         required: false,
         description:
           'Classes to add to the form group (for example to show error state for the whole group).'
+      },
+      attributes: {
+        type: 'object',
+        required: false,
+        description:
+          'HTML attributes (for example data attributes) to add to the form group.'
       }
     }
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
@@ -8,7 +8,8 @@
 {%- set describedBy = params.describedBy if params.describedBy else "" -%}
 {%- set id = params.id if params.id else params.name -%}
 
-<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+<div class="nhsuk-form-group {%- if params.errorMessage %} nhsuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}"
+  {{- nhsukAttributes(params.formGroup.attributes) }}>
   {{ label({
     html: params.label.html,
     text: params.label.text,


### PR DESCRIPTION
## Description

Previous updates to NHS.UK frontend have added `attributes` support to some component form groups

This PR reviews all components and adds support where it was missed

### Components with form group attributes support

The following components support `params.formGroup.attributes` but it's not documented:

* Character count
* Select

### Components without form group attributes support

The following components do not support `params.formGroup.attributes`:

* Checkboxes
* Radios
* Date input
* Text input
* Textarea

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
