### PR TITLE
Update package version to v10.0.0-internal.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK frontend Changelog
 
-## Unreleased
+## 10.0.0-internal.2 - 24 July 2025
 
 :new: **New features**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22518,7 +22518,7 @@
       }
     },
     "packages/nhsuk-frontend": {
-      "version": "10.0.0-internal.1",
+      "version": "10.0.0-internal.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.28.0",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "10.0.0-internal.1",
+  "version": "10.0.0-internal.2",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "homepage": "https://nhsuk.github.io/nhsuk-frontend/",
   "bugs": {


### PR DESCRIPTION
## Description

Bumps the version number to v10.0.0-internal.2 ready to install either:

```console
npm install nhsuk-frontend@10.0.0-internal.2
npm install nhsuk-frontend@next
```

The version bump was generated using:

```console
npm version prerelease --no-git-tag-version --preid internal --workspace nhsuk-frontend
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
