### PR TITLE
Sanitise character count allowed data attributes

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -165,5 +165,27 @@ describe('Character count', () => {
         threshold: 8
       })
     })
+
+    it('ignores unknown data attributes', () => {
+      document.body.innerHTML = components.render('character-count', {
+        context: {
+          ...examples['default'].context,
+          attributes: {
+            'data-unknown1': '100',
+            'data-unknown2': 200,
+            'data-unknown3': false
+          }
+        }
+      })
+
+      const characterCount = new CharacterCount(
+        document.querySelector(`[data-module="${CharacterCount.moduleName}"]`)
+      )
+
+      expect(characterCount.config).toEqual({
+        maxlength: 10,
+        threshold: 0
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description

This PR fixes a few potential issues in the character count component found by the TypeScript compiler:

1. **Data attributes are parsed as strings**
  Thankfully JavaScript can do maths on strings `this.maxLength - this.count($textarea.value)` 😱

2. **Data attributes are not sanitised**
  All values are allowed by `CharacterCount.getDataset()`

```patch
{
-   "maxlength": "10",
-   "module": "nhsuk-character-count",
-   "nhsuk-character-count-init": "",
-   "threshold": "8",
+   "maxlength": 10,
+   "threshold": 8,
}
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
