### PR TITLE
Remove unused close icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ As NHS.UK frontend no longer supports Internet Explorer versions older than 11, 
 
 This change was made in [pull request #1509: Remove `X-UA-Compatible meta tag`](https://github.com/nhsuk/nhsuk-frontend/pull/1509).
 
+:wrench: **Fixes**
+
+- [#1512: Remove unused close icon](https://github.com/nhsuk/nhsuk-frontend/pull/1512)
+
 ## 10.0.0-internal.2 - 24 July 2025
 
 :new: **New features**

--- a/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-close.svg
+++ b/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-close.svg
@@ -1,3 +1,0 @@
-<svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" height="34" width="34">
-  <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-</svg>

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
@@ -31,10 +31,6 @@
   fill: $color_nhsuk-blue;
 }
 
-.nhsuk-icon__close {
-  fill: $color_nhsuk-blue;
-}
-
 .nhsuk-icon__cross {
   fill: $color_nhsuk-red;
 }


### PR DESCRIPTION
## Description

Partially addresses #1028. The close icon is no longer used by the mobile menu in the header (the chevon rotates).

This PR will require a respective change to the service manual to remove this from the [table of icons](https://service-manual.nhs.uk/design-system/styles/icons). 

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
