### PR TITLE
Add missing `data-module` attributes to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@
 
 You must make the following changes when you migrate to this release, or your service might break.
 
+#### Add missing `data-module` attributes to components
+
+You do not need to do anything if you're using Nunjucks macros.
+
+If you are not using Nunjucks macros, add the missing `data-module` attributes to the following components' HTML:
+
+```patch
+- <div class="nhsuk-checkboxes">
++ <div class="nhsuk-checkboxes" data-module="nhsuk-checkboxes">
+```
+
+```patch
+- <div class="nhsuk-radios">
++ <div class="nhsuk-radios" data-module="nhsuk-radios">
+```
+
+```patch
+- <div class="nhsuk-error-summary">
++ <div class="nhsuk-error-summary" data-module="nhsuk-error-summary">
+```
+
+```patch
+- <header class="nhsuk-header">
++ <header class="nhsuk-header" data-module="nhsuk-header">
+```
+
+```patch
+- <a class="nhsuk-skip-link">
++ <a class="nhsuk-skip-link" data-module="nhsuk-skip-link">
+```
+
+This change was introduced in [pull request #1480: Add missing component `data-module` attributes](https://github.com/nhsuk/nhsuk-frontend/pull/1480).
+
 #### Check that tabs components work as expected
 
 The tabs component no longer triggers the `tab.show` and `tab.hide` custom events. [Get in touch](https://service-manual.nhs.uk/get-in-touch) if you need to continue using these events.

--- a/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
@@ -133,4 +133,19 @@ export function isSupported($scope = document.body) {
   return $scope.classList.contains('nhsuk-frontend-supported')
 }
 
+/**
+ * Format error message
+ *
+ * @param {ComponentConstructor} Component - Component that threw the error
+ * @param {string} message - Error message
+ * @returns {string} - Formatted error message
+ */
+export function formatErrorMessage(Component, message) {
+  return `${Component.moduleName}: ${message}`
+}
+
 export * from './nhsuk-frontend-version.mjs'
+
+/**
+ * @import { ComponentConstructor } from '../component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -54,6 +54,11 @@ export class Component {
       throw new SupportError()
     }
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-component'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
@@ -1,5 +1,4 @@
 import { components } from '@nhsuk/frontend-lib'
-import { getByRole } from '@testing-library/dom'
 
 import { Button, initButtons } from './button.mjs'
 
@@ -12,7 +11,7 @@ describe('Button', () => {
       context: { text: 'Save and continue' }
     })
 
-    $root = getByRole(document.body, 'button')
+    $root = document.querySelector(`[data-module="${Button.moduleName}"]`)
 
     jest.spyOn($root, 'addEventListener')
   })
@@ -70,11 +69,22 @@ describe('Button', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new Button($root)).toThrow(
+      expect(() => new Button($svg)).toThrow(
         'Button: Root element (`$root`) is not of type HTMLElement'
       )
+    })
+  })
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      initButtons()
+    })
+
+    it('should have accessible name and role', () => {
+      expect($root).toHaveAccessibleName('Save and continue')
+      expect($root).toHaveRole('button')
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
@@ -64,7 +64,7 @@ describe('Button', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new Button()).toThrow(
-        'Button: Root element (`$root`) not found'
+        `${Button.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -72,7 +72,7 @@ describe('Button', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new Button($svg)).toThrow(
-        'Button: Root element (`$root`) is not of type HTMLElement'
+        `${Button.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -68,6 +68,11 @@ export class Button extends Component {
       this.debounceFormSubmitTimer = null
     }, DEBOUNCE_TIMEOUT_IN_SECONDS * 1000)
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-button'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -83,7 +83,9 @@ export class Button extends Component {
  */
 export function initButtons(options = {}) {
   const $scope = options.scope || document
-  const $buttons = $scope.querySelectorAll('[data-module="nhsuk-button"]')
+  const $buttons = $scope.querySelectorAll(
+    `[data-module="${Button.moduleName}"]`
+  )
 
   $buttons.forEach(($root) => {
     new Button($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -27,7 +27,9 @@ describe('Character count', () => {
       }
     })
 
-    $root = document.querySelector('.nhsuk-character-count')
+    $root = document.querySelector(
+      `[data-module="${CharacterCount.moduleName}"]`
+    )
 
     $textarea = getByRole($root, 'textbox', {
       name: 'Can you provide more detail?'
@@ -105,9 +107,9 @@ describe('Character count', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new CharacterCount($root)).toThrow(
+      expect(() => new CharacterCount($svg)).toThrow(
         'CharacterCount: Root element (`$root`) is not of type HTMLElement'
       )
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -64,7 +64,7 @@ describe('Character count', () => {
       $textarea.remove()
 
       expect(() => initCharacterCounts()).toThrow(
-        'CharacterCount: Form field (`.nhsuk-js-character-count`) not found'
+        `${CharacterCount.moduleName}: Form field (\`.nhsuk-js-character-count\`) not found`
       )
     })
 
@@ -72,7 +72,7 @@ describe('Character count', () => {
       $description.remove()
 
       expect(() => new CharacterCount($root)).toThrow(
-        'CharacterCount: Count message (`id="example-info"`) not found'
+        `${CharacterCount.moduleName}: Count message (\`id="example-info"\`) not found`
       )
     })
 
@@ -102,7 +102,7 @@ describe('Character count', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new CharacterCount()).toThrow(
-        'CharacterCount: Root element (`$root`) not found'
+        `${CharacterCount.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -110,7 +110,7 @@ describe('Character count', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new CharacterCount($svg)).toThrow(
-        'CharacterCount: Root element (`$root`) is not of type HTMLElement'
+        `${CharacterCount.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -302,7 +302,7 @@ CharacterCount.prototype.defaults = {
 export function initCharacterCounts(options = {}) {
   const $scope = options.scope || document
   const $characterCounts = $scope.querySelectorAll(
-    '[data-module="nhsuk-character-count"]'
+    `[data-module="${CharacterCount.moduleName}"]`
   )
 
   $characterCounts.forEach(($root) => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -281,6 +281,11 @@ export class CharacterCount extends Component {
     // Cancel value checking on blur
     clearInterval(this.valueChecker)
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-character-count'
 }
 
 CharacterCount.prototype.defaults = {

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -133,7 +133,7 @@ describe('Checkboxes', () => {
       $conditionals[0].remove()
 
       expect(() => initCheckboxes()).toThrow(
-        `Checkboxes: Conditional reveal (\`id="${$conditionals[0].id}"\`) not found`
+        `${Checkboxes.moduleName}: Conditional reveal (\`id="${$conditionals[0].id}"\`) not found`
       )
     })
 
@@ -143,7 +143,7 @@ describe('Checkboxes', () => {
       }
 
       expect(() => initCheckboxes()).toThrow(
-        'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+        `${Checkboxes.moduleName}: Form inputs (\`<input type="checkbox">\`) not found`
       )
     })
 
@@ -181,7 +181,7 @@ describe('Checkboxes', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new Checkboxes()).toThrow(
-        'Checkboxes: Root element (`$root`) not found'
+        `${Checkboxes.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -189,7 +189,7 @@ describe('Checkboxes', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new Checkboxes($svg)).toThrow(
-        'Checkboxes: Root element (`$root`) is not of type HTMLElement'
+        `${Checkboxes.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -92,7 +92,7 @@ describe('Checkboxes', () => {
       </form>
     `
 
-    $root = document.querySelector('.nhsuk-checkboxes')
+    $root = document.querySelector(`[data-module="${Checkboxes.moduleName}"]`)
 
     $conditionals = [
       ...$root.querySelectorAll('.nhsuk-checkboxes__conditional')
@@ -186,9 +186,9 @@ describe('Checkboxes', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new Checkboxes($root)).toThrow(
+      expect(() => new Checkboxes($svg)).toThrow(
         'Checkboxes: Root element (`$root`) is not of type HTMLElement'
       )
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -136,6 +136,11 @@ export class Checkboxes extends Component {
       this.unCheckExclusiveInputs(event.target)
     }
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-checkboxes'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -152,7 +152,7 @@ export class Checkboxes extends Component {
 export function initCheckboxes(options = {}) {
   const $scope = options.scope || document
   const $checkboxes = $scope.querySelectorAll(
-    '[data-module="nhsuk-checkboxes"]'
+    `[data-module="${Checkboxes.moduleName}"]`
   )
 
   $checkboxes.forEach(($root) => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -146,7 +146,9 @@ export class Checkboxes extends Component {
  */
 export function initCheckboxes(options = {}) {
   const $scope = options.scope || document
-  const $checkboxes = $scope.querySelectorAll('.nhsuk-checkboxes')
+  const $checkboxes = $scope.querySelectorAll(
+    '[data-module="nhsuk-checkboxes"]'
+  )
 
   $checkboxes.forEach(($root) => {
     new Checkboxes($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -45,7 +45,9 @@
     text: params.errorMessage.text
   }) | indent(2) | trim }}
 {% endif %}
-  <div class="nhsuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %} {%- if isConditional %} nhsuk-checkboxes--conditional{% endif -%}"
+  <div class="nhsuk-checkboxes
+    {%- if params.classes %} {{ params.classes }}{% endif %}
+    {%- if isConditional %} nhsuk-checkboxes--conditional{% endif %}"
     {{- nhsukAttributes(params.attributes) }}>
     {% for item in params.items %}
     {% set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "")  %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -48,7 +48,7 @@
   <div class="nhsuk-checkboxes
     {%- if params.classes %} {{ params.classes }}{% endif %}
     {%- if isConditional %} nhsuk-checkboxes--conditional{% endif %}"
-    {{- nhsukAttributes(params.attributes) }}>
+    {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-checkboxes">
     {% for item in params.items %}
     {% set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "")  %}
     {% set name = item.name if item.name else params.name %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -119,7 +119,7 @@ describe('Error summary', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new ErrorSummary()).toThrow(
-        'ErrorSummary: Root element (`$root`) not found'
+        `${ErrorSummary.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -127,7 +127,7 @@ describe('Error summary', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new ErrorSummary($svg)).toThrow(
-        'ErrorSummary: Root element (`$root`) is not of type HTMLElement'
+        `${ErrorSummary.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -58,9 +58,7 @@ describe('Error summary', () => {
 
     const $container = document.querySelector('form')
 
-    $root = getByRole($container, 'alert', {
-      name: 'There is a problem'
-    })
+    $root = document.querySelector(`[data-module="${ErrorSummary.moduleName}"]`)
 
     $links = getAllByRole($root, 'link')
 
@@ -126,11 +124,22 @@ describe('Error summary', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new ErrorSummary($root)).toThrow(
+      expect(() => new ErrorSummary($svg)).toThrow(
         'ErrorSummary: Root element (`$root`) is not of type HTMLElement'
       )
+    })
+  })
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      initErrorSummary()
+    })
+
+    it('should add accessible name and role', () => {
+      expect($root).toHaveAccessibleName('There is a problem')
+      expect($root).toHaveRole('alert')
     })
   })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -139,7 +139,7 @@ export class ErrorSummary extends Component {
  */
 export function initErrorSummary(options = {}) {
   const $scope = options.scope || document
-  const $root = $scope.querySelector('.nhsuk-error-summary')
+  const $root = $scope.querySelector('[data-module="nhsuk-error-summary"]')
 
   if (!$root) {
     return

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -127,6 +127,11 @@ export class ErrorSummary extends Component {
       event.preventDefault()
     }
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-error-summary'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -144,7 +144,9 @@ export class ErrorSummary extends Component {
  */
 export function initErrorSummary(options = {}) {
   const $scope = options.scope || document
-  const $root = $scope.querySelector('[data-module="nhsuk-error-summary"]')
+  const $root = $scope.querySelector(
+    `[data-module="${ErrorSummary.moduleName}"]`
+  )
 
   if (!$root) {
     return

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
@@ -2,7 +2,7 @@
 
 <div class="nhsuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-  {{- nhsukAttributes(params.attributes) }}>
+  {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-error-summary">
   <h2 class="nhsuk-error-summary__title" id="error-summary-title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h2>

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
@@ -67,7 +67,7 @@ describe('Header class', () => {
       }
     })
 
-    $root = document.querySelector('.nhsuk-header')
+    $root = document.querySelector(`[data-module="${Header.moduleName}"]`)
 
     $navigation = getByRole($root, 'navigation')
     $navigationList = getByRole($navigation, 'list')
@@ -200,9 +200,9 @@ describe('Header class', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new Header($root)).toThrow(
+      expect(() => new Header($svg)).toThrow(
         'Header: Root element (`$root`) is not of type HTMLElement'
       )
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
@@ -133,7 +133,7 @@ describe('Header class', () => {
       $navigation.remove()
 
       expect(() => initHeader()).toThrow(
-        'Header: Navigation (`<nav class="nhsuk-header__navigation">`) not found'
+        `${Header.moduleName}: Navigation (\`<nav class="nhsuk-header__navigation">\`) not found`
       )
     })
 
@@ -141,7 +141,7 @@ describe('Header class', () => {
       $navigationList.remove()
 
       expect(() => initHeader()).toThrow(
-        'Header: List (`<ul class="nhsuk-header__navigation-list">`) not found'
+        `${Header.moduleName}: List (\`<ul class="nhsuk-header__navigation-list">\`) not found`
       )
     })
 
@@ -149,7 +149,7 @@ describe('Header class', () => {
       $navigationList.innerHTML = ''
 
       expect(() => initHeader()).toThrow(
-        'Header: List items (`<li class="nhsuk-header__navigation-item">`) not found'
+        `${Header.moduleName}: List items (\`<li class="nhsuk-header__navigation-item">\`) not found`
       )
     })
 
@@ -157,7 +157,7 @@ describe('Header class', () => {
       $menuButton.parentElement.remove()
 
       expect(() => initHeader()).toThrow(
-        'Header: Menu item (`<li class="nhsuk-header__menu" hidden>`) not found'
+        `${Header.moduleName}: Menu item (\`<li class="nhsuk-header__menu" hidden>\`) not found`
       )
     })
 
@@ -165,7 +165,7 @@ describe('Header class', () => {
       $menuButton.remove()
 
       expect(() => initHeader()).toThrow(
-        'Header: Menu button (`<button class="nhsuk-header__menu-toggle">`) not found'
+        `${Header.moduleName}: Menu button (\`<button class="nhsuk-header__menu-toggle">\`) not found`
       )
     })
 
@@ -195,7 +195,7 @@ describe('Header class', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new Header()).toThrow(
-        'Header: Root element (`$root`) not found'
+        `${Header.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -203,7 +203,7 @@ describe('Header class', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new Header($svg)).toThrow(
-        'Header: Root element (`$root`) is not of type HTMLElement'
+        `${Header.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -286,6 +286,11 @@ export class Header extends Component {
       )
     }
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-header'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -296,7 +296,7 @@ export class Header extends Component {
  */
 export function initHeader(options = {}) {
   const $scope = options.scope || document
-  const $root = $scope.querySelector('.nhsuk-header')
+  const $root = $scope.querySelector('[data-module="nhsuk-header"]')
 
   if (!$root) {
     return

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -301,7 +301,7 @@ export class Header extends Component {
  */
 export function initHeader(options = {}) {
   const $scope = options.scope || document
-  const $root = $scope.querySelector('[data-module="nhsuk-header"]')
+  const $root = $scope.querySelector(`[data-module="${Header.moduleName}"]`)
 
   if (!$root) {
     return

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -51,7 +51,7 @@
 <header class="nhsuk-header
   {%- if params.organisation %} nhsuk-header--organisation{% endif %}
   {%- if params.classes %} {{ params.classes }}{% endif %}" role="banner"
-  {{- nhsukAttributes(params.attributes) }}>
+  {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-header">
   <div class="nhsuk-header__container nhsuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
     <div class="nhsuk-header__service">
     {% if logoHref %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
@@ -131,7 +131,7 @@ describe('Radios', () => {
       $conditionals[0].remove()
 
       expect(() => initRadios()).toThrow(
-        `Radios: Conditional reveal (\`id="${$conditionals[0].id}"\`) not found`
+        `${Radios.moduleName}: Conditional reveal (\`id="${$conditionals[0].id}"\`) not found`
       )
     })
 
@@ -141,7 +141,7 @@ describe('Radios', () => {
       }
 
       expect(() => initRadios()).toThrow(
-        'Radios: Form inputs (`<input type="radio">`) not found'
+        `${Radios.moduleName}: Form inputs (\`<input type="radio">\`) not found`
       )
     })
 
@@ -179,7 +179,7 @@ describe('Radios', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new Radios()).toThrow(
-        'Radios: Root element (`$root`) not found'
+        `${Radios.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -187,7 +187,7 @@ describe('Radios', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new Radios($svg)).toThrow(
-        'Radios: Root element (`$root`) is not of type HTMLElement'
+        `${Radios.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
@@ -92,7 +92,7 @@ describe('Radios', () => {
       </form>
     `
 
-    $root = document.querySelector('.nhsuk-radios')
+    $root = document.querySelector(`[data-module="${Radios.moduleName}"]`)
 
     $conditionals = [...$root.querySelectorAll('.nhsuk-radios__conditional')]
 
@@ -184,9 +184,9 @@ describe('Radios', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new Radios($root)).toThrow(
+      expect(() => new Radios($svg)).toThrow(
         'Radios: Root element (`$root`) is not of type HTMLElement'
       )
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -69,6 +69,11 @@ export class Radios extends Component {
       toggleConditionalInput(input, 'nhsuk-radios__conditional--hidden')
     )
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-radios'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -79,7 +79,7 @@ export class Radios extends Component {
  */
 export function initRadios(options = {}) {
   const $scope = options.scope || document
-  const $radios = $scope.querySelectorAll('.nhsuk-radios--conditional')
+  const $radios = $scope.querySelectorAll('[data-module="nhsuk-radios"]')
 
   $radios.forEach(($root) => {
     new Radios($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -84,7 +84,9 @@ export class Radios extends Component {
  */
 export function initRadios(options = {}) {
   const $scope = options.scope || document
-  const $radios = $scope.querySelectorAll('[data-module="nhsuk-radios"]')
+  const $radios = $scope.querySelectorAll(
+    `[data-module="${Radios.moduleName}"]`
+  )
 
   $radios.forEach(($root) => {
     new Radios($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -45,7 +45,7 @@
   <div class="nhsuk-radios
     {%- if params.classes %} {{ params.classes }}{% endif %}
     {%- if isConditional %} nhsuk-radios--conditional{% endif %}"
-    {{- nhsukAttributes(params.attributes) }}>
+    {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-radios">
     {%- for item in params.items %}
     {%- set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "") %}
     {% set conditionalId = "conditional-" + id %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -43,8 +43,9 @@
   }) | indent(2) | trim }}
 {% endif %}
   <div class="nhsuk-radios
-  {%- if params.classes %} {{ params.classes }}{% endif %} {%- if isConditional %} nhsuk-radios--conditional{% endif -%}"
-  {{- nhsukAttributes(params.attributes) }}>
+    {%- if params.classes %} {{ params.classes }}{% endif %}
+    {%- if isConditional %} nhsuk-radios--conditional{% endif %}"
+    {{- nhsukAttributes(params.attributes) }}>
     {%- for item in params.items %}
     {%- set id = item.id if item.id else idPrefix + ("-" + loop.index if loop.index > 1 else "") %}
     {% set conditionalId = "conditional-" + id %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -57,7 +57,7 @@ describe('Skip link', () => {
       $root.setAttribute('href', 'https://example.com')
 
       expect(() => initSkipLinks()).toThrow(
-        'SkipLink: Target link (`href="https://example.com"`) hash fragment not found'
+        `${SkipLink.moduleName}: Target link (\`href="https://example.com"\`) hash fragment not found`
       )
     })
 
@@ -65,7 +65,7 @@ describe('Skip link', () => {
       $main.remove()
 
       expect(() => initSkipLinks()).toThrow(
-        'SkipLink: Target content (`id="maincontent"`) not found'
+        `${SkipLink.moduleName}: Target content (\`id="maincontent"\`) not found`
       )
     })
 
@@ -95,7 +95,7 @@ describe('Skip link', () => {
 
     it('should throw with missing $root element', () => {
       expect(() => new SkipLink()).toThrow(
-        'SkipLink: Root element (`$root`) not found'
+        `${SkipLink.moduleName}: Root element (\`$root\`) not found`
       )
     })
 
@@ -103,7 +103,7 @@ describe('Skip link', () => {
       $root = document.createElement('div')
 
       expect(() => new SkipLink($root)).toThrow(
-        'SkipLink: Root element (`$root`) is not of type HTMLAnchorElement'
+        `${SkipLink.moduleName}: Root element (\`$root\`) is not of type HTMLAnchorElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -1,5 +1,4 @@
 import { components } from '@nhsuk/frontend-lib'
-import { getByRole } from '@testing-library/dom'
 import { userEvent } from '@testing-library/user-event'
 
 import { SkipLink, initSkipLinks } from './skip-link.mjs'
@@ -34,10 +33,7 @@ describe('Skip link', () => {
     `
 
     $main = document.querySelector('main')
-
-    $root = getByRole(document.body, 'link', {
-      name: 'Skip to main content'
-    })
+    $root = document.querySelector(`[data-module="${SkipLink.moduleName}"]`)
 
     jest.spyOn($root, 'addEventListener')
   })
@@ -109,6 +105,17 @@ describe('Skip link', () => {
       expect(() => new SkipLink($root)).toThrow(
         'SkipLink: Root element (`$root`) is not of type HTMLAnchorElement'
       )
+    })
+  })
+
+  describe('Accessibility', () => {
+    beforeEach(() => {
+      initSkipLinks()
+    })
+
+    it('should add accessible name and role', () => {
+      expect($root).toHaveAccessibleName('Skip to main content')
+      expect($root).toHaveRole('link')
     })
   })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -75,7 +75,9 @@ export class SkipLink extends Component {
  */
 export function initSkipLinks(options = {}) {
   const $scope = options.scope || document
-  const $skipLinks = $scope.querySelectorAll('[data-module="nhsuk-skip-link"]')
+  const $skipLinks = $scope.querySelectorAll(
+    `[data-module="${SkipLink.moduleName}"]`
+  )
 
   $skipLinks.forEach(($root) => {
     new SkipLink($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -70,7 +70,7 @@ export class SkipLink extends Component {
  */
 export function initSkipLinks(options = {}) {
   const $scope = options.scope || document
-  const $skipLinks = $scope.querySelectorAll('.nhsuk-skip-link')
+  const $skipLinks = $scope.querySelectorAll('[data-module="nhsuk-skip-link"]')
 
   $skipLinks.forEach(($root) => {
     new SkipLink($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -60,6 +60,11 @@ export class SkipLink extends Component {
       })
     )
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-skip-link'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/template.njk
@@ -3,5 +3,5 @@
 <a class="nhsuk-skip-link
 {%- if params.classes %} {{ params.classes }}{% endif %}" href="
 {%- if params.href %}{{ params.href }}{% else %}#maincontent{% endif %}"
-{{- nhsukAttributes(params.attributes) }}>
+{{- nhsukAttributes(params.attributes) }} data-module="nhsuk-skip-link">
 {%- if params.text %}{{ params.text }}{% else %}Skip to main content{% endif %}</a>

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
@@ -58,7 +58,7 @@ describe('Tabs', () => {
       }
     })
 
-    $root = document.querySelector('.nhsuk-tabs')
+    $root = document.querySelector(`[data-module="${Tabs.moduleName}"]`)
 
     $list = getByRole($root, 'list')
     $listItems = getAllByRole($root, 'listitem')
@@ -165,9 +165,9 @@ describe('Tabs', () => {
     })
 
     it('should throw with wrong $root element type', () => {
-      $root = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
-      expect(() => new Tabs($root)).toThrow(
+      expect(() => new Tabs($svg)).toThrow(
         'Tabs: Root element (`$root`) is not of type HTMLElement'
       )
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
@@ -102,7 +102,7 @@ describe('Tabs', () => {
       }
 
       expect(() => initTabs()).toThrow(
-        'Tabs: Links (`<a class="nhsuk-tabs__tab">`) not found'
+        `${Tabs.moduleName}: Links (\`<a class="nhsuk-tabs__tab">\`) not found`
       )
     })
 
@@ -112,7 +112,7 @@ describe('Tabs', () => {
       $list.classList.add('nhsuk-tabs__typo')
 
       expect(() => initTabs()).toThrow(
-        'Tabs: List (`<ul class="nhsuk-tabs__list">`) not found'
+        `${Tabs.moduleName}: List (\`<ul class="nhsuk-tabs__list">\`) not found`
       )
     })
 
@@ -156,19 +156,21 @@ describe('Tabs', () => {
       document.documentElement.style.removeProperty('--nhsuk-breakpoint-tablet')
 
       expect(() => new Tabs($root)).toThrow(
-        'Tabs: CSS custom property (`--nhsuk-breakpoint-tablet`) on pseudo-class `:root` not found'
+        `${Tabs.moduleName}: CSS custom property (\`--nhsuk-breakpoint-tablet\`) on pseudo-class \`:root\` not found`
       )
     })
 
     it('should throw with missing $root element', () => {
-      expect(() => new Tabs()).toThrow('Tabs: Root element (`$root`) not found')
+      expect(() => new Tabs()).toThrow(
+        `${Tabs.moduleName}: Root element (\`$root\`) not found`
+      )
     })
 
     it('should throw with wrong $root element type', () => {
       const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
 
       expect(() => new Tabs($svg)).toThrow(
-        'Tabs: Root element (`$root`) is not of type HTMLElement'
+        `${Tabs.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -326,7 +326,7 @@ export class Tabs extends Component {
  */
 export function initTabs(options = {}) {
   const $scope = options.scope || document
-  const $tabs = $scope.querySelectorAll('[data-module="nhsuk-tabs"]')
+  const $tabs = $scope.querySelectorAll(`[data-module="${Tabs.moduleName}"]`)
 
   $tabs.forEach(($root) => {
     new Tabs($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -311,6 +311,11 @@ export class Tabs extends Component {
       '.nhsuk-tabs__list-item--selected .nhsuk-tabs__tab'
     )
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes
+   */
+  static moduleName = 'nhsuk-tabs'
 }
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
@@ -77,7 +77,7 @@ describe('Errors', () => {
 
       expect(error).toHaveProperty(
         'message',
-        'SkipLink: variableName not found'
+        `${SkipLink.moduleName}: variableName not found`
       )
     })
 
@@ -93,7 +93,7 @@ describe('Errors', () => {
 
       expect(error).toHaveProperty(
         'message',
-        'SkipLink: variableName is not of type HTMLAnchorElement'
+        `${SkipLink.moduleName}: variableName is not of type HTMLAnchorElement`
       )
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
@@ -1,3 +1,5 @@
+import { formatErrorMessage } from '../common/index.mjs'
+
 /**
  * NHS.UK frontend error
  *
@@ -59,15 +61,14 @@ export class ElementError extends NHSUKFrontendError {
   constructor(options) {
     const { component, identifier, element, expectedType } = options
 
-    // Add prefix and identifier
-    let message = `${component.name}: ${identifier}`
+    let message = identifier
 
     // Append reason
     message += element
       ? ` is not of type ${expectedType ?? 'HTMLElement'}`
       : ' not found'
 
-    super(message)
+    super(formatErrorMessage(component, message))
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes components that lack `data-module` attributes:

```patch
- <div class="nhsuk-checkboxes">
+ <div class="nhsuk-checkboxes" data-module="nhsuk-checkboxes">
```

```patch
- <div class="nhsuk-radios">
+ <div class="nhsuk-radios" data-module="nhsuk-radios">
```

```patch
- <div class="nhsuk-error-summary">
+ <div class="nhsuk-error-summary" data-module="nhsuk-error-summary">
```

```patch
- <header class="nhsuk-header">
+ <header class="nhsuk-header" data-module="nhsuk-header">
```

```patch
- <a class="nhsuk-skip-link">
+ <a class="nhsuk-skip-link" data-module="nhsuk-skip-link">
```

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
