### PR TITLE
Accommodate camera notches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ As NHS.UK frontend no longer supports Internet Explorer versions older than 11, 
 
 This change was made in [pull request #1509: Remove `X-UA-Compatible meta tag`](https://github.com/nhsuk/nhsuk-frontend/pull/1509).
 
+#### Update the viewport meta tag
+
+We've updated our grid layout gutter margins to accommodate devices with "camera notches". Browsers on these devices reserve a safe area in landscape orientation (known as pillar-boxing) so content isn't obscured.
+
+To avoid this, support has been added for `viewport-fit=cover` as shown here:
+https://webkit.org/blog/7929/designing-websites-for-iphone-x/
+
+This change was introduced in [pull request #1510: Accommodate camera notches](https://github.com/nhsuk/nhsuk-frontend/pull/1510).
+
 :wrench: **Fixes**
 
 - [#1512: Remove unused close icon](https://github.com/nhsuk/nhsuk-frontend/pull/1512)

--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -29,7 +29,7 @@ You'll not be able to:
    <html lang="en">
      <head>
        <title>Example - NHS.UK</title>
-       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
        <link rel="stylesheet" href="/stylesheets/nhsuk-frontend-<VERSION-NUMBER>.min.css">
      </head>
      <body>

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/_index.scss
@@ -1,3 +1,4 @@
+@use "sass:string";
 @use "../../core/settings" as *;
 @use "../../core/tools" as *;
 
@@ -16,6 +17,15 @@
   top: nhsuk-spacing(3);
   padding: nhsuk-spacing(2);
   @include nhsuk-visually-hidden-focusable; // [1]
+
+  // Respect 'display cutout' safe area (avoids notches and rounded corners)
+  @supports (left: string.unquote("max(calc(0px))")) {
+    $safe-area-left: calc(#{nhsuk-spacing(3)} + env(safe-area-inset-left));
+
+    // Use max() to pick largest offset, default or with safe area
+    // Escaped due to Sass max() vs. CSS native max()
+    left: string.unquote("max(#{nhsuk-spacing(3)}, #{$safe-area-left})");
+  }
 }
 
 .nhsuk-skip-link-focused-element {

--- a/packages/nhsuk-frontend/src/nhsuk/core/objects/_width-container.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/objects/_width-container.scss
@@ -1,3 +1,4 @@
+@use "sass:string";
 @use "../settings" as *;
 @use "../tools" as *;
 
@@ -29,10 +30,32 @@
   margin-right: $nhsuk-gutter-half;
   margin-left: $nhsuk-gutter-half;
 
+  // Respect 'display cutout' safe area (avoids notches and rounded corners)
+  @supports (margin: string.unquote("max(calc(0px))")) {
+    $gutter-safe-area-right: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-right));
+    $gutter-safe-area-left: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-left));
+
+    // Use max() to pick largest margin, default or with safe area
+    // Escaped due to Sass max() vs. CSS native max()
+    margin-right: string.unquote("max(#{$nhsuk-gutter-half}, #{$gutter-safe-area-right})");
+    margin-left: string.unquote("max(#{$nhsuk-gutter-half}, #{$gutter-safe-area-left})");
+  }
+
   // On desktop, add full width gutters
   @include nhsuk-media-query($from: desktop) {
     margin-right: $nhsuk-gutter;
     margin-left: $nhsuk-gutter;
+
+    // Respect 'display cutout' safe area (avoids notches and rounded corners)
+    @supports (margin: string.unquote("max(calc(0px))")) {
+      $gutter-safe-area-right: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-right));
+      $gutter-safe-area-left: calc(#{$nhsuk-gutter-half} + env(safe-area-inset-left));
+
+      // Use max() to pick largest margin, default or with safe area
+      // Escaped due to Sass max() vs. CSS native max()
+      margin-right: string.unquote("max(#{$nhsuk-gutter}, #{$gutter-safe-area-right})");
+      margin-left: string.unquote("max(#{$nhsuk-gutter}, #{$gutter-safe-area-left})");
+    }
   }
 
   // As soon as the viewport is greater than the width of the page plus the
@@ -40,6 +63,13 @@
   @include nhsuk-media-query($and: "(min-width: #{($width + $nhsuk-gutter * 2)})") {
     margin-right: auto;
     margin-left: auto;
+
+    // Since a safe area may have previously been set above,
+    // we need to duplicate this margin that centers the page.
+    @supports (margin: string.unquote("max(calc(0px))")) {
+      margin-right: auto;
+      margin-left: auto;
+    }
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/objects/width-container.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/objects/width-container.unit.test.mjs
@@ -27,16 +27,34 @@ describe('Page width container', () => {
             margin-right: 16px;
             margin-left: 16px;
           }
+          @supports (margin: max(calc(0px))) {
+            .app-width-container--wide {
+              margin-right: max(16px, calc(16px + env(safe-area-inset-right)));
+              margin-left: max(16px, calc(16px + env(safe-area-inset-left)));
+            }
+          }
           @media (min-width: 48.0625em) {
             .app-width-container--wide {
               margin-right: 32px;
               margin-left: 32px;
+            }
+            @supports (margin: max(calc(0px))) {
+              .app-width-container--wide {
+                margin-right: max(32px, calc(16px + env(safe-area-inset-right)));
+                margin-left: max(32px, calc(16px + env(safe-area-inset-left)));
+              }
             }
           }
           @media (min-width: 1264px) {
             .app-width-container--wide {
               margin-right: auto;
               margin-left: auto;
+            }
+            @supports (margin: max(calc(0px))) {
+              .app-width-container--wide {
+                margin-right: auto;
+                margin-left: auto;
+              }
             }
           }
         `)

--- a/packages/nhsuk-frontend/src/nhsuk/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/template.njk
@@ -7,7 +7,7 @@
   <head>
     <meta charset="utf-8">
     <title>{% block pageTitle %}NHS{% endblock %}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
     {% block headIcons %}
       <link rel="shortcut icon" href="{{ assetPath | default("/assets", true) }}/favicons/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
@colinrotherham noticed this, and nerd-snipped me into contributing a new feature for it.

**NHS.UK frontend** doesn't support the dreaded "notch" (or Display Cutouts as they're known) on various devices. See the unused white area on the left hand side here:

![notch safe area](https://github.com/user-attachments/assets/cdc2baad-5962-480f-b238-72b9bf6a55c7)

The `safe-area-inset-*` variables were [added in iOS 11](https://webkit.org/blog/7929/designing-websites-for-iphone-x/), and Android P added support via Chrome for Android 69: https://www.chromestatus.com/feature/5710044637167616

Firefox added support in v65:
https://bugzilla.mozilla.org/show_bug.cgi?id=1462233

### Before

<img width="524" height="242" alt="before" src="https://github.com/user-attachments/assets/4276108d-ca86-4362-bd2d-9ccd9bdb0de0" />

### After

<img width="524" height="242" alt="after" src="https://github.com/user-attachments/assets/ababddf0-3663-4b2d-84e0-b3d1458631b1" />

This pull request adds the initial support to patch `.nhsuk-width-container`

## Description

See (and in tribute to) https://github.com/alphagov/govuk-frontend/pull/1176

The implementation used by GOV.UK Frontend has been adapted slightly for this project as our skip link doesn’t take up the full width of the page (yet?). So instead of accounting for the safe area in the padding, I’ve used it to calculate the left offset.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
