### PR TITLE
Prevent multiple initialisations of a single component instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,9 @@ Errors you might see include:
 
 - `SupportError` - when NHS.UK frontend is not supported in the current browser
 - `ElementError` - when component templates have missing or broken HTML elements
+- `InitError` - when components are initialised multiple times
 
-This change was introduced in pull requests [#1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459) and [#1466: Throw `ElementError` for all missing elements](https://github.com/nhsuk/nhsuk-frontend/pull/1466).
+This change was introduced in pull requests [#1459: Add NHS.UK frontend browser support checks](https://github.com/nhsuk/nhsuk-frontend/pull/1459), [#1466: Throw `ElementError` for all missing elements](https://github.com/nhsuk/nhsuk-frontend/pull/1466) and [#1481: Prevent multiple initialisations of a single component instance](https://github.com/nhsuk/nhsuk-frontend/pull/1481).
 
 :wrench: **Fixes**
 

--- a/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
@@ -117,6 +117,20 @@ export function setFocus($element, options = {}) {
 }
 
 /**
+ * Checks if component is already initialised
+ *
+ * @param {Element} $root - HTML element to be checked
+ * @param {string} moduleName - name of component module
+ * @returns {boolean} Whether component is already initialised
+ */
+export function isInitialised($root, moduleName) {
+  return (
+    $root instanceof HTMLElement &&
+    $root.hasAttribute(`data-${moduleName}-init`)
+  )
+}
+
+/**
  * Checks if NHS.UK frontend is supported on this page
  *
  * Some browsers will load and run our JavaScript but NHS.UK frontend

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -1,5 +1,5 @@
-import { isSupported } from './common/index.mjs'
-import { ElementError, SupportError } from './errors/index.mjs'
+import { isInitialised, isSupported } from './common/index.mjs'
+import { ElementError, InitError, SupportError } from './errors/index.mjs'
 
 /**
  * Base component class
@@ -42,6 +42,26 @@ export class Component {
     this.$root = /** @type {RootElementType} */ ($root)
 
     ComponentClass.checkSupport()
+
+    this.checkInitialised()
+
+    const { moduleName } = ComponentClass
+    this.$root.setAttribute(`data-${moduleName}-init`, '')
+  }
+
+  /**
+   * Validates whether component is already initialised
+   *
+   * @throws {InitError} when component is already initialised
+   */
+  checkInitialised() {
+    const ComponentClass = /** @type {ComponentConstructor} */ (
+      this.constructor
+    )
+
+    if (isInitialised(this.$root, ComponentClass.moduleName)) {
+      throw new InitError(ComponentClass)
+    }
   }
 
   /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
@@ -75,6 +75,15 @@ describe('Button', () => {
         `${Button.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new Button($root)
+        new Button($root)
+      }).toThrow(
+        `${Button.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Accessibility', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -113,5 +113,14 @@ describe('Character count', () => {
         `${CharacterCount.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new CharacterCount($root)
+        new CharacterCount($root)
+      }).toThrow(
+        `${CharacterCount.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -192,6 +192,15 @@ describe('Checkboxes', () => {
         `${Checkboxes.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new Checkboxes($root)
+        new Checkboxes($root)
+      }).toThrow(
+        `${Checkboxes.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Conditional content', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -130,6 +130,15 @@ describe('Error summary', () => {
         `${ErrorSummary.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new ErrorSummary($root)
+        new ErrorSummary($root)
+      }).toThrow(
+        `${ErrorSummary.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Accessibility', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
@@ -206,6 +206,15 @@ describe('Header class', () => {
         `${Header.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new Header($root)
+        new Header($root)
+      }).toThrow(
+        `${Header.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Menu button', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
@@ -190,6 +190,15 @@ describe('Radios', () => {
         `${Radios.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new Radios($root)
+        new Radios($root)
+      }).toThrow(
+        `${Radios.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Conditional content', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -106,6 +106,15 @@ describe('Skip link', () => {
         `${SkipLink.moduleName}: Root element (\`$root\`) is not of type HTMLAnchorElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new SkipLink($root)
+        new SkipLink($root)
+      }).toThrow(
+        `${SkipLink.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Accessibility', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
@@ -173,6 +173,15 @@ describe('Tabs', () => {
         `${Tabs.moduleName}: Root element (\`$root\`) is not of type HTMLElement`
       )
     })
+
+    it('should throw when initialised twice', () => {
+      expect(() => {
+        new Tabs($root)
+        new Tabs($root)
+      }).toThrow(
+        `${Tabs.moduleName}: Root element (\`$root\`) already initialised`
+      )
+    })
   })
 
   describe('Accessibility (mobile)', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
@@ -1,6 +1,11 @@
 import { SkipLink } from '../index.mjs'
 
-import { ElementError, NHSUKFrontendError, SupportError } from './index.mjs'
+import {
+  ElementError,
+  NHSUKFrontendError,
+  InitError,
+  SupportError
+} from './index.mjs'
 
 describe('Errors', () => {
   describe('NHSUKFrontendError', () => {
@@ -47,6 +52,26 @@ describe('Errors', () => {
       expect(new SupportError(null).message).toBe(
         'NHS.UK frontend initialised without `<script type="module">`'
       )
+    })
+  })
+
+  describe('InitError', () => {
+    it('is an instance of NHSUKFrontendError', () => {
+      expect(new InitError(SkipLink)).toBeInstanceOf(NHSUKFrontendError)
+    })
+
+    it('has its own name set', () => {
+      expect(new InitError(SkipLink).name).toBe('InitError')
+    })
+
+    it('provides feedback for modules already initialised', () => {
+      expect(new InitError(SkipLink).message).toBe(
+        'nhsuk-skip-link: Root element (`$root`) already initialised'
+      )
+    })
+
+    it('allows a custom message to be provided', () => {
+      expect(new InitError('custom message').message).toBe('custom message')
     })
   })
 

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
@@ -73,6 +73,28 @@ export class ElementError extends NHSUKFrontendError {
 }
 
 /**
+ * Indicates that a component is already initialised
+ */
+export class InitError extends NHSUKFrontendError {
+  name = 'InitError'
+
+  /**
+   * @param {ComponentConstructor | string} componentOrMessage - Component or init error message
+   */
+  constructor(componentOrMessage) {
+    const message =
+      typeof componentOrMessage === 'string'
+        ? componentOrMessage
+        : formatErrorMessage(
+            componentOrMessage,
+            'Root element (`$root`) already initialised'
+          )
+
+    super(message)
+  }
+}
+
+/**
  * Element error options
  *
  * @typedef {object} ElementErrorOptions


### PR DESCRIPTION
## Description

This PR copies GOV.UK Frontend in https://github.com/alphagov/govuk-frontend/pull/5272

We now prevent JavaScript from initialising components multiple times (e.g. accidental React rerenders)

```js
import { Button } from 'nhsuk-frontend'

const $root = document.querySelector('.app-button')

new Button($root) // ✅
new Button($root) // 🔥
```

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
