### PR TITLE
Fix Sass "Error: This module was already loaded"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - [#1504: Skip header missing element checks without navigation](https://github.com/nhsuk/nhsuk-frontend/pull/1504)
+- [#1505: Fix Sass "Error: This module was already loaded"](https://github.com/nhsuk/nhsuk-frontend/pull/1505)
 
 ## 10.0.0-internal.1 - 22 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/_index.scss
@@ -2,9 +2,9 @@
 /// Core
 ////
 
-@forward "nhsuk-frontend-properties";
 @forward "settings";
 @forward "tools";
+@forward "nhsuk-frontend-properties";
 @forward "generic";
 @forward "elements";
 @forward "objects";

--- a/packages/nhsuk-frontend/src/nhsuk/core/_nhsuk-frontend-properties.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/_nhsuk-frontend-properties.scss
@@ -1,4 +1,4 @@
-@use "settings/breakpoints" as *;
+@use "settings" as *;
 @use "tools" as *;
 
 :root {

--- a/packages/nhsuk-frontend/src/nhsuk/core/all.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/all.scss
@@ -1,4 +1,4 @@
-@use "settings/warnings" as *;
+@use "settings" as *;
 @forward ".";
 
 @include nhsuk-warning(

--- a/packages/nhsuk-frontend/src/nhsuk/core/core.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/core.unit.test.mjs
@@ -10,6 +10,34 @@ describe('Core', () => {
     logger.warn = jest.fn().mockReturnValue(sassNull)
   })
 
+  describe('importing using index file', () => {
+    it('forwards core styles', async () => {
+      const sass = `
+        @forward "core";
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).resolves.not.toThrow()
+    })
+
+    it('forwards core styles (with settings)', async () => {
+      const sass = `
+        @forward "core" with (
+          $nhsuk-page-width: 1100px
+        );
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).resolves.not.toThrow()
+    })
+  })
+
   describe('importing using "all" files', () => {
     it('outputs a warning when importing the core "all" file', async () => {
       const sass = `

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_all.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_all.scss
@@ -1,4 +1,4 @@
-@use "warnings" as *;
+@use "../settings" as *;
 @forward ".";
 
 @include nhsuk-warning(

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_all.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_all.scss
@@ -1,4 +1,4 @@
-@use "../settings/warnings" as *;
+@use "../settings" as *;
 @forward ".";
 
 @include nhsuk-warning(

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_shape-arrow.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_shape-arrow.scss
@@ -1,5 +1,5 @@
 @use "sass:math";
-@use "../settings/warnings" as *;
+@use "../settings" as *;
 
 ////
 /// Shape arrow

--- a/packages/nhsuk-frontend/src/nhsuk/core/vendor/sass-mq.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/vendor/sass-mq.scss
@@ -1,4 +1,4 @@
-@use "../settings/warnings" as *;
+@use "../settings" as *;
 
 // mq() v6.0.0
 // sass-mq/sass-mq


### PR DESCRIPTION
## Description

This PR fixes an issue raised by @paulrobertlloyd following the [`nhsuk-frontend@10.0.0-internal.1` pre-release](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v10.0.0-internal.1)

We now load Sass `"settings"` first before nested `"settings/breakpoints"` etc to fix:

```console
Error: This module was already loaded, so it can't be configured using "with".

  ┌──> ../../../../packages/nhsuk-frontend/src/nhsuk/core/_index.scss
6 │   @forward "settings";
  │   ^^^^^^^^^^^^^^^^^^^ new load
  ╵
  ┌──> ../../../../packages/nhsuk-frontend/src/nhsuk/core/tools/_functions.scss
2 │   @use "../settings" as *;
  │   ━━━━━━━━━━━━━━━━━━━━━━━ original load
  ╵
  ╷
2 │ ┌         @forward "core" with (
3 │ │           $nhsuk-page-width: 1100px
4 │ │         );
  │ └─────────^ configuration
  ╵
  _index.scss 6:1  @forward
  - 2:9            root stylesheet
```

The regression was added in https://github.com/nhsuk/nhsuk-frontend/commit/77a62d9ad8aa4b366f31f8a973717372b8612cda as part of:

* https://github.com/nhsuk/nhsuk-frontend/pull/1478

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
