### PR TITLE
Remove unused global Sass variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ This change was introduced in [pull request #1510: Accommodate camera notches](h
 
 :wrench: **Fixes**
 
+- [#1516: Remove unused global Sass variables](https://github.com/nhsuk/nhsuk-frontend/pull/1516)
 - [#1512: Remove unused close icon](https://github.com/nhsuk/nhsuk-frontend/pull/1512)
 
 ## 10.0.0-internal.2 - 24 July 2025

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
@@ -15,7 +15,6 @@ $nhsuk-font-fallback: arial, sans-serif !default; // [1]
 $nhsuk-font-family-print: sans-serif !default;
 $nhsuk-font-bold: 600 !default;
 $nhsuk-font-normal: 400 !default;
-$nhsuk-font-light: $nhsuk-font-normal !default;
 $nhsuk-fonts-path: "https://assets.nhs.uk/fonts/" !default;
 $nhsuk-include-font-face: true !default;
 
@@ -48,8 +47,6 @@ $nhsuk-grid-widths: (
 /// Border sizes
 
 $nhsuk-border-width-inset-text: 8px !default;
-$nhsuk-care-card-triangle-border: 16px !default;
-$nhsuk-hero-content-triangle-border: 16px !default;
 $nhsuk-hero-border: 1px !default;
 $nhsuk-border-table-header-width: 2px !default;
 $nhsuk-border-table-cell-width: 1px !default;
@@ -57,20 +54,6 @@ $nhsuk-border-table-cell-width: 1px !default;
 /// Border radius
 
 $nhsuk-border-radius: 4px !default;
-
-/// Box shadow
-
-$nhsuk-box-shadow-spread: 4px !default;
-$nhsuk-box-shadow-blur: 4px !default;
-$nhsuk-box-shadow-link: 4px !default;
-$nhsuk-box-details: 8px !default;
-$nhsuk-box-expander: 4px !default;
-$nhsuk-box-shadow-pagination: 16px !default;
-$nhsuk-box-shadow-link: 4px !default;
-
-/// Header spacing
-
-$nhsuk-header-spacing: 20px;
 
 /// Form elements
 


### PR DESCRIPTION
## Description

Absolute rabbit hole this one, but spotted that `$nhsuk-header-spacing` needs removing, and so did a search across the other global variables.

Notes:

- `$nhsuk-font-light` wasn’t removed to prevent needing to release a breaking change… in 2019 (see: https://github.com/nhsuk/nhsuk-frontend/pull/460#issuecomment-502674057)
- `$nhsuk-font-family-print` isn’t used anywhere… but probably should (in GOV.UK Frontend it is used in the `govuk-typography-common` mixin)
- the following ‘global’ variables should probably be moved to their respective components, but have left them here for now:
  - `$nhsuk-border-width-inset-text`
  - `$nhsuk-hero-border`
  - `$nhsuk-border-table-header-width`
  - `$nhsuk-border-table-cell-width`

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
