### PR TITLE
Add JavaScript configuration support to components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,14 @@ module.exports = {
         'jest-dom'
       ],
       rules: {
+        // Access import namespace (e.g. NHSUKFrontend) using string keys
+        'import/namespace': [
+          'error',
+          {
+            allowComputed: true
+          }
+        ],
+
         // Check import or require statements are A-Z ordered
         'import/order': [
           'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+:new: **New features**
+
+#### Create individual components with `createAll`
+
+We've added a new `createAll` function that lets you initialise specific components in the same way that `initAll` does.
+
+The `createAll` function will:
+
+- find all elements in the page with the corresponding `data-module` attribute
+- initialise a new component for each element
+- catch errors and log them in the console
+- return an array of all the successfully initialised components.
+
+```mjs
+import { createAll, Button, Checkboxes } from 'nhsuk-frontend'
+
+createAll(Button)
+createAll(Checkboxes)
+```
+
+You can also pass a config object and a scope within which to search for elements.
+
+You can find out more about [how to use the `createAll` function](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/installation/installing-with-npm.md#initialise-individual-components) in our documentation.
+
+This was added in [pull request #1506: Add JavaScript configuration support to components](https://github.com/nhsuk/nhsuk-frontend/pull/1506).
+
 :boom: **Breaking changes**
 
 #### Check that your favicons, app icons and Open Graph image still work

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -125,31 +125,31 @@ if ($element) {
 
 #### Initialise individual components
 
-Rather than using `initAll`, you can initialise all instances of individual components used by your service. For example:
+Rather than using `initAll`, you can initialise all instances of individual components using `createAll`. For example:
 
 ```js
-import { initButtons, initRadios } from 'nhsuk-frontend';
+import { createAll, Button, Checkboxes } from 'nhsuk-frontend'
 
 // Initialise all button components
-initButtons();
+createAll(Button)
 
-// Initialise all radios components
-initRadios();
+// Initialise all checkboxes components
+createAll(Checkboxes)
 ```
 
 Or where necessary, single instances of individual components only:
 
 ```js
-import { Button, Checkboxes } from 'nhsuk-frontend';
+import { Button, Checkboxes } from 'nhsuk-frontend'
 
 const $button = document.querySelector('.app-button')
 const $checkboxes = document.querySelector('.app-checkboxes')
 
 // Initialise single button component
-new Button($button);
+new Button($button)
 
 // Initialise single checkboxes component
-new Checkboxes($checkboxes);
+new Checkboxes($checkboxes)
 ```
 
 ## Importing assets (optional)

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -107,6 +107,18 @@ import { initAll } from 'nhsuk-frontend'
 initAll()
 ```
 
+You can pass configuration to components by including key-value pairs of camel-cased component names with their options:
+
+```js
+import { initAll } from 'nhsuk-frontend'
+
+initAll({
+  button: {
+    preventDoubleClick: true
+  }
+})
+```
+
 #### Initialise only part of a page
 
 If you update a page with new markup, for example a modal dialogue box, you can initialise components on that part of the page only.
@@ -131,7 +143,9 @@ Rather than using `initAll`, you can initialise all instances of individual comp
 import { createAll, Button, Checkboxes } from 'nhsuk-frontend'
 
 // Initialise all button components
-createAll(Button)
+createAll(Button, {
+  preventDoubleClick: true
+})
 
 // Initialise all checkboxes components
 createAll(Checkboxes)
@@ -146,7 +160,9 @@ const $button = document.querySelector('.app-button')
 const $checkboxes = document.querySelector('.app-checkboxes')
 
 // Initialise single button component
-new Button($button)
+new Button($button, {
+  preventDoubleClick: true
+})
 
 // Initialise single checkboxes component
 new Checkboxes($checkboxes)

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const { headless = true } = jestPuppeteerConfig.launch
  */
 const config = {
   cacheDirectory: '<rootDir>/.cache/jest',
+  clearMocks: true,
   coveragePathIgnorePatterns: [
     '.eslintrc.js',
     '.test.(js|mjs)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22480,6 +22480,7 @@
         "del-cli": "^6.0.0",
         "gulp": "^5.0.1",
         "gulp-zip": "^6.1.0",
+        "lodash": "^4.17.21",
         "outdent": "^0.8.0",
         "postcss": "^8.5.6",
         "postcss-scss": "^4.0.9",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -44,7 +44,7 @@
     "build": "concurrently npm:build:* --group --prefix none",
     "build:package": "gulp build --color",
     "build:types": "tsc --build --noEmit false --pretty tsconfig.json",
-    "watch": "concurrently npm:watch:* --group --prefix none",
+    "watch": "concurrently npm:watch:* --prefix none",
     "watch:package": "gulp watch --color",
     "watch:types": "npm run build:types -- --preserveWatchOutput --watch",
     "release": "gulp release --color",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -64,6 +64,7 @@
     "del-cli": "^6.0.0",
     "gulp": "^5.0.1",
     "gulp-zip": "^6.1.0",
+    "lodash": "^4.17.21",
     "outdent": "^0.8.0",
     "postcss": "^8.5.6",
     "postcss-scss": "^4.0.9",

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.jsdom.test.mjs
@@ -1,0 +1,263 @@
+import { outdent } from 'outdent'
+
+import { extractConfigByNamespace } from './extract-config-by-namespace.mjs'
+
+describe('extractConfigByNamespace', () => {
+  /**
+   * @satisfies {Schema<MockConfig1>}
+   */
+  const schema1 = {
+    properties: {
+      a: { type: 'string' },
+      b: { type: 'object' },
+      c: { type: 'object' },
+      d: { type: 'string' },
+      e: { type: 'string' },
+      f: { type: 'object' }
+    }
+  }
+
+  /**
+   * @satisfies {Schema<MockConfig2>}
+   */
+  const schema2 = {
+    properties: {
+      namespace: {
+        type: 'object'
+      }
+    }
+  }
+
+  /** @type {HTMLElement} */
+  let $element
+
+  beforeEach(() => {
+    document.body.outerHTML = outdent`
+      <div id="app-example"
+        data-a="aardvark"
+        data-b.a="bat"
+        data-b.e="bear"
+        data-b.o="boar"
+        data-c.a="camel"
+        data-c.o="cow"
+        data-d="dog"
+        data-e="element">
+      </div>
+    `
+
+    $element = document.getElementById('app-example')
+  })
+
+  it('defaults to empty config for known namespaces only', () => {
+    const { dataset } = $element
+
+    const nonObject1 = extractConfigByNamespace(schema1, dataset, 'a')
+    const nonObject2 = extractConfigByNamespace(schema1, dataset, 'd')
+    const nonObject3 = extractConfigByNamespace(schema1, dataset, 'e')
+
+    const namespaceKnown = extractConfigByNamespace(schema1, dataset, 'f')
+    const namespaceUnknown = extractConfigByNamespace(
+      schema1,
+      dataset,
+      // @ts-expect-error - Allow unknown schema key for test
+      'unknown'
+    )
+
+    // With known namespace but non-object type, default to no config
+    expect(nonObject1).toBeUndefined()
+    expect(nonObject2).toBeUndefined()
+    expect(nonObject3).toBeUndefined()
+
+    // With known namespace, default to empty config
+    expect(namespaceKnown).toEqual({})
+
+    // With unknown namespace, default to no config
+    expect(namespaceUnknown).toBeUndefined()
+  })
+
+  it('can extract config from key-value pairs', () => {
+    const result = extractConfigByNamespace(schema1, $element.dataset, 'b')
+    expect(result).toEqual({ a: 'bat', e: 'bear', o: 'boar' })
+  })
+
+  it('can extract config from key-value pairs (with invalid namespace, first)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example2"
+        data-namespace
+        data-namespace.key1="One"
+        data-namespace.key2="Two"
+        data-namespace.key3="Three">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example2')
+    const result = extractConfigByNamespace(schema2, dataset, 'namespace')
+
+    expect(result).toEqual({ key1: 'One', key2: 'Two', key3: 'Three' })
+  })
+
+  it('can extract config from key-value pairs (with invalid namespace, last)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example2"
+        data-namespace.key1="One"
+        data-namespace.key2="Two"
+        data-namespace.key3="Three"
+        data-namespace>
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example2')
+    const result = extractConfigByNamespace(schema2, dataset, 'namespace')
+
+    expect(result).toEqual({ key1: 'One', key2: 'Two', key3: 'Three' })
+  })
+
+  it('handles when both shallow and deep keys are set (namespace collision)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example"
+        data-a="aardvark"
+        data-b="bat"
+        data-c="jellyfish"
+        data-c.a="cat"
+        data-c.o="cow"
+        data-d="dog"
+        data-e="element"
+        data-f.e="elk"
+        data-f.e.l="elephant">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
+
+    expect(result).toEqual({ a: 'cat', o: 'cow' })
+  })
+
+  it('handles when both shallow and deep keys are set (namespace collision + key collision in namespace)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example"
+        data-a="aardvark"
+        data-b="bat"
+        data-c.c="crow"
+        data-c="jellyfish"
+        data-c.a="cat"
+        data-c.o="cow"
+        data-d="dog"
+        data-e="element"
+        data-f.e="elk"
+        data-f.e.l="elephant">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
+
+    expect(result).toEqual({ a: 'cat', c: 'crow', o: 'cow' })
+  })
+
+  it('handles when both shallow and deep keys are set (namespace collision + key collision in namespace after shallow)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example"
+        data-a="aardvark"
+        data-b="bat"
+        data-c="jellyfish"
+        data-c.a="cat"
+        data-c.c="crow"
+        data-c.o="cow"
+        data-d="dog"
+        data-e="element"
+        data-f.e="elk"
+        data-f.e.l="elephant">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example')
+    const result = extractConfigByNamespace(schema1, dataset, 'c')
+
+    expect(result).toEqual({ a: 'cat', c: 'crow', o: 'cow' })
+  })
+
+  it('handles when both shallow and deep keys are set (deeper collision)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example"
+        data-a="aardvark"
+        data-b="bat"
+        data-c="jellyfish"
+        data-c.a="cat"
+        data-c.o="cow"
+        data-d="dog"
+        data-f.e="elk"
+        data-f.e.l="elephant">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example')
+    const result = extractConfigByNamespace(schema1, dataset, 'f')
+
+    expect(result).toEqual({ e: { l: 'elephant' } })
+  })
+
+  it('can handle multiple levels of nesting', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example2"
+        data-namespace.key1="This, That"
+        data-namespace.key2.one="The"
+        data-namespace.key2.other="Other">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example2')
+    const result = extractConfigByNamespace(schema2, dataset, 'namespace')
+
+    expect(result).toEqual({
+      key1: 'This, That',
+      key2: {
+        one: 'The',
+        other: 'Other'
+      }
+    })
+  })
+
+  it('can handle multiple levels of nesting (prioritises the last parameter provided)', () => {
+    document.body.outerHTML = outdent`
+      <div id="app-example2"
+        data-namespace.key1.one="This"
+        data-namespace.key1.other="That"
+        data-namespace.key2.one="The"
+        data-namespace.key2.other="Other"
+        data-namespace.key1="This, That"
+        data-namespace.key2="The Other">
+      </div>
+    `
+
+    const { dataset } = document.getElementById('app-example2')
+    const result = extractConfigByNamespace(schema2, dataset, 'namespace')
+
+    expect(result).toEqual({
+      key1: 'This, That',
+      key2: 'The Other'
+    })
+  })
+})
+
+/**
+ * @typedef {object} MockConfig1
+ * @property {string} a - Item A
+ * @property {string | {[key: string]: string}} b - Item B
+ * @property {string | {[key: string]: string}} c - Item C
+ * @property {string} d - Item D
+ * @property {string} [e] - Item E
+ * @property {{ e: string | { l: string } }} [f] - Item F
+ */
+
+/**
+ * @typedef {object} MockConfig2
+ * @property {{
+ *   key1: string | {[key: string]: string},
+ *   key2: string | {[key: string]: string}
+ * }} namespace - Namespace
+ */
+
+/**
+ * @import { Schema } from './index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.mjs
@@ -1,0 +1,81 @@
+import { isObject } from '../index.mjs'
+
+import { normaliseString } from './normalise-string.mjs'
+
+/**
+ * Extracts keys starting with a particular namespace from dataset ('data-*')
+ * object, removing the namespace in the process, normalising all values
+ *
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
+ * @param {Schema<ConfigurationType>} schema - The schema of a component
+ * @param {DOMStringMap} dataset - The object to extract key-value pairs from
+ * @param {keyof ConfigurationType} namespace - The namespace to filter keys with
+ * @returns {ObjectNested | undefined} Nested object with dot-separated key namespace removed
+ */
+export function extractConfigByNamespace(schema, dataset, namespace) {
+  const property = schema.properties[namespace]
+
+  // Only extract configs for object schema properties
+  if (property?.type !== 'object') {
+    return
+  }
+
+  // Add default empty config
+  const newObject = /** @type {Record<typeof namespace, ObjectNested>} */ ({
+    [namespace]: {}
+  })
+
+  for (const [key, value] of Object.entries(dataset)) {
+    /** @type {ObjectNested | ObjectNested[NestedKey]} */
+    let current = newObject
+
+    // Split the key into parts, using . as our namespace separator
+    const keyParts = key.split('.')
+
+    /**
+     * Create new level per part
+     *
+     * e.g. 'i18n.textareaDescription.other' becomes
+     * `{ i18n: { textareaDescription: { other } } }`
+     */
+    for (const [index, name] of keyParts.entries()) {
+      if (isObject(current)) {
+        // Drop down to nested object until the last part
+        if (index < keyParts.length - 1) {
+          // New nested object (optionally) replaces existing value
+          if (!isObject(current[name])) {
+            current[name] = {}
+          }
+
+          // Drop down into new or existing nested object
+          current = current[name]
+        } else if (key !== namespace) {
+          // Normalised value (optionally) replaces existing value
+          current[name] = normaliseString(value)
+        }
+      }
+    }
+  }
+
+  return newObject[namespace]
+}
+
+/**
+ * Schema for component config
+ *
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
+ * @typedef {object} Schema
+ * @property {Record<keyof ConfigurationType, SchemaProperty | undefined>} properties - Schema properties
+ */
+
+/**
+ * Schema property for component config
+ *
+ * @typedef {object} SchemaProperty
+ * @property {'string' | 'boolean' | 'number' | 'object'} type - Property type
+ */
+
+/**
+ * @typedef {keyof ObjectNested} NestedKey
+ * @typedef {{ [key: string]: string | boolean | number | ObjectNested | undefined }} ObjectNested
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
@@ -1,4 +1,5 @@
 export * from './extract-config-by-namespace.mjs'
 export * from './merge-configs.mjs'
 export * from './normalise-dataset.mjs'
+export * from './normalise-options.mjs'
 export * from './normalise-string.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
@@ -1,0 +1,2 @@
+export * from './merge-configs.mjs'
+export * from './normalise-string.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
@@ -1,2 +1,3 @@
 export * from './merge-configs.mjs'
+export * from './normalise-dataset.mjs'
 export * from './normalise-string.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/index.mjs
@@ -1,3 +1,4 @@
+export * from './extract-config-by-namespace.mjs'
 export * from './merge-configs.mjs'
 export * from './normalise-dataset.mjs'
 export * from './normalise-string.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/merge-configs.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/merge-configs.jsdom.test.mjs
@@ -1,0 +1,101 @@
+import { mergeConfigs } from './merge-configs.mjs'
+
+describe('mergeConfigs', () => {
+  const config1 = {
+    a: 'antelope',
+    c: { a: 'camel' }
+  }
+  const config2 = {
+    a: 'aardvark',
+    b: 'bee',
+    c: { a: 'cat', o: 'cobra' }
+  }
+  const config3 = {
+    b: 'bat',
+    c: { o: 'cow' },
+    d: 'dog',
+    e: {
+      l: {
+        e: 'elephant'
+      }
+    }
+  }
+
+  it('ignores a single object', () => {
+    const config = mergeConfigs(config1)
+    expect(config).toEqual({
+      a: 'antelope',
+      c: { a: 'camel' }
+    })
+  })
+
+  it('merges two objects', () => {
+    const config = mergeConfigs(config1, config2)
+    expect(config).toEqual({
+      a: 'aardvark',
+      b: 'bee',
+      c: { a: 'cat', o: 'cobra' }
+    })
+  })
+
+  it('merges three objects', () => {
+    const config = mergeConfigs(config1, config2, config3)
+    expect(config).toEqual({
+      a: 'aardvark',
+      b: 'bat',
+      c: { a: 'cat', o: 'cow' },
+      d: 'dog',
+      e: {
+        l: {
+          e: 'elephant'
+        }
+      }
+    })
+  })
+
+  it('ignores empty objects when merging', () => {
+    const test1 = mergeConfigs({}, config1)
+    const test2 = mergeConfigs(config1, {}, config2)
+    const test3 = mergeConfigs(config3, {})
+
+    expect(test1).toEqual(mergeConfigs(config1))
+    expect(test2).toEqual(mergeConfigs(config1, config2))
+    expect(test3).toEqual(mergeConfigs(config3))
+  })
+
+  it('prioritises the last parameter provided', () => {
+    const config = mergeConfigs(config1, config2, config3, config1)
+    expect(config).toEqual({
+      a: 'antelope',
+      b: 'bat',
+      c: { a: 'camel', o: 'cow' },
+      d: 'dog',
+      e: {
+        l: {
+          e: 'elephant'
+        }
+      }
+    })
+  })
+
+  it('prioritises the last parameter provided (different types)', () => {
+    const config = mergeConfigs(config1, config2, config3, {
+      c: 'jellyfish', // Replaces top-level object with string
+      e: { l: 'shark' } // Replaces nested object with string
+    })
+    expect(config).toEqual({
+      a: 'aardvark',
+      b: 'bat',
+      c: 'jellyfish',
+      d: 'dog',
+      e: {
+        l: 'shark'
+      }
+    })
+  })
+
+  it('returns an empty object if no parameters are provided', () => {
+    const config = mergeConfigs()
+    expect(config).toEqual({})
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/merge-configs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/merge-configs.mjs
@@ -1,0 +1,36 @@
+import { isObject } from '../index.mjs'
+
+/**
+ * Config merging function
+ *
+ * Takes any number of objects and combines them together, with
+ * greatest priority on the LAST item passed in.
+ *
+ * @param {...{ [key: string]: unknown }} configObjects - Config objects to merge
+ * @returns A merged config object
+ */
+export function mergeConfigs(...configObjects) {
+  // Start with an empty object as our base
+  /** @type {{ [key: string]: unknown }} */
+  const formattedConfigObject = {}
+
+  // Loop through each of the passed objects
+  for (const configObject of configObjects) {
+    for (const key of Object.keys(configObject)) {
+      const option = formattedConfigObject[key]
+      const override = configObject[key]
+
+      // Push their keys one-by-one into formattedConfigObject. Any duplicate
+      // keys with object values will be merged, otherwise the new value will
+      // override the existing value.
+      if (isObject(option) && isObject(override)) {
+        formattedConfigObject[key] = mergeConfigs(option, override)
+      } else {
+        // Apply override
+        formattedConfigObject[key] = override
+      }
+    }
+  }
+
+  return formattedConfigObject
+}

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
@@ -26,7 +26,8 @@ describe('normaliseDataset', () => {
         aString: { type: 'string' },
         aStringBoolean: { type: 'string' },
         aStringNumber: { type: 'string' },
-        anOptionalString: { type: 'string' }
+        anOptionalString: { type: 'string' },
+        anObject: { type: 'object' }
       }
     }
 
@@ -39,20 +40,28 @@ describe('normaliseDataset', () => {
       aBoolean: false,
       aString: '',
       aStringBoolean: 'true',
-      aStringNumber: '0'
+      aStringNumber: '0',
+      anObject: {
+        one: '100',
+        two: '200',
+        three: '300'
+      }
     }
   }
 
   it('normalises the entire dataset', () => {
     expect(
       normaliseDataset(MockConfigurableComponent, {
-        aNumber: '1000',
-        aDecimalNumber: '100.50',
-        aBoolean: 'true',
-        aString: 'Hello!',
-        aStringBoolean: 'false',
-        aStringNumber: '2024',
-        anOptionalString: ''
+        'aNumber': '1000',
+        'aDecimalNumber': '100.50',
+        'aBoolean': 'true',
+        'aString': 'Hello!',
+        'aStringBoolean': 'false',
+        'aStringNumber': '2024',
+        'anOptionalString': '',
+        'anObject.one': '111',
+        'anObject.two': '222',
+        'anObject.three': '333'
       })
     ).toEqual({
       aNumber: 1000,
@@ -61,7 +70,12 @@ describe('normaliseDataset', () => {
       aString: 'Hello!',
       aStringBoolean: 'false',
       aStringNumber: '2024',
-      anOptionalString: ''
+      anOptionalString: '',
+      anObject: {
+        one: 111,
+        two: 222,
+        three: 333
+      }
     })
   })
 
@@ -81,6 +95,7 @@ describe('normaliseDataset', () => {
  * @property {'true' | 'false'} aStringBoolean - A string boolean
  * @property {string} aStringNumber - A string number
  * @property {string} [anOptionalString] - An optional string
+ * @property {{ one: string, two: string, three: string }} anObject - An object
  */
 
 /**

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
@@ -1,0 +1,88 @@
+import { Component } from '../../component.mjs'
+import { ConfigurableComponent } from '../../configurable-component.mjs'
+
+import { normaliseDataset } from './index.mjs'
+
+describe('normaliseDataset', () => {
+  class MockComponent extends Component {
+    constructor($root) {
+      super($root)
+      this.args = [$root]
+    }
+  }
+
+  /**
+   * @augments ConfigurableComponent<MockConfig>
+   */
+  class MockConfigurableComponent extends ConfigurableComponent {
+    /**
+     * @satisfies {Schema<MockConfig>}
+     */
+    static schema = {
+      properties: {
+        aNumber: { type: 'number' },
+        aDecimalNumber: { type: 'number' },
+        aBoolean: { type: 'boolean' },
+        aString: { type: 'string' },
+        aStringBoolean: { type: 'string' },
+        aStringNumber: { type: 'string' },
+        anOptionalString: { type: 'string' }
+      }
+    }
+
+    /**
+     * @satisfies {MockConfig}
+     */
+    static defaults = {
+      aNumber: 0,
+      aDecimalNumber: 0,
+      aBoolean: false,
+      aString: '',
+      aStringBoolean: 'true',
+      aStringNumber: '0'
+    }
+  }
+
+  it('normalises the entire dataset', () => {
+    expect(
+      normaliseDataset(MockConfigurableComponent, {
+        aNumber: '1000',
+        aDecimalNumber: '100.50',
+        aBoolean: 'true',
+        aString: 'Hello!',
+        aStringBoolean: 'false',
+        aStringNumber: '2024',
+        anOptionalString: ''
+      })
+    ).toEqual({
+      aNumber: 1000,
+      aDecimalNumber: 100.5,
+      aBoolean: true,
+      aString: 'Hello!',
+      aStringBoolean: 'false',
+      aStringNumber: '2024',
+      anOptionalString: ''
+    })
+  })
+
+  it('throws when component schema is not defined', () => {
+    expect(() => normaliseDataset(MockComponent, {})).toThrow(
+      `${MockComponent.moduleName}: Config passed as parameter into constructor but no schema defined`
+    )
+  })
+})
+
+/**
+ * @typedef {object} MockConfig
+ * @property {number} aNumber - A number
+ * @property {number} aDecimalNumber - A decimal number
+ * @property {boolean} aBoolean - A boolean
+ * @property {string} aString - A string
+ * @property {'true' | 'false'} aStringBoolean - A string boolean
+ * @property {string} aStringNumber - A string number
+ * @property {string} [anOptionalString] - An optional string
+ */
+
+/**
+ * @import { Schema } from './index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.mjs
@@ -1,0 +1,54 @@
+import { ConfigError } from '../../errors/index.mjs'
+import { formatErrorMessage, isObject } from '../index.mjs'
+
+import { normaliseString } from './normalise-string.mjs'
+
+/**
+ * Normalise dataset
+ *
+ * Loop over an object and normalise each value using {@link normaliseString}
+ *
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
+ * @template {[keyof ConfigurationType, SchemaProperty | undefined][]} SchemaEntryType
+ * @param {CompatibleClass & { schema?: Schema<ConfigurationType> }} Component - Component class
+ * @param {DOMStringMap} dataset - HTML element dataset
+ * @returns {ObjectNested} Normalised dataset
+ */
+export function normaliseDataset(Component, dataset) {
+  if (!isObject(Component.schema)) {
+    throw new ConfigError(
+      formatErrorMessage(
+        Component,
+        'Config passed as parameter into constructor but no schema defined'
+      )
+    )
+  }
+
+  const out = /** @type {ObjectNested} */ ({})
+  const entries = /** @type {SchemaEntryType} */ (
+    Object.entries(Component.schema.properties)
+  )
+
+  // Normalise top-level dataset ('data-*') values using schema types
+  for (const entry of entries) {
+    const [namespace, property] = entry
+
+    // Cast the `namespace` to string so it can be used to access the dataset
+    const field = namespace.toString()
+
+    if (field in dataset) {
+      out[field] = normaliseString(dataset[field], property)
+    }
+  }
+
+  return out
+}
+
+/**
+ * @typedef {{ [key: string]: string | boolean | number | ObjectNested | undefined }} ObjectNested
+ */
+
+/**
+ * @import { CompatibleClass } from '../../component.mjs'
+ * @import { Schema, SchemaProperty } from '../../configurable-component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.mjs
@@ -1,12 +1,14 @@
 import { ConfigError } from '../../errors/index.mjs'
 import { formatErrorMessage, isObject } from '../index.mjs'
 
+import { extractConfigByNamespace } from './extract-config-by-namespace.mjs'
 import { normaliseString } from './normalise-string.mjs'
 
 /**
  * Normalise dataset
  *
- * Loop over an object and normalise each value using {@link normaliseString}
+ * Loop over an object and normalise each value using {@link normaliseString},
+ * optionally expanding `data-namespace.property` nested values
  *
  * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
  * @template {[keyof ConfigurationType, SchemaProperty | undefined][]} SchemaEntryType
@@ -39,16 +41,24 @@ export function normaliseDataset(Component, dataset) {
     if (field in dataset) {
       out[field] = normaliseString(dataset[field], property)
     }
+
+    /**
+     * Extract and normalise nested object values automatically using
+     * {@link normaliseString} but only schema object types are allowed
+     */
+    if (property?.type === 'object') {
+      out[field] = extractConfigByNamespace(
+        Component.schema,
+        dataset,
+        namespace
+      )
+    }
   }
 
   return out
 }
 
 /**
- * @typedef {{ [key: string]: string | boolean | number | ObjectNested | undefined }} ObjectNested
- */
-
-/**
  * @import { CompatibleClass } from '../../component.mjs'
- * @import { Schema, SchemaProperty } from '../../configurable-component.mjs'
+ * @import { ObjectNested, Schema, SchemaProperty } from './index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-options.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-options.jsdom.test.mjs
@@ -1,0 +1,153 @@
+import { normaliseOptions } from './normalise-options.mjs'
+
+describe('normaliseOptions', () => {
+  const scopes = [
+    {
+      name: 'document',
+      $scope: document
+    },
+    {
+      name: 'document (new)',
+      $scope: document.implementation.createHTMLDocument()
+    },
+    {
+      name: 'div element',
+      $scope: document.createElement('div')
+    },
+    {
+      name: 'article element',
+      $scope: document.createElement('article')
+    },
+    {
+      name: 'null selector',
+      $scope: document.querySelector('.unknown-scope')
+    },
+    {
+      name: 'null',
+      $scope: null
+    }
+  ]
+
+  const handlers = [
+    {
+      name: 'plain function',
+      handler: function errorCallback() {}
+    },
+    {
+      name: 'anonymous function',
+      handler: function () {}
+    },
+    {
+      name: 'shorthand function',
+      handler() {}
+    },
+    {
+      name: 'arrow function',
+      handler: () => {}
+    }
+  ]
+
+  it('returns defaults', () => {
+    expect(normaliseOptions()).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it('returns defaults for empty object', () => {
+    expect(normaliseOptions({})).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'undefined' scope option", () => {
+    expect(
+      normaliseOptions({
+        scope: undefined
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'undefined' error handler option", () => {
+    expect(
+      normaliseOptions({
+        onError: undefined
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("returns defaults for 'null' error handler option", () => {
+    expect(
+      normaliseOptions({
+        onError: null
+      })
+    ).toMatchObject({
+      scope: document,
+      onError: undefined
+    })
+  })
+
+  it("preserves 'null' scope", () => {
+    expect(normaliseOptions(null)).toMatchObject({
+      scope: null,
+      onError: undefined
+    })
+
+    expect(normaliseOptions({ scope: null })).toMatchObject({
+      scope: null,
+      onError: undefined
+    })
+  })
+
+  describe('with $scope option', () => {
+    it.each(scopes)("normalises '$name' option into object", ({ $scope }) => {
+      expect(normaliseOptions({ scope: $scope })).toMatchObject({
+        scope: $scope,
+        onError: undefined
+      })
+    })
+  })
+
+  describe('with $scope parameter', () => {
+    it.each(scopes)(
+      "normalises '$name' parameter into object",
+      ({ $scope }) => {
+        expect(normaliseOptions($scope)).toMatchObject({
+          scope: $scope,
+          onError: undefined
+        })
+      }
+    )
+  })
+
+  describe('with error handler option', () => {
+    it.each(handlers)(
+      "normalises '$name' option into object",
+      ({ handler }) => {
+        expect(normaliseOptions({ onError: handler })).toMatchObject({
+          scope: document,
+          onError: handler
+        })
+      }
+    )
+  })
+
+  describe('with error handler parameter', () => {
+    it.each(handlers)(
+      "normalises '$name' parameter into object",
+      ({ handler }) => {
+        expect(normaliseOptions(handler)).toMatchObject({
+          scope: document,
+          onError: handler
+        })
+      }
+    )
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-options.mjs
@@ -1,0 +1,46 @@
+import { isObject, isScope } from '../index.mjs'
+
+/**
+ * Normalise options passed to `initAll` or `createAll`
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @param {Config | CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document | null} [scopeOrOptions] - Scope of the document to search within, initialisation options or error callback function
+ * @returns {CreateAllOptions<ComponentClass>} Normalised options
+ */
+export function normaliseOptions(scopeOrOptions) {
+  let /** @type {Element | Document | null} */ $scope = document
+  let /** @type {OnErrorCallback<ComponentClass> | undefined} */ onError
+
+  // Handle options object
+  if (isObject(scopeOrOptions)) {
+    const options = scopeOrOptions
+
+    // Scope must be valid or null
+    if (isScope(options.scope) || options.scope === null) {
+      $scope = options.scope
+    }
+
+    // Error handler must be a function
+    if (typeof options.onError === 'function') {
+      onError = options.onError
+    }
+  }
+
+  if (isScope(scopeOrOptions)) {
+    $scope = scopeOrOptions
+  } else if (scopeOrOptions === null) {
+    $scope = null
+  } else if (typeof scopeOrOptions === 'function') {
+    onError = scopeOrOptions
+  }
+
+  return {
+    scope: $scope,
+    onError
+  }
+}
+
+/**
+ * @import { CompatibleClass } from '../../component.mjs'
+ * @import { Config, CreateAllOptions, OnErrorCallback } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
@@ -1,0 +1,83 @@
+import { normaliseString } from './normalise-string.mjs'
+
+describe('normaliseString', () => {
+  it('normalises the string "true" to boolean true', () => {
+    expect(normaliseString('true')).toBe(true)
+  })
+
+  it('normalises the string "false" to boolean false', () => {
+    expect(normaliseString('false')).toBe(false)
+  })
+
+  it('normalises the string " true " to boolean true', () => {
+    expect(normaliseString(' true ')).toBe(true)
+  })
+
+  it('normalises the string " false " to boolean false', () => {
+    expect(normaliseString(' false ')).toBe(false)
+  })
+
+  it('does not normalise non-lowercase booleans', () => {
+    expect(normaliseString('TRUE')).toBe('TRUE')
+    expect(normaliseString('True')).toBe('True')
+    expect(normaliseString('FALSE')).toBe('FALSE')
+    expect(normaliseString('False')).toBe('False')
+  })
+
+  it('does not normalise strings that contain booleans', () => {
+    expect(normaliseString('true!')).toBe('true!')
+  })
+
+  it('normalises the string "0" to the number 0', () => {
+    expect(normaliseString('0')).toBe(0)
+  })
+
+  it('normalises strings representing positive numbers to numbers', () => {
+    expect(normaliseString('1337')).toBe(1337)
+  })
+
+  it('normalises strings representing negative numbers to numbers', () => {
+    expect(normaliseString('-1337')).toBe(-1337)
+  })
+
+  it('converts strings representing decimal numbers to numbers', () => {
+    expect(normaliseString('0.5')).toBe(0.5)
+  })
+
+  it('normalises strings representing decimal numbers with extra precision to numbers', () => {
+    expect(normaliseString('100.500')).toBe(100.5)
+  })
+
+  it('normalises strings representing decimal numbers with no integer-part to numbers', () => {
+    expect(normaliseString('.5')).toBe(0.5)
+  })
+
+  it('normalises strings representing numbers with whitespace to numbers', () => {
+    expect(normaliseString('   1337   ')).toBe(1337)
+  })
+
+  it('does not normalise the string "NaN"', () => {
+    expect(normaliseString('NaN')).toBe('NaN')
+  })
+
+  it('does not normalise the string "Infinity"', () => {
+    expect(normaliseString('Infinity')).toBe('Infinity')
+  })
+
+  it('normalises strings that represent very big positive numbers to numbers', () => {
+    const biggestNumber = Number.MAX_SAFE_INTEGER + 1
+    expect(normaliseString(`${biggestNumber}`)).toEqual(biggestNumber)
+  })
+
+  it('does not normalise strings that contain numbers', () => {
+    expect(normaliseString('100%')).toBe('100%')
+  })
+
+  it('does not normalise empty strings', () => {
+    expect(normaliseString('')).toBe('')
+  })
+
+  it('does not normalise whitespace only strings', () => {
+    expect(normaliseString('   ')).toBe('   ')
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
@@ -49,8 +49,5 @@ export function normaliseString(value, property) {
 }
 
 /**
- * Schema property for component config
- *
- * @typedef {object} SchemaProperty
- * @property {'string' | 'boolean' | 'number' | 'object'} type - Property type
+ * @import { SchemaProperty } from '../../configurable-component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
@@ -49,5 +49,5 @@ export function normaliseString(value, property) {
 }
 
 /**
- * @import { SchemaProperty } from '../../configurable-component.mjs'
+ * @import { SchemaProperty } from './index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
@@ -1,0 +1,56 @@
+/**
+ * Normalise string
+ *
+ * 'If it looks like a duck, and it quacks like a duck…' 🦆
+ *
+ * If the passed value looks like a boolean or a number, convert it to a boolean
+ * or number.
+ *
+ * Designed to be used to convert config passed via data attributes (which are
+ * always strings) into something sensible.
+ *
+ * @param {string | undefined} value - The value to normalise
+ * @param {SchemaProperty} [property] - Component schema property
+ * @returns Normalised data
+ */
+export function normaliseString(value, property) {
+  const trimmedValue = value ? value.trim() : ''
+
+  let output
+  let outputType = property?.type
+
+  // No schema type set? Determine automatically
+  if (!outputType) {
+    if (['true', 'false'].includes(trimmedValue)) {
+      outputType = 'boolean'
+    }
+
+    // Empty / whitespace-only strings are considered finite so we need to check
+    // the length of the trimmed string as well
+    if (trimmedValue.length > 0 && isFinite(Number(trimmedValue))) {
+      outputType = 'number'
+    }
+  }
+
+  switch (outputType) {
+    case 'boolean':
+      output = trimmedValue === 'true'
+      break
+
+    case 'number':
+      output = Number(trimmedValue)
+      break
+
+    default:
+      output = value
+  }
+
+  return output
+}
+
+/**
+ * Schema property for component config
+ *
+ * @typedef {object} SchemaProperty
+ * @property {'string' | 'boolean' | 'number' | 'object'} type - Property type
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
@@ -143,7 +143,7 @@ export function isObject(option) {
 /**
  * Format error message
  *
- * @param {ComponentConstructor} Component - Component that threw the error
+ * @param {CompatibleClass} Component - Component that threw the error
  * @param {string} message - Error message
  * @returns {string} - Formatted error message
  */
@@ -154,5 +154,5 @@ export function formatErrorMessage(Component, message) {
 export * from './nhsuk-frontend-version.mjs'
 
 /**
- * @import { ComponentConstructor } from '../component.mjs'
+ * @import { CompatibleClass } from '../component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
@@ -130,6 +130,17 @@ export function isSupported($scope = document.body) {
 }
 
 /**
+ * Check for an object
+ *
+ * @template {Partial<Record<keyof ObjectType, unknown>>} ObjectType
+ * @param {unknown | ObjectType} option - Option to check
+ * @returns {option is ObjectType} Whether the option is an object
+ */
+export function isObject(option) {
+  return !!option && typeof option === 'object' && !Array.isArray(option)
+}
+
+/**
  * Format error message
  *
  * @param {ComponentConstructor} Component - Component that threw the error

--- a/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/index.mjs
@@ -141,6 +141,17 @@ export function isObject(option) {
 }
 
 /**
+ * Check for valid scope
+ *
+ * @template {Element | Document} ScopeType
+ * @param {unknown | ScopeType} $scope - Scope of the document to search within
+ * @returns {$scope is ScopeType} Whether the scope can be queried
+ */
+export function isScope($scope) {
+  return !!$scope && ($scope instanceof Element || $scope instanceof Document)
+}
+
+/**
  * Format error message
  *
  * @param {CompatibleClass} Component - Component that threw the error

--- a/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
@@ -2,6 +2,11 @@ import { Component } from './component.mjs'
 import { SupportError } from './errors/index.mjs'
 
 describe('Component', () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = ''
+    document.body.classList.add('nhsuk-frontend-supported')
+  })
+
   describe('checkSupport()', () => {
     describe('default implementation', () => {
       class ServiceComponent extends Component {

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -81,7 +81,33 @@ export class Component {
   static moduleName = 'nhsuk-component'
 }
 
+/* eslint-disable jsdoc/valid-types --
+ * `{new(...args: any[] ): any}` is not recognised as valid
+ * https://github.com/gajus/eslint-plugin-jsdoc/issues/145#issuecomment-1308722878
+ * https://github.com/jsdoc-type-pratt-parser/jsdoc-type-pratt-parser/issues/131
+ **/
+
 /**
- * @template {Element} [RootElementType=HTMLElement]
- * @typedef {typeof Component<RootElementType>} ComponentConstructor
+ * Component compatible class
+ *
+ * @template {typeof Component | typeof ConfigurableComponent} [ComponentType=typeof Component]
+ * @typedef {{
+ *   new(...args: ConstructorParameters<ComponentType>): InstanceType<ComponentType>,
+ *   defaults?: ObjectNested,
+ *   moduleName: string
+ * }} CompatibleClass
+ */
+
+/* eslint-enable jsdoc/valid-types */
+
+/**
+ * Component constructor
+ *
+ * @template {typeof Component | typeof ConfigurableComponent} [ComponentType=typeof Component]
+ * @typedef {CompatibleClass & ComponentType} ComponentConstructor
+ */
+
+/**
+ * @import { ObjectNested } from './common/configuration/index.mjs'
+ * @import { ConfigurableComponent } from './configurable-component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -26,26 +26,26 @@ export class Component {
    * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
-    const ComponentClass = /** @type {ComponentConstructor} */ (
+    const childConstructor = /** @type {ComponentConstructor} */ (
       this.constructor
     )
 
-    if (!$root || !($root instanceof ComponentClass.elementType)) {
+    if (!$root || !($root instanceof childConstructor.elementType)) {
       throw new ElementError({
         element: $root,
-        component: ComponentClass,
+        component: childConstructor,
         identifier: 'Root element (`$root`)',
-        expectedType: ComponentClass.elementType.name
+        expectedType: childConstructor.elementType.name
       })
     }
 
     this.$root = /** @type {RootElementType} */ ($root)
 
-    ComponentClass.checkSupport()
+    childConstructor.checkSupport()
 
     this.checkInitialised()
 
-    const { moduleName } = ComponentClass
+    const { moduleName } = childConstructor
     this.$root.setAttribute(`data-${moduleName}-init`, '')
   }
 
@@ -55,12 +55,12 @@ export class Component {
    * @throws {InitError} when component is already initialised
    */
   checkInitialised() {
-    const ComponentClass = /** @type {ComponentConstructor} */ (
+    const childConstructor = /** @type {ComponentConstructor} */ (
       this.constructor
     )
 
-    if (isInitialised(this.$root, ComponentClass.moduleName)) {
-      throw new InitError(ComponentClass)
+    if (isInitialised(this.$root, childConstructor.moduleName)) {
+      throw new InitError(childConstructor)
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -108,6 +108,13 @@ export class Component {
  */
 
 /**
+ * Component initialisation options
+ *
+ * @typedef {object} InitOptions
+ * @property {Element | Document | null} [scope] - Scope of the document to search within
+ */
+
+/**
  * @import { ObjectNested } from './common/configuration/index.mjs'
  * @import { ConfigurableComponent } from './configurable-component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -23,7 +23,7 @@ export class Component {
   /**
    * Constructs a new component, validating that NHS.UK frontend is supported
    *
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     const ComponentClass = /** @type {ComponentConstructor} */ (

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
@@ -179,4 +179,67 @@ describe('Button', () => {
       expect($root.click).toHaveBeenCalled()
     })
   })
+
+  describe('Nunjucks configuration', () => {
+    it('configures prevent double click explicitly enabled', () => {
+      initExample('with double click prevented')
+
+      const button = new Button($root)
+      expect(button.config).toEqual({
+        preventDoubleClick: true
+      })
+    })
+
+    it('configures prevent double click disabled', () => {
+      initExample('with double click not prevented')
+
+      const button = new Button($root)
+      expect(button.config).toEqual({
+        preventDoubleClick: false
+      })
+    })
+
+    it('ignores unknown data attributes', () => {
+      document.body.innerHTML = components.render('button', {
+        context: {
+          ...examples['default'].context,
+          attributes: {
+            'data-unknown1': '100',
+            'data-unknown2': 200,
+            'data-unknown3': false
+          }
+        }
+      })
+
+      const button = new Button(
+        document.querySelector(`[data-module="${Button.moduleName}"]`)
+      )
+
+      expect(button.config).toEqual({
+        preventDoubleClick: false
+      })
+    })
+  })
+
+  describe('JavaScript configuration', () => {
+    it('configures prevent double click explicitly enabled', () => {
+      const button = new Button($root, {
+        preventDoubleClick: true
+      })
+
+      expect(button.config).toEqual({
+        preventDoubleClick: true
+      })
+    })
+
+    it('configures prevent double click disabled', () => {
+      const button = new Button($root, {
+        preventDoubleClick: false
+      })
+
+      expect(button.config).toEqual({
+        preventDoubleClick: false
+      })
+    })
+  })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.jsdom.test.mjs
@@ -76,6 +76,7 @@ describe('Button', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new Button()).toThrow(
         `${Button.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { ConfigurableComponent } from '../../configurable-component.mjs'
 
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
@@ -117,13 +118,14 @@ export class Button extends ConfigurableComponent {
  * @deprecated Use {@link createAll | `createAll(Button, options)`} instead.
  * @param {InitOptions & ButtonConfig} [options]
  */
-export function initButtons(options = {}) {
-  const $scope = options.scope ?? document
-  const $buttons = $scope.querySelectorAll(
+export function initButtons(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $buttons = $scope?.querySelectorAll(
     `[data-module="${Button.moduleName}"]`
   )
 
-  $buttons.forEach(($root) => {
+  $buttons?.forEach(($root) => {
     new Button($root, options)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -1,11 +1,13 @@
-import { Component } from '../../component.mjs'
+import { ConfigurableComponent } from '../../configurable-component.mjs'
 
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
 
 /**
  * Button component
+ *
+ * @augments ConfigurableComponent<ButtonConfig>
  */
-export class Button extends Component {
+export class Button extends ConfigurableComponent {
   /**
    * @type {number | null}
    */
@@ -13,9 +15,10 @@ export class Button extends Component {
 
   /**
    * @param {Element | null} $root - HTML element to use for component
+   * @param {ButtonConfig} [config] - Button config
    */
-  constructor($root) {
-    super($root)
+  constructor($root, config = {}) {
+    super($root, config)
 
     /**
      * Initialise an event listener for keydown at document level
@@ -63,11 +66,8 @@ export class Button extends Component {
    * @returns {undefined | false} Returns undefined, or false when debounced
    */
   debounce(event) {
-    // Check the button that is clicked on has the preventDoubleClick feature enabled
-    if (
-      !(event.target instanceof HTMLElement) ||
-      event.target.dataset.preventDoubleClick !== 'true'
-    ) {
+    // Check the button that was clicked has preventDoubleClick enabled
+    if (!this.config.preventDoubleClick) {
       return
     }
 
@@ -86,13 +86,36 @@ export class Button extends Component {
    * Name for the component used when initialising using data-module attributes
    */
   static moduleName = 'nhsuk-button'
+
+  /**
+   * Button default config
+   *
+   * @see {@link ButtonConfig}
+   * @constant
+   * @type {ButtonConfig}
+   */
+  static defaults = Object.freeze({
+    preventDoubleClick: false
+  })
+
+  /**
+   * Button config schema
+   *
+   * @constant
+   * @satisfies {Schema<ButtonConfig>}
+   */
+  static schema = Object.freeze({
+    properties: {
+      preventDoubleClick: { type: 'boolean' }
+    }
+  })
 }
 
 /**
  * Initialise button component
  *
- * @deprecated Use {@link createAll | `createAll(Button)`} instead.
- * @param {InitOptions} [options]
+ * @deprecated Use {@link createAll | `createAll(Button, options)`} instead.
+ * @param {InitOptions & ButtonConfig} [options]
  */
 export function initButtons(options = {}) {
   const $scope = options.scope ?? document
@@ -101,10 +124,19 @@ export function initButtons(options = {}) {
   )
 
   $buttons.forEach(($root) => {
-    new Button($root)
+    new Button($root, options)
   })
 }
 
 /**
+ * Button config
+ *
+ * @typedef {object} ButtonConfig
+ * @property {boolean} [preventDoubleClick=false] - Prevent accidental double
+ *   clicks on submit buttons from submitting forms multiple times.
+ */
+
+/**
  * @import { createAll, InitOptions } from '../../index.mjs'
+ * @import { Schema } from '../../common/configuration/index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -12,7 +12,7 @@ export class Button extends Component {
   debounceFormSubmitTimer = null
 
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.mjs
@@ -91,8 +91,8 @@ export class Button extends Component {
 /**
  * Initialise button component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(Button)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initButtons(options = {}) {
   const $scope = options.scope ?? document
@@ -104,3 +104,7 @@ export function initButtons(options = {}) {
     new Button($root)
   })
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -136,8 +136,8 @@ describe('Character count', () => {
     })
   })
 
-  describe('JavaScript configuration', () => {
-    it('configures the number of characters using `data-maxlength`', () => {
+  describe('Nunjucks configuration', () => {
+    it('configures the number of characters', () => {
       const characterCount = new CharacterCount($root)
       expect(characterCount.config).toEqual({
         maxlength: 10,
@@ -145,7 +145,7 @@ describe('Character count', () => {
       })
     })
 
-    it('configures the number of words using `data-maxwords`', () => {
+    it('configures the number of words', () => {
       initExample('with word count')
 
       const characterCount = new CharacterCount($root)
@@ -155,7 +155,7 @@ describe('Character count', () => {
       })
     })
 
-    it('configures the threshold using `data-threshold`', () => {
+    it('configures the threshold', () => {
       initExample('with threshold')
 
       const characterCount = new CharacterCount($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -101,6 +101,7 @@ describe('Character count', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new CharacterCount()).toThrow(
         `${CharacterCount.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -1,10 +1,12 @@
-import { Component } from '../../component.mjs'
+import { ConfigurableComponent } from '../../configurable-component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
 /**
  * Character count component
+ *
+ * @augments ConfigurableComponent<CharacterCountConfig>
  */
-export class CharacterCount extends Component {
+export class CharacterCount extends ConfigurableComponent {
   /**
    * @type {number | null}
    */
@@ -18,9 +20,10 @@ export class CharacterCount extends Component {
 
   /**
    * @param {Element | null} $root - HTML element to use for component
+   * @param {Record<string, never>} [config] - Not yet supported. Character count config
    */
-  constructor($root) {
-    super($root)
+  constructor($root, config = {}) {
+    super($root, config)
 
     const $textarea = this.$root.querySelector('.nhsuk-js-character-count')
     if (
@@ -87,17 +90,6 @@ export class CharacterCount extends Component {
     // Hide the fallback limit message
     $fallbackLimitMessage.classList.add('nhsuk-u-visually-hidden')
 
-    /**
-     * Read config set using dataset ('data-' values)
-     *
-     * @type {CharacterCountConfig}
-     */
-    this.config = Object.assign(
-      {},
-      CharacterCount.defaults,
-      CharacterCount.getDataset(this.$root)
-    )
-
     // Determine the limit attribute (characters or words)
     this.maxLength = this.config.maxwords ?? this.config.maxlength ?? Infinity
 
@@ -115,23 +107,6 @@ export class CharacterCount extends Component {
     // could be called after those events have fired, for example if they are
     // added to the page dynamically, so update now too.
     this.updateCountMessage()
-  }
-
-  /**
-   * Read data attributes
-   *
-   * @param {HTMLElement} $element - HTML element
-   */
-  static getDataset($element) {
-    const dataset = /** @type {CharacterCountConfig} */ ({})
-
-    for (const [key, value] of Object.entries($element.dataset)) {
-      if (key === 'maxlength' || key === 'maxwords' || key === 'threshold') {
-        dataset[key] = Number(value)
-      }
-    }
-
-    return dataset
   }
 
   /**
@@ -320,6 +295,20 @@ export class CharacterCount extends Component {
   static defaults = Object.freeze({
     threshold: 0
   })
+
+  /**
+   * Character config schema
+   *
+   * @constant
+   * @satisfies {Schema<CharacterCountConfig>}
+   */
+  static schema = Object.freeze({
+    properties: {
+      maxwords: { type: 'number' },
+      maxlength: { type: 'number' },
+      threshold: { type: 'number' }
+    }
+  })
 }
 
 /**
@@ -355,4 +344,5 @@ export function initCharacterCounts(options = {}) {
 
 /**
  * @import { createAll, InitOptions } from '../../index.mjs'
+ * @import { Schema } from '../../common/configuration/index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -17,7 +17,7 @@ export class CharacterCount extends Component {
   valueChecker = null
 
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -325,8 +325,8 @@ export class CharacterCount extends Component {
 /**
  * Initialise character count component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(CharacterCount)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initCharacterCounts(options = {}) {
   const $scope = options.scope ?? document
@@ -351,4 +351,8 @@ export function initCharacterCounts(options = {}) {
  * @property {number} [threshold=0] - The percentage value of the limit at
  *   which point the count message is displayed. If this attribute is set, the
  *   count message will be hidden by default.
+ */
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { ConfigurableComponent } from '../../configurable-component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -317,13 +318,14 @@ export class CharacterCount extends ConfigurableComponent {
  * @deprecated Use {@link createAll | `createAll(CharacterCount)`} instead.
  * @param {InitOptions} [options]
  */
-export function initCharacterCounts(options = {}) {
-  const $scope = options.scope ?? document
-  const $characterCounts = $scope.querySelectorAll(
+export function initCharacterCounts(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $characterCounts = $scope?.querySelectorAll(
     `[data-module="${CharacterCount.moduleName}"]`
   )
 
-  $characterCounts.forEach(($root) => {
+  $characterCounts?.forEach(($root) => {
     new CharacterCount($root)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.jsdom.test.mjs
@@ -126,6 +126,7 @@ describe('Checkboxes', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new Checkboxes()).toThrow(
         `${Checkboxes.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { toggleConditionalInput } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
@@ -202,13 +203,14 @@ export class Checkboxes extends Component {
  * @deprecated Use {@link createAll | `createAll(Checkboxes)`} instead.
  * @param {InitOptions} [options]
  */
-export function initCheckboxes(options = {}) {
-  const $scope = options.scope ?? document
-  const $checkboxes = $scope.querySelectorAll(
+export function initCheckboxes(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $checkboxes = $scope?.querySelectorAll(
     `[data-module="${Checkboxes.moduleName}"]`
   )
 
-  $checkboxes.forEach(($root) => {
+  $checkboxes?.forEach(($root) => {
     new Checkboxes($root)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -11,7 +11,7 @@ import { ElementError } from '../../errors/index.mjs'
  */
 export class Checkboxes extends Component {
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.mjs
@@ -199,8 +199,8 @@ export class Checkboxes extends Component {
 /**
  * Initialise checkboxes component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(Checkboxes)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initCheckboxes(options = {}) {
   const $scope = options.scope ?? document
@@ -212,3 +212,7 @@ export function initCheckboxes(options = {}) {
     new Checkboxes($root)
   })
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -94,6 +94,7 @@ describe('Error summary', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new ErrorSummary()).toThrow(
         `${ErrorSummary.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -45,6 +45,8 @@ describe('Error summary', () => {
     jest.spyOn($root, 'addEventListener')
     jest.spyOn($input, 'focus')
     jest.spyOn($label, 'scrollIntoView')
+
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   describe('Initialisation via init function', () => {
@@ -134,18 +136,32 @@ describe('Error summary', () => {
         expect($root).toHaveFocus()
       })
 
-      it('sets focus automatically (focusOnPageLoad: true)', () => {
-        initErrorSummary({
-          focusOnPageLoad: true
-        })
+      it('moves focus to the $root element', () => {
+        initErrorSummary()
 
         expect($root).toHaveFocus()
       })
 
-      it('does not set focus automatically (focusOnPageLoad: false)', () => {
+      it('moves focus to the $root element with `focusOnPageLoad: true` (deprecated)', () => {
+        initErrorSummary({
+          focusOnPageLoad: true
+        })
+
+        expect(console.warn).toHaveBeenCalledWith(
+          `${ErrorSummary.moduleName}: Option \`focusOnPageLoad\` is deprecated. Use \`disableAutoFocus\` instead.`
+        )
+
+        expect($root).toHaveFocus()
+      })
+
+      it('does not move focus to the $root element with `focusOnPageLoad: false` (deprecated)', () => {
         initErrorSummary({
           focusOnPageLoad: false
         })
+
+        expect(console.warn).toHaveBeenCalledWith(
+          `${ErrorSummary.moduleName}: Option \`focusOnPageLoad\` is deprecated. Use \`disableAutoFocus\` instead.`
+        )
 
         expect($root).not.toHaveFocus()
       })

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.jsdom.test.mjs
@@ -20,10 +20,13 @@ describe('Error summary', () => {
   /** @type {HTMLLabelElement} */
   let $label
 
-  beforeEach(() => {
+  /**
+   * @param {keyof typeof examples} example
+   */
+  function initExample(example) {
     document.body.innerHTML = outdent`
       <form method="post" novalidate>
-        ${components.render('error-summary', examples['with description'])}
+        ${components.render('error-summary', examples[example])}
         ${components.render('date-input', dateInputExamples['with errors and hint'])}
       </form>
     `
@@ -46,7 +49,11 @@ describe('Error summary', () => {
     jest.spyOn($input, 'focus')
     jest.spyOn($label, 'scrollIntoView')
 
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation()
+  }
+
+  beforeEach(() => {
+    initExample('with description')
   })
 
   describe('Initialisation via init function', () => {
@@ -179,6 +186,69 @@ describe('Error summary', () => {
         expect($input.focus).toHaveBeenCalledWith({
           preventScroll: true
         })
+      })
+    })
+  })
+
+  describe('Nunjucks configuration', () => {
+    it('configures auto-focus explicitly enabled', () => {
+      initExample('auto-focus explicitly enabled')
+
+      const errorSummary = new ErrorSummary($root)
+      expect(errorSummary.config).toEqual({
+        disableAutoFocus: false
+      })
+    })
+
+    it('configures auto-focus disabled', () => {
+      initExample('auto-focus disabled')
+
+      const errorSummary = new ErrorSummary($root)
+      expect(errorSummary.config).toEqual({
+        disableAutoFocus: true
+      })
+    })
+
+    it('ignores unknown data attributes', () => {
+      document.body.innerHTML = components.render('error-summary', {
+        context: {
+          ...examples['default'].context,
+          attributes: {
+            'data-unknown1': '100',
+            'data-unknown2': 200,
+            'data-unknown3': false
+          }
+        }
+      })
+
+      const errorSummary = new ErrorSummary(
+        document.querySelector(`[data-module="${ErrorSummary.moduleName}"]`)
+      )
+
+      expect(errorSummary.config).toEqual({
+        disableAutoFocus: false
+      })
+    })
+  })
+
+  describe('JavaScript configuration', () => {
+    it('configures auto-focus explicitly enabled', () => {
+      const errorSummary = new ErrorSummary($root, {
+        disableAutoFocus: false
+      })
+
+      expect(errorSummary.config).toEqual({
+        disableAutoFocus: false
+      })
+    })
+
+    it('configures auto-focus disabled', () => {
+      const errorSummary = new ErrorSummary($root, {
+        disableAutoFocus: true
+      })
+
+      expect(errorSummary.config).toEqual({
+        disableAutoFocus: true
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -152,6 +152,8 @@ export class ErrorSummary extends Component {
  *
  * @param {object} [options]
  * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @param {boolean} [options.disableAutoFocus] - If set to `true` the error
+ *   summary will not be focussed when the page loads
  * @param {boolean} [options.focusOnPageLoad] - Deprecated, use `disableAutoFocus` instead
  */
 export function initErrorSummary(options = {}) {
@@ -174,7 +176,8 @@ export function initErrorSummary(options = {}) {
   }
 
   new ErrorSummary($root, {
-    disableAutoFocus: options.focusOnPageLoad === false
+    disableAutoFocus:
+      options.disableAutoFocus ?? options.focusOnPageLoad === false
   })
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { formatErrorMessage, setFocus } from '../../common/index.mjs'
 import { ConfigurableComponent } from '../../configurable-component.mjs'
 
@@ -205,9 +206,10 @@ export class ErrorSummary extends ConfigurableComponent {
  * @deprecated Use {@link createAll | `createAll(ErrorSummary, options)`} instead.
  * @param {InitOptions & ErrorSummaryConfig} [options]
  */
-export function initErrorSummary(options = {}) {
-  const $scope = options.scope ?? document
-  const $root = $scope.querySelector(
+export function initErrorSummary(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $root = $scope?.querySelector(
     `[data-module="${ErrorSummary.moduleName}"]`
   )
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -8,7 +8,7 @@ import { Component } from '../../component.mjs'
  */
 export class ErrorSummary extends Component {
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($root, config = {}) {

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -1,3 +1,4 @@
+import { formatErrorMessage } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 
 /**
@@ -151,8 +152,7 @@ export class ErrorSummary extends Component {
  *
  * @param {object} [options]
  * @param {Element | Document | null} [options.scope] - Scope of the document to search within
- * @param {boolean} [options.focusOnPageLoad] - If set to `false` the error
- *   summary will not be focussed when the page loads.
+ * @param {boolean} [options.focusOnPageLoad] - Deprecated, use `disableAutoFocus` instead
  */
 export function initErrorSummary(options = {}) {
   const $scope = options.scope ?? document
@@ -162,6 +162,15 @@ export function initErrorSummary(options = {}) {
 
   if (!$root) {
     return
+  }
+
+  if ('focusOnPageLoad' in options) {
+    console.warn(
+      formatErrorMessage(
+        ErrorSummary,
+        'Option `focusOnPageLoad` is deprecated. Use `disableAutoFocus` instead.'
+      )
+    )
   }
 
   new ErrorSummary($root, {

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.mjs
@@ -150,11 +150,8 @@ export class ErrorSummary extends Component {
 /**
  * Initialise error summary component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
- * @param {boolean} [options.disableAutoFocus] - If set to `true` the error
- *   summary will not be focussed when the page loads
- * @param {boolean} [options.focusOnPageLoad] - Deprecated, use `disableAutoFocus` instead
+ * @deprecated Use {@link createAll | `createAll(ErrorSummary, options)`} instead.
+ * @param {InitOptions & ErrorSummaryConfig} [options]
  */
 export function initErrorSummary(options = {}) {
   const $scope = options.scope ?? document
@@ -185,6 +182,11 @@ export function initErrorSummary(options = {}) {
  * Error summary config
  *
  * @typedef {object} ErrorSummaryConfig
+ * @property {boolean} [focusOnPageLoad=true] - Deprecated. Use `disableAutoFocus` instead.
  * @property {boolean} [disableAutoFocus=false] - If set to `true` the error
  *   summary will not be focussed when the page loads.
+ */
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/macro-options.mjs
@@ -70,6 +70,12 @@ export const params = {
       }
     }
   },
+  disableAutoFocus: {
+    type: 'boolean',
+    required: false,
+    description:
+      'Prevent moving focus to the error summary when the page loads.'
+  },
   classes: {
     type: 'string',
     required: false,
@@ -112,6 +118,30 @@ export const examples = {
       ]
     },
     screenshot: true
+  },
+  'auto-focus disabled': {
+    context: {
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: 'Date of birth must be in the past',
+          href: '#example-day'
+        }
+      ],
+      disableAutoFocus: true
+    }
+  },
+  'auto-focus explicitly enabled': {
+    context: {
+      titleText: 'There is a problem',
+      errorList: [
+        {
+          text: 'Date of birth must be in the past',
+          href: '#example-day'
+        }
+      ],
+      disableAutoFocus: false
+    }
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
@@ -2,6 +2,7 @@
 
 <div class="nhsuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+  {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-error-summary">
   <h2 class="nhsuk-error-summary__title" id="error-summary-title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.jsdom.test.mjs
@@ -167,6 +167,7 @@ describe('Header class', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new Header()).toThrow(
         `${Header.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -39,7 +39,7 @@ export class Header extends Component {
   menuIsOpen = false
 
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -374,8 +374,8 @@ export class Header extends Component {
 /**
  * Initialise header component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(Header)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initHeader(options = {}) {
   const $scope = options.scope ?? document
@@ -387,3 +387,7 @@ export function initHeader(options = {}) {
 
   new Header($root)
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
 
@@ -377,9 +378,10 @@ export class Header extends Component {
  * @deprecated Use {@link createAll | `createAll(Header)`} instead.
  * @param {InitOptions} [options]
  */
-export function initHeader(options = {}) {
-  const $scope = options.scope ?? document
-  const $root = $scope.querySelector(`[data-module="${Header.moduleName}"]`)
+export function initHeader(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $root = $scope?.querySelector(`[data-module="${Header.moduleName}"]`)
 
   if (!$root) {
     return

--- a/packages/nhsuk-frontend/src/nhsuk/components/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/index.mjs
@@ -7,3 +7,7 @@ export * from './notification-banner/notification-banner.mjs'
 export * from './radios/radios.mjs'
 export * from './skip-link/skip-link.mjs'
 export * from './tabs/tabs.mjs'
+
+// Base components
+export * from '../component.mjs'
+export * from '../configurable-component.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.jsdom.test.mjs
@@ -10,15 +10,22 @@ describe('Notification banner', () => {
   /** @type {HTMLElement} */
   let $root
 
-  beforeEach(() => {
+  /**
+   * @param {keyof typeof examples} example
+   */
+  function initExample(example) {
     document.body.innerHTML = components.render(
       'notification-banner',
-      examples['with type as success']
+      examples[example]
     )
 
     $root = /** @type {HTMLElement} */ (
       document.querySelector(`[data-module="${NotificationBanner.moduleName}"]`)
     )
+  }
+
+  beforeEach(() => {
+    initExample('with type as success')
   })
 
   describe('Initialisation via init function', () => {
@@ -80,6 +87,75 @@ describe('Notification banner', () => {
     it('should add accessible name and role', () => {
       expect($root).toHaveAccessibleName('Success')
       expect($root).toHaveRole('alert')
+    })
+  })
+
+  describe('Nunjucks configuration', () => {
+    it('configures auto-focus explicitly enabled', () => {
+      initExample('auto-focus explicitly enabled, with type as success')
+
+      const notificationBanner = new NotificationBanner($root)
+      expect(notificationBanner.config).toEqual({
+        disableAutoFocus: false
+      })
+
+      expect($root).toHaveFocus()
+    })
+
+    it('configures auto-focus disabled', () => {
+      initExample('auto-focus disabled, with type as success')
+
+      const notificationBanner = new NotificationBanner($root)
+      expect(notificationBanner.config).toEqual({
+        disableAutoFocus: true
+      })
+
+      expect($root).not.toHaveFocus()
+    })
+
+    it('ignores unknown data attributes', () => {
+      document.body.innerHTML = components.render('notification-banner', {
+        context: {
+          ...examples['default'].context,
+          attributes: {
+            'data-unknown1': '100',
+            'data-unknown2': 200,
+            'data-unknown3': false
+          }
+        }
+      })
+
+      const notificationBanner = new NotificationBanner(
+        document.querySelector(
+          `[data-module="${NotificationBanner.moduleName}"]`
+        )
+      )
+
+      expect(notificationBanner.config).toEqual({
+        disableAutoFocus: false
+      })
+    })
+  })
+
+  describe('JavaScript configuration', () => {
+    it('configures auto-focus explicitly enabled', () => {
+      const notificationBanner = new NotificationBanner($root, {
+        disableAutoFocus: false
+      })
+
+      expect(notificationBanner.config).toEqual({
+        disableAutoFocus: false
+      })
+    })
+
+    it('configures auto-focus disabled', () => {
+      const notificationBanner = new NotificationBanner($root, {
+        disableAutoFocus: true
+      })
+
+      expect(notificationBanner.config).toEqual({
+        disableAutoFocus: true
+      })
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.jsdom.test.mjs
@@ -52,6 +52,7 @@ describe('Notification banner', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new NotificationBanner()).toThrow(
         `${NotificationBanner.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
@@ -1,28 +1,20 @@
 import { setFocus } from '../../common/index.mjs'
-import { Component } from '../../component.mjs'
+import { ConfigurableComponent } from '../../configurable-component.mjs'
 
 /**
  * Notification banner component
  *
  * Adapted from https://github.com/alphagov/govuk-frontend/blob/v5.10.2/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+ *
+ * @augments ConfigurableComponent<NotificationBannerConfig>
  */
-export class NotificationBanner extends Component {
+export class NotificationBanner extends ConfigurableComponent {
   /**
    * @param {Element | null} $root - HTML element to use for component
+   * @param {NotificationBannerConfig} [config] - Notification banner config
    */
-  constructor($root) {
-    super($root)
-
-    /**
-     * Read config set using dataset ('data-' values)
-     *
-     * @type {NotificationBannerConfig}
-     */
-    this.config = Object.assign(
-      {},
-      NotificationBanner.defaults,
-      NotificationBanner.getDataset(this.$root)
-    )
+  constructor($root, config = {}) {
+    super($root, config)
 
     /**
      * Focus the notification banner
@@ -44,23 +36,6 @@ export class NotificationBanner extends Component {
   }
 
   /**
-   * Read data attributes
-   *
-   * @param {HTMLElement} element - HTML element
-   */
-  static getDataset(element) {
-    const dataset = /** @type {NotificationBannerConfig} */ ({})
-
-    for (const [key, value] of Object.entries(element.dataset)) {
-      if (key === 'disableAutoFocus') {
-        dataset[key] = value === 'true'
-      }
-    }
-
-    return dataset
-  }
-
-  /**
    * Name for the component used when initialising using data-module attributes.
    */
   static moduleName = 'nhsuk-notification-banner'
@@ -75,13 +50,25 @@ export class NotificationBanner extends Component {
   static defaults = Object.freeze({
     disableAutoFocus: false
   })
+
+  /**
+   * Notification banner config schema
+   *
+   * @constant
+   * @satisfies {Schema<NotificationBannerConfig>}
+   */
+  static schema = Object.freeze({
+    properties: {
+      disableAutoFocus: { type: 'boolean' }
+    }
+  })
 }
 
 /**
  * Initialise notification banner component
  *
- * @deprecated Use {@link createAll | `createAll(NotificationBanner)`} instead.
- * @param {InitOptions} [options]
+ * @deprecated Use {@link createAll | `createAll(NotificationBanner, options)`} instead.
+ * @param {InitOptions & NotificationBannerConfig} [options]
  */
 export function initNotificationBanners(options = {}) {
   const $scope = options.scope ?? document
@@ -90,7 +77,7 @@ export function initNotificationBanners(options = {}) {
   )
 
   $notificationBanners.forEach(($notificationBanner) => {
-    new NotificationBanner($notificationBanner)
+    new NotificationBanner($notificationBanner, options)
   })
 }
 
@@ -106,4 +93,5 @@ export function initNotificationBanners(options = {}) {
 
 /**
  * @import { createAll, InitOptions } from '../../index.mjs'
+ * @import { Schema } from '../../common/configuration/index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
@@ -8,7 +8,7 @@ import { Component } from '../../component.mjs'
  */
 export class NotificationBanner extends Component {
   /**
-   * @param {Element | null} [$root] - HTML element to use for notification banner
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
@@ -80,8 +80,8 @@ export class NotificationBanner extends Component {
 /**
  * Initialise notification banner component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(NotificationBanner)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initNotificationBanners(options = {}) {
   const $scope = options.scope ?? document
@@ -102,4 +102,8 @@ export function initNotificationBanners(options = {}) {
  *   notification banner will not be focussed when the page loads. This only
  *   applies if the component has a `role` of `alert` – in other cases the
  *   component will not be focused on page load, regardless of this option.
+ */
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { setFocus } from '../../common/index.mjs'
 import { ConfigurableComponent } from '../../configurable-component.mjs'
 
@@ -70,13 +71,14 @@ export class NotificationBanner extends ConfigurableComponent {
  * @deprecated Use {@link createAll | `createAll(NotificationBanner, options)`} instead.
  * @param {InitOptions & NotificationBannerConfig} [options]
  */
-export function initNotificationBanners(options = {}) {
-  const $scope = options.scope ?? document
-  const $notificationBanners = $scope.querySelectorAll(
+export function initNotificationBanners(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $notificationBanners = $scope?.querySelectorAll(
     `[data-module="${NotificationBanner.moduleName}"]`
   )
 
-  $notificationBanners.forEach(($notificationBanner) => {
+  $notificationBanners?.forEach(($notificationBanner) => {
     new NotificationBanner($notificationBanner, options)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.jsdom.test.mjs
@@ -108,6 +108,7 @@ describe('Radios', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new Radios()).toThrow(
         `${Radios.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { toggleConditionalInput } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
@@ -125,13 +126,14 @@ export class Radios extends Component {
  * @deprecated Use {@link createAll | `createAll(Radios)`} instead.
  * @param {InitOptions} [options]
  */
-export function initRadios(options = {}) {
-  const $scope = options.scope ?? document
-  const $radios = $scope.querySelectorAll(
+export function initRadios(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $radios = $scope?.querySelectorAll(
     `[data-module="${Radios.moduleName}"]`
   )
 
-  $radios.forEach(($root) => {
+  $radios?.forEach(($root) => {
     new Radios($root)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -122,8 +122,8 @@ export class Radios extends Component {
 /**
  * Initialise radios component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(Radios)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initRadios(options = {}) {
   const $scope = options.scope ?? document
@@ -135,3 +135,7 @@ export function initRadios(options = {}) {
     new Radios($root)
   })
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -11,7 +11,7 @@ import { ElementError } from '../../errors/index.mjs'
  */
 export class Radios extends Component {
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.mjs
@@ -72,7 +72,6 @@ export class Radios extends Component {
    * Synchronise the visibility of the conditional reveal, and its accessible
    * state, with the input's checked state.
    *
-   * @private
    * @param {HTMLInputElement} $input - Radio input
    */
   syncConditionalRevealWithInputState($input) {

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.jsdom.test.mjs
@@ -93,6 +93,7 @@ describe('Skip link', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new SkipLink()).toThrow(
         `${SkipLink.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { setFocus } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
@@ -71,13 +72,14 @@ export class SkipLink extends Component {
  * @deprecated Use {@link createAll | `createAll(SkipLink)`} instead.
  * @param {InitOptions} [options]
  */
-export function initSkipLinks(options = {}) {
-  const $scope = options.scope ?? document
-  const $skipLinks = $scope.querySelectorAll(
+export function initSkipLinks(options) {
+  const { scope: $scope } = normaliseOptions(options)
+
+  const $skipLinks = $scope?.querySelectorAll(
     `[data-module="${SkipLink.moduleName}"]`
   )
 
-  $skipLinks.forEach(($root) => {
+  $skipLinks?.forEach(($root) => {
     new SkipLink($root)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -14,7 +14,7 @@ export class SkipLink extends Component {
   static elementType = HTMLAnchorElement
 
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.mjs
@@ -68,8 +68,8 @@ export class SkipLink extends Component {
 /**
  * Initialise skip link component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(SkipLink)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initSkipLinks(options = {}) {
   const $scope = options.scope ?? document
@@ -81,3 +81,7 @@ export function initSkipLinks(options = {}) {
     new SkipLink($root)
   })
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.jsdom.test.mjs
@@ -139,6 +139,7 @@ describe('Tabs', () => {
     })
 
     it('should throw with missing $root element', () => {
+      // @ts-expect-error Parameter '$root' not provided
       expect(() => new Tabs()).toThrow(
         `${Tabs.moduleName}: Root element (\`$root\`) not found`
       )

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -474,8 +474,8 @@ export class Tabs extends Component {
 /**
  * Initialise tabs component
  *
- * @param {object} [options]
- * @param {Element | Document | null} [options.scope] - Scope of the document to search within
+ * @deprecated Use {@link createAll | `createAll(Tabs)`} instead.
+ * @param {InitOptions} [options]
  */
 export function initTabs(options = {}) {
   const $scope = options.scope ?? document
@@ -485,3 +485,7 @@ export function initTabs(options = {}) {
     new Tabs($root)
   })
 }
+
+/**
+ * @import { createAll, InitOptions } from '../../index.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -1,3 +1,4 @@
+import { normaliseOptions } from '../../common/configuration/index.mjs'
 import { getBreakpoint } from '../../common/index.mjs'
 import { Component } from '../../component.mjs'
 import { ElementError } from '../../errors/index.mjs'
@@ -477,11 +478,12 @@ export class Tabs extends Component {
  * @deprecated Use {@link createAll | `createAll(Tabs)`} instead.
  * @param {InitOptions} [options]
  */
-export function initTabs(options = {}) {
-  const $scope = options.scope ?? document
-  const $tabs = $scope.querySelectorAll(`[data-module="${Tabs.moduleName}"]`)
+export function initTabs(options) {
+  const { scope: $scope } = normaliseOptions(options)
 
-  $tabs.forEach(($root) => {
+  const $tabs = $scope?.querySelectorAll(`[data-module="${Tabs.moduleName}"]`)
+
+  $tabs?.forEach(($root) => {
     new Tabs($root)
   })
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -15,7 +15,7 @@ export class Tabs extends Component {
   mql = null
 
   /**
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    */
   constructor($root) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -1,0 +1,155 @@
+import { ConfigurableComponent } from './configurable-component.mjs'
+import { ConfigError } from './errors/index.mjs'
+
+describe('ConfigurableComponent', () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = ''
+    document.body.classList.add('nhsuk-frontend-supported')
+  })
+
+  describe('throws error', () => {
+    it('if no schema defined', () => {
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      expect(() => new MockConfigurableComponent(document.body)).toThrow(
+        new ConfigError(
+          'config-component: Config passed as parameter into constructor but no schema defined'
+        )
+      )
+    })
+
+    it('if no defaults defined', () => {
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+      }
+
+      expect(() => new MockConfigurableComponent(document.body)).toThrow(
+        new ConfigError(
+          'config-component: Config passed as parameter into constructor but no defaults defined'
+        )
+      )
+    })
+  })
+
+  describe('set configuration on initialisation to', () => {
+    it('defaults if no configuration provided', () => {
+      document.body.innerHTML = `
+        <div id="test-component"></div>
+      `
+
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      const testComponent = document.querySelector('#test-component')
+
+      const configComponent = new MockConfigurableComponent(testComponent)
+
+      expect(configComponent.config).toMatchObject({ randomAttribute: 0 })
+    })
+
+    it('dataset of root', () => {
+      document.body.innerHTML = `
+        <div id="test-component" data-random-attribute="42"></div>
+      `
+
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      const testComponent = document.querySelector('#test-component')
+
+      const configComponent = new MockConfigurableComponent(testComponent)
+
+      expect(configComponent.config).toMatchObject({ randomAttribute: 42 })
+    })
+
+    it('configuration object from class initialisation', () => {
+      document.body.innerHTML = `
+        <div id="test-component"></div>
+      `
+
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      const testComponent = document.querySelector('#test-component')
+
+      const configComponent = new MockConfigurableComponent(testComponent, {
+        randomAttribute: 100
+      })
+
+      expect(configComponent.config).toMatchObject({ randomAttribute: 100 })
+    })
+
+    it('dataset configuration over the configuration object from class initialisation', () => {
+      document.body.innerHTML = `
+        <div id="test-component" data-random-attribute="12"></div>
+      `
+
+      class MockConfigurableComponent extends ConfigurableComponent {
+        static moduleName = 'config-component'
+
+        static schema = {
+          properties: {
+            randomAttribute: { type: 'number' }
+          }
+        }
+
+        static defaults = {
+          randomAttribute: 0
+        }
+      }
+
+      const testComponent = document.querySelector('#test-component')
+
+      const configComponent = new MockConfigurableComponent(testComponent, {
+        randomAttribute: 100
+      })
+
+      expect(configComponent.config).toMatchObject({ randomAttribute: 12 })
+    })
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -1,0 +1,99 @@
+import {
+  mergeConfigs,
+  normaliseDataset
+} from './common/configuration/index.mjs'
+import { formatErrorMessage, isObject } from './common/index.mjs'
+import { Component } from './component.mjs'
+import { ConfigError } from './errors/index.mjs'
+
+/**
+ * Configurable base component class
+ *
+ * @abstract
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
+ * @template {HTMLElement} [RootElementType=HTMLElement]
+ * @augments Component<RootElementType>
+ */
+export class ConfigurableComponent extends Component {
+  /**
+   * @type {ConfigurationType}
+   */
+  config
+
+  /**
+   * Constructs a new component, validating that NHS.UK frontend is supported
+   *
+   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {ConfigurationType} [config] - HTML element to use for component
+   */
+  constructor($root, config) {
+    super($root)
+
+    const ComponentClass =
+      /** @type {ComponentConstructor<typeof ConfigurableComponent>} */ (
+        this.constructor
+      )
+
+    if (!isObject(ComponentClass.defaults)) {
+      throw new ConfigError(
+        formatErrorMessage(
+          ComponentClass,
+          'Config passed as parameter into constructor but no defaults defined'
+        )
+      )
+    }
+
+    const datasetConfig = /** @type {ConfigurationType} */ (
+      normaliseDataset(ComponentClass, this.$root.dataset)
+    )
+
+    // Override defaults with JavaScript config
+    this.config = /** @type {ConfigurationType} */ (
+      mergeConfigs(ComponentClass.defaults, config ?? {})
+    )
+
+    // Override merged config with dataset config
+    this.config = /** @type {ConfigurationType} */ (
+      mergeConfigs(
+        this.config,
+        this.configOverride(datasetConfig),
+        datasetConfig
+      )
+    )
+  }
+
+  /**
+   * Config override
+   *
+   * It should take a subset of configuration as input and return
+   * a new configuration object with properties that should be
+   * overridden based on the root element's dataset
+   *
+   * @abstract
+   * @param {Partial<ConfigurationType>} _datasetConfig - Config specified by dataset
+   * @returns {Partial<ConfigurationType>} Config to override by dataset
+   */
+  configOverride(_datasetConfig = {}) {
+    return {}
+  }
+}
+
+/**
+ * Schema for component config
+ *
+ * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
+ * @typedef {object} Schema
+ * @property {Record<keyof ConfigurationType, SchemaProperty | undefined>} properties - Schema properties
+ */
+
+/**
+ * Schema property for component config
+ *
+ * @typedef {object} SchemaProperty
+ * @property {'string' | 'boolean' | 'number' | 'object'} type - Property type
+ */
+
+/**
+ * @import { ObjectNested } from './common/configuration/index.mjs'
+ * @import { ComponentConstructor } from './component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -23,7 +23,7 @@ export class ConfigurableComponent extends Component {
   /**
    * Constructs a new component, validating that NHS.UK frontend is supported
    *
-   * @param {Element | null} [$root] - HTML element to use for component
+   * @param {Element | null} $root - HTML element to use for component
    * @param {ConfigurationType} [config] - HTML element to use for component
    */
   constructor($root, config) {

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -29,27 +29,27 @@ export class ConfigurableComponent extends Component {
   constructor($root, config) {
     super($root)
 
-    const ComponentClass =
+    const childConstructor =
       /** @type {ComponentConstructor<typeof ConfigurableComponent>} */ (
         this.constructor
       )
 
-    if (!isObject(ComponentClass.defaults)) {
+    if (!isObject(childConstructor.defaults)) {
       throw new ConfigError(
         formatErrorMessage(
-          ComponentClass,
+          childConstructor,
           'Config passed as parameter into constructor but no defaults defined'
         )
       )
     }
 
     const datasetConfig = /** @type {ConfigurationType} */ (
-      normaliseDataset(ComponentClass, this.$root.dataset)
+      normaliseDataset(childConstructor, this.$root.dataset)
     )
 
     // Override defaults with JavaScript config
     this.config = /** @type {ConfigurationType} */ (
-      mergeConfigs(ComponentClass.defaults, config ?? {})
+      mergeConfigs(childConstructor.defaults, config ?? {})
     )
 
     // Override merged config with dataset config

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -79,21 +79,6 @@ export class ConfigurableComponent extends Component {
 }
 
 /**
- * Schema for component config
- *
- * @template {Partial<Record<keyof ConfigurationType, unknown>>} ConfigurationType
- * @typedef {object} Schema
- * @property {Record<keyof ConfigurationType, SchemaProperty | undefined>} properties - Schema properties
- */
-
-/**
- * Schema property for component config
- *
- * @typedef {object} SchemaProperty
- * @property {'string' | 'boolean' | 'number' | 'object'} type - Property type
- */
-
-/**
  * @import { ObjectNested } from './common/configuration/index.mjs'
  * @import { ComponentConstructor } from './component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.jsdom.test.mjs
@@ -78,7 +78,7 @@ describe('Errors', () => {
     it('is an instance of NHSUKFrontendError', () => {
       const error = new ElementError({
         component: SkipLink,
-        identifier: 'variableName'
+        identifier: 'Element name'
       })
 
       expect(error).toBeInstanceOf(NHSUKFrontendError)
@@ -87,38 +87,65 @@ describe('Errors', () => {
     it('has its own name set', () => {
       const error = new ElementError({
         component: SkipLink,
-        identifier: 'variableName'
+        identifier: 'Element name'
       })
 
       expect(error).toHaveProperty('name', 'ElementError')
     })
 
-    it('formats the message when the element is not found', () => {
-      const error = new ElementError({
-        component: SkipLink,
-        identifier: 'variableName'
+    describe('with component', () => {
+      it('formats the message when the element is not found', () => {
+        const error = new ElementError({
+          component: SkipLink,
+          identifier: 'Element name'
+        })
+
+        expect(error).toHaveProperty(
+          'message',
+          `${SkipLink.moduleName}: Element name not found`
+        )
       })
 
-      expect(error).toHaveProperty(
-        'message',
-        `${SkipLink.moduleName}: variableName not found`
-      )
+      it('formats the message when the element is not the right type', () => {
+        const $element = document.createElement('div')
+
+        const error = new ElementError({
+          element: $element,
+          component: SkipLink,
+          identifier: 'Element name',
+          expectedType: 'HTMLAnchorElement'
+        })
+
+        expect(error).toHaveProperty(
+          'message',
+          `${SkipLink.moduleName}: Element name is not of type HTMLAnchorElement`
+        )
+      })
     })
 
-    it('formats the message when the element is not the right type', () => {
-      const $element = document.createElement('div')
+    describe('without component', () => {
+      it('formats the message when the element is not found', () => {
+        const error = new ElementError({
+          identifier: 'Element name'
+        })
 
-      const error = new ElementError({
-        element: $element,
-        component: SkipLink,
-        identifier: 'variableName',
-        expectedType: 'HTMLAnchorElement'
+        expect(error).toHaveProperty('message', 'Element name not found')
       })
 
-      expect(error).toHaveProperty(
-        'message',
-        `${SkipLink.moduleName}: variableName is not of type HTMLAnchorElement`
-      )
+      it('formats the message when the element is not the right type', () => {
+        const $element = document.createElement('div')
+
+        const error = new ElementError({
+          element: $element,
+          identifier: 'Element name',
+          expectedType: 'HTMLAnchorElement'
+        })
+
+        expect(error).toHaveProperty(
+          'message',
+          'Element name is not of type HTMLAnchorElement'
+        )
+      })
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
@@ -75,7 +75,12 @@ export class ElementError extends NHSUKFrontendError {
       ? ` is not of type ${expectedType ?? 'HTMLElement'}`
       : ' not found'
 
-    super(formatErrorMessage(component, message))
+    // Prepend with module name (optional)
+    if (component) {
+      message = formatErrorMessage(component, message)
+    }
+
+    super(message)
   }
 }
 
@@ -105,8 +110,8 @@ export class InitError extends NHSUKFrontendError {
  * Element error options
  *
  * @typedef {object} ElementErrorOptions
- * @property {Element | null} [element] - The element in error
- * @property {CompatibleClass} component - Component throwing the error
+ * @property {Element | Document | null} [element] - The element in error (optional)
+ * @property {CompatibleClass} [component] - Component throwing the error (optional)
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
  * @property {string} [expectedType] - The type that was expected for the identifier
  */

--- a/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/errors/index.mjs
@@ -50,6 +50,13 @@ export class SupportError extends NHSUKFrontendError {
 }
 
 /**
+ * Indicates that a component has received an illegal configuration
+ */
+export class ConfigError extends NHSUKFrontendError {
+  name = 'ConfigError'
+}
+
+/**
  * Indicates an issue with an element (possibly `null` or `undefined`)
  */
 export class ElementError extends NHSUKFrontendError {
@@ -79,7 +86,7 @@ export class InitError extends NHSUKFrontendError {
   name = 'InitError'
 
   /**
-   * @param {ComponentConstructor | string} componentOrMessage - Component or init error message
+   * @param {CompatibleClass | string} componentOrMessage - Component or init error message
    */
   constructor(componentOrMessage) {
     const message =
@@ -99,11 +106,11 @@ export class InitError extends NHSUKFrontendError {
  *
  * @typedef {object} ElementErrorOptions
  * @property {Element | null} [element] - The element in error
- * @property {ComponentConstructor} component - Component throwing the error
+ * @property {CompatibleClass} component - Component throwing the error
  * @property {string} identifier - An identifier that'll let the user understand which element has an error. This is whatever makes the most sense
  * @property {string} [expectedType] - The type that was expected for the identifier
  */
 
 /**
- * @import { ComponentConstructor } from '../component.mjs'
+ * @import { CompatibleClass } from '../component.mjs'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
@@ -246,10 +246,11 @@ describe('NHS.UK frontend', () => {
           }
         })
 
-        expect(NamespaceComponent).toHaveBeenCalledWith($root2, {
+        expect(NamespaceComponent).not.toHaveBeenCalledWith($root1, {
           __test: true
         })
-        expect(NamespaceComponent).not.toHaveBeenCalledWith($root1, {
+
+        expect(NamespaceComponent).toHaveBeenCalledWith($root2, {
           __test: true
         })
       })

--- a/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
@@ -256,6 +256,52 @@ describe('NHS.UK frontend', () => {
       })
     })
 
+    it('should skip initialisation with null scope parameter (and log errors)', () => {
+      const $scope = document.querySelector('.unknown-scope')
+
+      initAll($scope)
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'NHS.UK frontend scope element (`$scope`) not found'
+        })
+      )
+
+      expect(Button).not.toHaveBeenCalled()
+      expect(CharacterCount).not.toHaveBeenCalled()
+      expect(Checkboxes).not.toHaveBeenCalled()
+      expect(ErrorSummary).not.toHaveBeenCalled()
+      expect(Header).not.toHaveBeenCalled()
+      expect(NotificationBanner).not.toHaveBeenCalled()
+      expect(Radios).not.toHaveBeenCalled()
+      expect(SkipLink).not.toHaveBeenCalled()
+      expect(Tabs).not.toHaveBeenCalled()
+    })
+
+    it('should skip initialisation with null scope option (and log errors)', () => {
+      const $scope = document.querySelector('.unknown-scope')
+
+      initAll({ scope: $scope })
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'NHS.UK frontend scope element (`$scope`) not found'
+        })
+      )
+
+      expect(Button).not.toHaveBeenCalled()
+      expect(CharacterCount).not.toHaveBeenCalled()
+      expect(Checkboxes).not.toHaveBeenCalled()
+      expect(ErrorSummary).not.toHaveBeenCalled()
+      expect(Header).not.toHaveBeenCalled()
+      expect(NotificationBanner).not.toHaveBeenCalled()
+      expect(Radios).not.toHaveBeenCalled()
+      expect(SkipLink).not.toHaveBeenCalled()
+      expect(Tabs).not.toHaveBeenCalled()
+    })
+
     it('should ignore unsupported browsers (and log errors)', () => {
       document.body.classList.remove('nhsuk-frontend-supported')
 
@@ -385,6 +431,38 @@ describe('NHS.UK frontend', () => {
       const result = createAll(MockComponent)
 
       expect(result).toStrictEqual([])
+    })
+
+    it('should return empty array with null scope parameter (and log errors)', () => {
+      const $scope = document.querySelector('.unknown-scope')
+
+      const result = createAll(MockComponent, undefined, $scope)
+
+      expect(result).toStrictEqual([])
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `${MockComponent.moduleName}: Scope element (\`$scope\`) not found`
+        })
+      )
+    })
+
+    it('should return empty array with null scope option (and log errors)', () => {
+      const $scope = document.querySelector('.unknown-scope')
+
+      const result = createAll(MockComponent, undefined, {
+        scope: $scope
+      })
+
+      expect(result).toStrictEqual([])
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `${MockComponent.moduleName}: Scope element (\`$scope\`) not found`
+        })
+      )
     })
 
     it('should return empty array with unsupported browsers (and log errors)', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
@@ -98,7 +98,7 @@ describe('NHS.UK frontend', () => {
 
   describe('initAll', () => {
     beforeEach(() => {
-      jest.spyOn(console, 'log').mockImplementation(() => {})
+      jest.spyOn(console, 'log').mockImplementation()
 
       document.body.innerHTML = outdent`
         <div data-module="${Button.moduleName}"></div>

--- a/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
@@ -1,14 +1,20 @@
+import camelCase from 'lodash/camelCase.js'
+import { outdent } from 'outdent'
+
 import {
+  Button,
+  CharacterCount,
+  Checkboxes,
+  ErrorSummary,
+  Header,
+  NotificationBanner,
+  Radios,
+  SkipLink,
+  Tabs,
   initAll,
-  initButtons,
-  initCharacterCounts,
-  initCheckboxes,
-  initErrorSummary,
-  initHeader,
-  initNotificationBanners,
-  initRadios,
-  initSkipLinks,
-  initTabs
+  createAll,
+  Component,
+  ConfigurableComponent
 } from './index.mjs'
 import * as NHSUKFrontend from './index.mjs'
 
@@ -23,16 +29,61 @@ jest.mock('./components/skip-link/skip-link.mjs')
 jest.mock('./components/tabs/tabs.mjs')
 
 describe('NHS.UK frontend', () => {
-  beforeAll(() => {
-    jest.spyOn(console, 'log').mockImplementation(() => {})
-  })
+  const components = [
+    'Checkboxes',
+    'Header',
+    'Radios',
+    'SkipLink',
+    'Tabs',
+    'Button',
+    'CharacterCount',
+    'ErrorSummary',
+    'NotificationBanner'
+  ]
+
+  const componentsWithoutConfig = components.filter(
+    (name) => !('defaults' in NHSUKFrontend[name])
+  )
+
+  const componentsWithConfig = components.filter(
+    (name) => 'defaults' in NHSUKFrontend[name]
+  )
 
   describe('Exports', () => {
-    it('should export init all function', () => {
+    it("should export 'initAll' function", () => {
       expect(NHSUKFrontend).toHaveProperty('initAll')
     })
 
-    it('should export init component functions', () => {
+    it("should export 'createAll' function", () => {
+      expect(NHSUKFrontend).toHaveProperty('createAll')
+    })
+
+    it('should export error classes', () => {
+      expect(NHSUKFrontend).toHaveProperty('NHSUKFrontendError')
+      expect(NHSUKFrontend).toHaveProperty('SupportError')
+      expect(NHSUKFrontend).toHaveProperty('ConfigError')
+      expect(NHSUKFrontend).toHaveProperty('ElementError')
+      expect(NHSUKFrontend).toHaveProperty('InitError')
+    })
+
+    it('should export component classes', () => {
+      expect(NHSUKFrontend).toHaveProperty('Button')
+      expect(NHSUKFrontend).toHaveProperty('CharacterCount')
+      expect(NHSUKFrontend).toHaveProperty('Checkboxes')
+      expect(NHSUKFrontend).toHaveProperty('ErrorSummary')
+      expect(NHSUKFrontend).toHaveProperty('Header')
+      expect(NHSUKFrontend).toHaveProperty('NotificationBanner')
+      expect(NHSUKFrontend).toHaveProperty('Radios')
+      expect(NHSUKFrontend).toHaveProperty('SkipLink')
+      expect(NHSUKFrontend).toHaveProperty('Tabs')
+    })
+
+    it('should export component base classes', () => {
+      expect(NHSUKFrontend).toHaveProperty('Component')
+      expect(NHSUKFrontend).toHaveProperty('ConfigurableComponent')
+    })
+
+    it('should export component init functions', () => {
       expect(NHSUKFrontend).toHaveProperty('initButtons')
       expect(NHSUKFrontend).toHaveProperty('initCharacterCounts')
       expect(NHSUKFrontend).toHaveProperty('initCheckboxes')
@@ -46,56 +97,436 @@ describe('NHS.UK frontend', () => {
   })
 
   describe('initAll', () => {
-    it('should ignore unsupported browsers', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'log').mockImplementation(() => {})
+
+      document.body.innerHTML = outdent`
+        <div data-module="${Button.moduleName}"></div>
+        <div data-module="${CharacterCount.moduleName}"></div>
+        <div data-module="${Checkboxes.moduleName}"></div>
+        <div data-module="${ErrorSummary.moduleName}"></div>
+        <div data-module="${Header.moduleName}"></div>
+        <div data-module="${NotificationBanner.moduleName}"></div>
+        <div data-module="${Radios.moduleName}"></div>
+        <div data-module="${SkipLink.moduleName}"></div>
+        <div data-module="${Tabs.moduleName}"></div>
+      `
+    })
+
+    describe('Non-configurable components', () => {
+      it.each(componentsWithoutConfig)("should init '%s'", (name) => {
+        const NamespaceComponent = /** @type {CompatibleClass} */ (
+          NHSUKFrontend[name]
+        )
+
+        document.body.innerHTML = outdent`
+          <div data-module="${NamespaceComponent.moduleName}"></div>
+        `
+
+        const $root = document.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        initAll()
+
+        expect(NamespaceComponent).toHaveBeenCalledWith(
+          ...('defaults' in NamespaceComponent ? [$root, undefined] : [$root])
+        )
+      })
+    })
+
+    describe('Non-configurable components (with scope)', () => {
+      it.each(componentsWithoutConfig)("should init scoped '%s'", (name) => {
+        const NamespaceComponent = /** @type {CompatibleClass} */ (
+          NHSUKFrontend[name]
+        )
+
+        document.body.innerHTML = outdent`
+          <div class="app-scope-1">
+            <!-- No components -->
+          </div>
+          <div class="app-scope-2">
+            <div data-module="${NamespaceComponent.moduleName}"></div>
+          </div>
+        `
+
+        const $scope1 = document.querySelector('.app-scope-1')
+        const $scope2 = document.querySelector('.app-scope-2')
+
+        const $root1 = $scope1.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        const $root2 = $scope2.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        initAll($scope1)
+        expect(NamespaceComponent).not.toHaveBeenCalled()
+
+        initAll($scope2)
+        expect(NamespaceComponent).toHaveBeenCalledWith($root2)
+        expect(NamespaceComponent).not.toHaveBeenCalledWith($root1)
+      })
+    })
+
+    describe('Configurable components', () => {
+      it.each(componentsWithConfig)("should init '%s'", (name) => {
+        const NamespaceComponent = /** @type {CompatibleClass} */ (
+          NHSUKFrontend[name]
+        )
+
+        document.body.innerHTML = outdent`
+          <div data-module="${NamespaceComponent.moduleName}"></div>
+        `
+
+        const $root = document.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        // Determine `nhsuk-character-count` → `characterCount` config key
+        const configName = camelCase(
+          NamespaceComponent.moduleName.replace(/^nhsuk-/, '')
+        )
+
+        initAll({
+          [configName]: {
+            __test: true
+          }
+        })
+
+        expect(NamespaceComponent).toHaveBeenCalledWith($root, { __test: true })
+      })
+    })
+
+    describe('Configurable components (with scope)', () => {
+      it.each(componentsWithConfig)("should init scoped '%s'", (name) => {
+        const NamespaceComponent = /** @type {CompatibleClass} */ (
+          NHSUKFrontend[name]
+        )
+
+        document.body.innerHTML = outdent`
+          <div class="app-scope-1">
+            <!-- No components -->
+          </div>
+          <div class="app-scope-2">
+            <div data-module="${NamespaceComponent.moduleName}"></div>
+          </div>
+        `
+
+        const $scope1 = document.querySelector('.app-scope-1')
+        const $scope2 = document.querySelector('.app-scope-2')
+
+        const $root1 = $scope1.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        const $root2 = $scope2.querySelector(
+          `[data-module="${NamespaceComponent.moduleName}"]`
+        )
+
+        // Determine `nhsuk-character-count` → `characterCount` config key
+        const configName = camelCase(
+          NamespaceComponent.moduleName.replace(/^nhsuk-/, '')
+        )
+
+        initAll({
+          scope: $scope1,
+          [configName]: {
+            __test: true
+          }
+        })
+
+        expect(NamespaceComponent).not.toHaveBeenCalled()
+
+        initAll({
+          scope: $scope2,
+          [configName]: {
+            __test: true
+          }
+        })
+
+        expect(NamespaceComponent).toHaveBeenCalledWith($root2, {
+          __test: true
+        })
+        expect(NamespaceComponent).not.toHaveBeenCalledWith($root1, {
+          __test: true
+        })
+      })
+    })
+
+    it('should ignore unsupported browsers (and log errors)', () => {
       document.body.classList.remove('nhsuk-frontend-supported')
 
       initAll()
 
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
       expect(console.log).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'NHS.UK frontend is not supported in this browser'
         })
       )
 
-      expect(initButtons).not.toHaveBeenCalled()
-      expect(initCharacterCounts).not.toHaveBeenCalled()
-      expect(initCheckboxes).not.toHaveBeenCalled()
-      expect(initErrorSummary).not.toHaveBeenCalled()
-      expect(initHeader).not.toHaveBeenCalled()
-      expect(initNotificationBanners).not.toHaveBeenCalled()
-      expect(initRadios).not.toHaveBeenCalled()
-      expect(initSkipLinks).not.toHaveBeenCalled()
-      expect(initTabs).not.toHaveBeenCalled()
+      expect(Button).not.toHaveBeenCalled()
+      expect(CharacterCount).not.toHaveBeenCalled()
+      expect(Checkboxes).not.toHaveBeenCalled()
+      expect(ErrorSummary).not.toHaveBeenCalled()
+      expect(Header).not.toHaveBeenCalled()
+      expect(NotificationBanner).not.toHaveBeenCalled()
+      expect(Radios).not.toHaveBeenCalled()
+      expect(SkipLink).not.toHaveBeenCalled()
+      expect(Tabs).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createAll', () => {
+    beforeEach(() => {
+      document.body.innerHTML = ''
     })
 
-    it('should init components', () => {
-      initAll()
+    class MockComponent extends Component {
+      constructor($root) {
+        super($root)
+        this.args = [$root]
+      }
+    }
 
-      expect(initButtons).toHaveBeenCalled()
-      expect(initCharacterCounts).toHaveBeenCalled()
-      expect(initCheckboxes).toHaveBeenCalled()
-      expect(initErrorSummary).toHaveBeenCalled()
-      expect(initHeader).toHaveBeenCalled()
-      expect(initNotificationBanners).toHaveBeenCalled()
-      expect(initRadios).toHaveBeenCalled()
-      expect(initSkipLinks).toHaveBeenCalled()
-      expect(initTabs).toHaveBeenCalled()
+    class MockComponentThatErrors extends MockComponent {
+      constructor($root) {
+        super($root)
+
+        if ('boom' in $root.dataset) {
+          throw new Error('Error thrown from constructor')
+        }
+      }
+    }
+
+    /**
+     * @augments ConfigurableComponent<MockConfig>
+     */
+    class MockConfigurableComponent extends ConfigurableComponent {
+      constructor($root, config) {
+        super($root, config)
+        this.args = [$root, config]
+      }
+
+      /**
+       * @satisfies {Schema<MockConfig>}
+       */
+      static schema = {
+        properties: {
+          __test: { type: 'boolean' }
+        }
+      }
+
+      /**
+       * @satisfies {MockConfig}
+       */
+      static defaults = {
+        __test: false
+      }
+    }
+
+    it('should return initialised components', () => {
+      document.body.innerHTML = outdent`
+        <div data-module="${MockComponent.moduleName}" id="a"></div>
+        <div data-module="${MockComponent.moduleName}" id="b"></div>
+      `
+
+      const $root1 = document.getElementById('a')
+      const $root2 = document.getElementById('b')
+
+      const result = createAll(MockComponent)
+
+      expect(result).toStrictEqual([
+        expect.any(MockComponent),
+        expect.any(MockComponent)
+      ])
+
+      expect(result[0]).toHaveProperty('args', [$root1])
+      expect(result[1]).toHaveProperty('args', [$root2])
     })
 
-    it('should init components (with scope)', () => {
-      const scope = document
+    it('should return initialised components (with failed components omitted)', () => {
+      document.body.innerHTML = outdent`
+        <div data-module="${MockComponentThatErrors.moduleName}" id="a"></div>
+        <div data-module="${MockComponentThatErrors.moduleName}" id="b" data-boom></div>
+        <div data-module="${MockComponentThatErrors.moduleName}" id="c"></div>
+      `
 
-      initAll(scope)
+      const $root1 = document.getElementById('a')
+      const $root2 = document.getElementById('b')
+      const $root3 = document.getElementById('c')
 
-      expect(initButtons).toHaveBeenCalledWith({ scope })
-      expect(initCharacterCounts).toHaveBeenCalledWith({ scope })
-      expect(initCheckboxes).toHaveBeenCalledWith({ scope })
-      expect(initErrorSummary).toHaveBeenCalledWith({ scope })
-      expect(initHeader).toHaveBeenCalledWith({ scope })
-      expect(initNotificationBanners).toHaveBeenCalledWith({ scope })
-      expect(initRadios).toHaveBeenCalledWith({ scope })
-      expect(initSkipLinks).toHaveBeenCalledWith({ scope })
-      expect(initTabs).toHaveBeenCalledWith({ scope })
+      const result = createAll(MockComponentThatErrors)
+
+      expect(result).toStrictEqual([
+        expect.any(MockComponentThatErrors),
+        expect.any(MockComponentThatErrors)
+      ])
+
+      expect(result[0]).toHaveProperty('args', [$root1])
+      expect(result[1]).not.toHaveProperty('args', [$root2])
+      expect(result[1]).toHaveProperty('args', [$root3])
+    })
+
+    it('should return empty array without components', () => {
+      const result = createAll(MockComponent)
+
+      expect(result).toStrictEqual([])
+    })
+
+    it('should return empty array without matching components', () => {
+      document.body.innerHTML = outdent`
+        <div data-module="this-is-not-the-component-you-are-looking-for"></div>
+      `
+
+      const result = createAll(MockComponent)
+
+      expect(result).toStrictEqual([])
+    })
+
+    it('should return empty array with unsupported browsers (and log errors)', () => {
+      document.body.classList.remove('nhsuk-frontend-supported')
+
+      const result = createAll(MockComponent)
+
+      expect(result).toStrictEqual([])
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'NHS.UK frontend is not supported in this browser'
+        })
+      )
+    })
+
+    it('should return empty array with failed component (and log errors)', () => {
+      document.body.innerHTML = outdent`
+        <div data-module="${MockComponentThatErrors.moduleName}" data-boom></div>
+      `
+
+      const result = createAll(MockComponentThatErrors)
+
+      expect(result).toStrictEqual([])
+
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error))
+      expect(console.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Error thrown from constructor'
+        })
+      )
+    })
+
+    describe('Non-configurable components', () => {
+      it('initialises component', () => {
+        document.body.innerHTML = outdent`
+          <div data-module="${MockComponent.moduleName}"></div>
+        `
+
+        const $root = document.querySelector(
+          `[data-module="${MockComponent.moduleName}"]`
+        )
+
+        const result = createAll(MockComponent)
+
+        expect(result).toStrictEqual([expect.any(MockComponent)])
+        expect(result[0]).toHaveProperty('args', [$root])
+      })
+    })
+
+    describe('Non-configurable components (with scope)', () => {
+      it('initialises scoped component', () => {
+        document.body.innerHTML = outdent`
+          <div class="app-scope-1">
+            <!-- No components -->
+          </div>
+          <div class="app-scope-2">
+            <div data-module="${MockComponent.moduleName}"></div>
+          </div>
+        `
+
+        const $scope1 = document.querySelector('.app-scope-1')
+        const $scope2 = document.querySelector('.app-scope-2')
+
+        const $root2 = $scope2.querySelector(
+          `[data-module="${MockComponent.moduleName}"]`
+        )
+
+        const result1 = createAll(MockComponent, undefined, $scope1)
+        expect(result1).toStrictEqual([])
+
+        const result2 = createAll(MockComponent, undefined, $scope2)
+
+        expect(result2).toStrictEqual([expect.any(MockComponent)])
+        expect(result2[0]).toHaveProperty('args', [$root2])
+      })
+    })
+
+    describe('Configurable components', () => {
+      it('initialises component', () => {
+        document.body.innerHTML = outdent`
+          <div data-module="${MockConfigurableComponent.moduleName}"></div>
+        `
+
+        const $root = document.querySelector(
+          `[data-module="${MockConfigurableComponent.moduleName}"]`
+        )
+
+        const result = createAll(MockConfigurableComponent, {
+          __test: true
+        })
+
+        expect(result).toStrictEqual([expect.any(MockConfigurableComponent)])
+        expect(result[0]).toHaveProperty('args', [$root, { __test: true }])
+      })
+    })
+
+    describe('Configurable components (with scope)', () => {
+      it('initialises scoped component', () => {
+        document.body.innerHTML = outdent`
+          <div class="app-scope-1">
+            <!-- No components -->
+          </div>
+          <div class="app-scope-2">
+            <div data-module="${MockConfigurableComponent.moduleName}"></div>
+          </div>
+        `
+
+        const $scope1 = document.querySelector('.app-scope-1')
+        const $scope2 = document.querySelector('.app-scope-2')
+
+        const $root2 = $scope2.querySelector(
+          `[data-module="${MockConfigurableComponent.moduleName}"]`
+        )
+
+        const result1 = createAll(
+          MockConfigurableComponent,
+          { __test: true },
+          $scope1
+        )
+
+        expect(result1).toStrictEqual([])
+
+        const result2 = createAll(
+          MockConfigurableComponent,
+          { __test: true },
+          $scope2
+        )
+
+        expect(result2).toStrictEqual([expect.any(MockConfigurableComponent)])
+        expect(result2[0]).toHaveProperty('args', [$root2, { __test: true }])
+      })
     })
   })
 })
+
+/**
+ * @typedef {object} MockConfig
+ * @property {boolean} __test - Test flag
+ */
+
+/**
+ * @import { Schema } from './common/configuration/index.mjs'
+ * @import { CompatibleClass } from './component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.mjs
@@ -11,7 +11,7 @@ import {
   SkipLink,
   Tabs
 } from './components/index.mjs'
-import { SupportError } from './errors/index.mjs'
+import { ElementError, SupportError } from './errors/index.mjs'
 
 /**
  * Initialise all components
@@ -43,6 +43,15 @@ export function initAll(scopeOrConfig = {}) {
     // Skip initialisation when NHS.UK frontend is not supported
     if (!isSupported()) {
       throw new SupportError()
+    }
+
+    // Users can initialise NHS.UK frontend in certain sections of the page
+    // unless the scope is null (for example, query selector not found)
+    if (options.scope === null) {
+      throw new ElementError({
+        element: options.scope,
+        identifier: 'NHS.UK frontend scope element (`$scope`)'
+      })
     }
   } catch (error) {
     if (options.onError) {
@@ -124,6 +133,16 @@ export function createAll(Component, config, scopeOrOptions) {
     // Skip initialisation when NHS.UK frontend is not supported
     if (!isSupported()) {
       throw new SupportError()
+    }
+
+    // Users can initialise NHS.UK frontend in certain sections of the page
+    // unless the scope is null (for example, query selector not found)
+    if (options.scope === null) {
+      throw new ElementError({
+        element: options.scope,
+        component: Component,
+        identifier: 'Scope element (`$scope`)'
+      })
     }
 
     $elements = options.scope?.querySelectorAll(

--- a/packages/nhsuk-frontend/src/nhsuk/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.mjs
@@ -1,14 +1,14 @@
-import { isSupported } from './common/index.mjs'
+import { isObject, isScope, isSupported } from './common/index.mjs'
 import {
-  initRadios,
-  initHeader,
-  initButtons,
-  initCharacterCounts,
-  initCheckboxes,
-  initErrorSummary,
-  initNotificationBanners,
-  initSkipLinks,
-  initTabs
+  Button,
+  CharacterCount,
+  Checkboxes,
+  ErrorSummary,
+  Header,
+  NotificationBanner,
+  Radios,
+  SkipLink,
+  Tabs
 } from './components/index.mjs'
 import { SupportError } from './errors/index.mjs'
 
@@ -31,17 +31,175 @@ export function initAll($scope) {
     return
   }
 
-  initHeader(options)
-  initSkipLinks(options)
-  initButtons(options)
-  initCharacterCounts(options)
-  initCheckboxes(options)
-  initErrorSummary(options)
-  initNotificationBanners(options)
-  initRadios(options)
-  initTabs(options)
+  const components = /** @type {const} */ ([
+    [Button],
+    [CharacterCount],
+    [Checkboxes],
+    [ErrorSummary],
+    [Header],
+    [NotificationBanner],
+    [Radios],
+    [SkipLink],
+    [Tabs]
+  ])
+
+  components.forEach(([Component]) => {
+    createAll(Component, undefined, options)
+  })
+}
+
+/**
+ * Create all instances of a specific component on the page
+ *
+ * Uses the `data-module` attribute to find all elements matching the specified
+ * component on the page, creating instances of the component object for each
+ * of them.
+ *
+ * Any component errors will be caught and logged to the console.
+ *
+ * @template {CompatibleClass | CompatibleClass<typeof ConfigurableComponent>} ComponentClass
+ * @overload
+ * @param {ComponentClass} Component - Component class to initialise
+ * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
+ * @param {CreateAllOptions<ComponentClass>} [options] - Options including scope of the document to search within and callback function if error throw by component on init
+ * @returns {InstanceType<ComponentClass>[]} Array of initialised components
+ */
+
+/**
+ * @template {CompatibleClass | CompatibleClass<typeof ConfigurableComponent>} ComponentClass
+ * @overload
+ * @param {ComponentClass} Component - Component class to initialise
+ * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
+ * @param {OnErrorCallback<ComponentClass>} [onError] - Initialisation error callback
+ * @returns {InstanceType<ComponentClass>[]} Array of initialised components
+ */
+
+/**
+ * @template {CompatibleClass | CompatibleClass<typeof ConfigurableComponent>} ComponentClass
+ * @overload
+ * @param {ComponentClass} Component - Component class to initialise
+ * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
+ * @param {Element | null} [$scope] - Scope of the document to search within
+ * @returns {InstanceType<ComponentClass>[]} Array of initialised components
+ */
+
+/**
+ * @template {CompatibleClass | CompatibleClass<typeof ConfigurableComponent>} ComponentClass
+ * @param {ComponentClass} Component - Component class to initialise
+ * @param {ComponentConfig<ComponentClass>} [config] - Config supplied to component
+ * @param {CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document | null} [scopeOrOptions]
+ */
+export function createAll(Component, config, scopeOrOptions) {
+  let /** @type {Element | Document | null} */ $scope = document
+  let /** @type {OnErrorCallback<Component> | undefined} */ onError
+
+  // Handle options object
+  if (isObject(scopeOrOptions)) {
+    const options = scopeOrOptions
+
+    // Scope must be valid or null
+    if (isScope(options.scope) || options.scope === null) {
+      $scope = options.scope
+    }
+
+    // Error handler must be a function
+    if (typeof options.onError === 'function') {
+      onError = options.onError
+    }
+  }
+
+  if (isScope(scopeOrOptions)) {
+    $scope = scopeOrOptions
+  } else if (scopeOrOptions === null) {
+    $scope = null
+  } else if (typeof scopeOrOptions === 'function') {
+    onError = scopeOrOptions
+  }
+
+  const $elements =
+    $scope?.querySelectorAll(`[data-module="${Component.moduleName}"]`) ?? []
+
+  // Skip initialisation when NHS.UK frontend is not supported
+  if (!isSupported()) {
+    if (onError) {
+      onError(new SupportError(), {
+        component: Component,
+        config
+      })
+    } else {
+      console.log(new SupportError())
+    }
+    return []
+  }
+
+  return Array.from($elements)
+    .map(($element) => {
+      try {
+        return /** @type {InstanceType<ComponentClass>} */ (
+          // Only pass config to components that accept it
+          'defaults' in Component
+            ? new Component($element, config)
+            : new Component($element)
+        )
+      } catch (error) {
+        if (onError) {
+          onError(error, {
+            element: $element,
+            component: Component,
+            config
+          })
+        } else {
+          console.log(error)
+        }
+
+        return null
+      }
+    })
+    .filter((instance) => !!instance) // Exclude components that errored
 }
 
 export { isSupported, version } from './common/index.mjs'
 export * from './components/index.mjs'
 export * from './errors/index.mjs'
+
+/**
+ * Component config
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @typedef {ConstructorParameters<ComponentClass>[1]} ComponentConfig
+ */
+
+/**
+ * Initialisation error context
+ *
+ * Contains the element, component class and configuration
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @typedef {object} ErrorContext
+ * @property {Element} [element] - Element used for component module initialisation
+ * @property {ComponentClass} [component] - Class of component
+ * @property {ComponentConfig<ComponentClass>} config - Config supplied to components
+ */
+
+/**
+ * Initialisation error callback
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @callback OnErrorCallback
+ * @param {unknown} error - Thrown error
+ * @param {ErrorContext<ComponentClass>} context - Object containing the element, component class and configuration
+ */
+
+/**
+ * Initialisation options
+ *
+ * @template {CompatibleClass} ComponentClass
+ * @typedef {object} CreateAllOptions
+ * @property {Element | Document | null} [scope] - Scope of the document to search within
+ * @property {OnErrorCallback<ComponentClass>} [onError] - Initialisation error callback
+ */
+
+/**
+ * @import { CompatibleClass } from './component.mjs'
+ * @import { ConfigurableComponent } from './configurable-component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.mjs
@@ -39,15 +39,20 @@ export function initAll(scopeOrConfig = {}) {
   // Extract initialisation options
   const options = normaliseOptions(scopeOrConfig)
 
-  // Skip initialisation when NHS.UK frontend is not supported
-  if (!isSupported()) {
+  try {
+    // Skip initialisation when NHS.UK frontend is not supported
+    if (!isSupported()) {
+      throw new SupportError()
+    }
+  } catch (error) {
     if (options.onError) {
-      options.onError(new SupportError(), {
+      options.onError(error, {
         config
       })
     } else {
-      console.log(new SupportError())
+      console.log(error)
     }
+
     return
   }
 
@@ -110,27 +115,34 @@ export function initAll(scopeOrConfig = {}) {
  * @param {CreateAllOptions<ComponentClass> | OnErrorCallback<ComponentClass> | Element | Document | null} [scopeOrOptions]
  */
 export function createAll(Component, config, scopeOrOptions) {
+  let /** @type {NodeListOf<Element> | undefined} */ $elements
+
+  // Extract initialisation options
   const options = normaliseOptions(scopeOrOptions)
 
-  const $elements =
-    options.scope?.querySelectorAll(
-      `[data-module="${Component.moduleName}"]`
-    ) ?? []
+  try {
+    // Skip initialisation when NHS.UK frontend is not supported
+    if (!isSupported()) {
+      throw new SupportError()
+    }
 
-  // Skip initialisation when NHS.UK frontend is not supported
-  if (!isSupported()) {
+    $elements = options.scope?.querySelectorAll(
+      `[data-module="${Component.moduleName}"]`
+    )
+  } catch (error) {
     if (options.onError) {
-      options.onError(new SupportError(), {
+      options.onError(error, {
         component: Component,
         config
       })
     } else {
-      console.log(new SupportError())
+      console.log(error)
     }
+
     return []
   }
 
-  return Array.from($elements)
+  return Array.from($elements ?? [])
     .map(($element) => {
       try {
         return /** @type {InstanceType<ComponentClass>} */ (

--- a/packages/nhsuk-frontend/src/nhsuk/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.mjs
@@ -44,4 +44,4 @@ export function initAll($scope) {
 
 export { isSupported, version } from './common/index.mjs'
 export * from './components/index.mjs'
-export * from './component.mjs'
+export * from './errors/index.mjs'

--- a/packages/nhsuk-frontend/src/nhsuk/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.mjs
@@ -71,12 +71,12 @@ export function initAll(scopeOrConfig = {}) {
   }
 
   const components = /** @type {const} */ ([
-    [Button],
-    [CharacterCount],
+    [Button, config.button],
+    [CharacterCount, config.characterCount],
     [Checkboxes],
-    [ErrorSummary],
+    [ErrorSummary, config.errorSummary],
     [Header],
-    [NotificationBanner],
+    [NotificationBanner, config.notificationBanner],
     [Radios],
     [SkipLink],
     [Tabs]
@@ -89,8 +89,8 @@ export function initAll(scopeOrConfig = {}) {
     scope: config.scope ?? document
   }
 
-  components.forEach(([Component]) => {
-    createAll(Component, undefined, options)
+  components.forEach(([Component, componentConfig]) => {
+    createAll(Component, componentConfig, options)
   })
 }
 
@@ -183,7 +183,7 @@ export function createAll(Component, config, scopeOrOptions) {
       try {
         return /** @type {InstanceType<ComponentClass>} */ (
           // Only pass config to components that accept it
-          'defaults' in Component
+          !!config && 'defaults' in Component
             ? new Component($element, config)
             : new Component($element)
         )
@@ -214,6 +214,10 @@ export * from './errors/index.mjs'
  * @typedef {object} Config
  * @property {Element | Document | null} [scope] - Scope of the document to search within
  * @property {OnErrorCallback<CompatibleClass>} [onError] - Initialisation error callback
+ * @property {ComponentConfig<typeof Button>} [button] - Button config
+ * @property {ComponentConfig<typeof CharacterCount>} [characterCount] - Character count config
+ * @property {ComponentConfig<typeof ErrorSummary>} [errorSummary] - Error Summary config
+ * @property {ComponentConfig<typeof NotificationBanner>} [notificationBanner] - Notification Banner config
  */
 
 /**

--- a/packages/nhsuk-frontend/tasks/scripts.mjs
+++ b/packages/nhsuk-frontend/tasks/scripts.mjs
@@ -22,8 +22,8 @@ export const compile = gulp.series(
       // Build entry scripts last to restore modules
       // removed from components due to tree-shaking
       'nhsuk/common/index.mjs',
-      'nhsuk/index.mjs',
-      'nhsuk/nhsuk.mjs'
+      'nhsuk/nhsuk.mjs',
+      'nhsuk/index.mjs'
     ]) {
       await Promise.all([
         /**


### PR DESCRIPTION
## Description

This PR ensures all configurable components support both Nunjucks and JavaScript configurations

* **Button component**
  Supports option `preventDoubleClick`

* **Error summary component**
  Supports options `disableAutoFocus` to replace (deprecated) `focusOnPageLoad`

* **Notification banner component**
  Supports option `disableAutoFocus`

**Note:** Character count needs [`%{count} characters` placeholders](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#localise-gov-uk-frontend) so is not yet supported

---

A new base class `ConfigurableComponent` and utilties have been ported from GOV.UK Frontend

* [**Passing configuration using data attributes in HTML**](https://frontend.design-system.service.gov.uk/v4/configure-components-with-javascript/#setting-nunjucks-macro-options)
* [**Passing configuration to a new instance of a component in JavaScript**](https://frontend.design-system.service.gov.uk/v4/configure-components-with-javascript/#passing-configuration-using-data-attributes-in-html)

Which provides support for the following:

### Component configuration via `initAll()`

```js
import { initAll } from 'nhsuk-frontend'

initAll({
  button: {
    preventDoubleClick: true
  }
})
```

### Component configuration via `createAll()`

```js
import { createAll, Button } from 'nhsuk-frontend'

// Initialise all button components
createAll(Button, {
  preventDoubleClick: true
})
```

### Component configuration via classes

```js
import { Button } from 'nhsuk-frontend'

const $button = document.querySelector('.app-button')

// Initialise single button component
new Button($button, {
  preventDoubleClick: true
})
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
