### PR TITLE
Fix alt text in new header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ This change was introduced in [pull request #1510: Accommodate camera notches](h
 - [#1516: Remove unused global Sass variables](https://github.com/nhsuk/nhsuk-frontend/pull/1516)
 - [#1522: Use em helper for contents list tick placement](https://github.com/nhsuk/nhsuk-frontend/pull/1522)
 - [#1525: Fix exclusive checkbox groups with unique name attributes](https://github.com/nhsuk/nhsuk-frontend/pull/1525)
+- [#1528: Fix alt text in header](https://github.com/nhsuk/nhsuk-frontend/pull/1528)
 
 ## 10.0.0-internal.2 - 24 July 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -15,10 +15,10 @@
 
 {#- The NHS logo can be replaced by a bitmap image and/or suffixed by an
     organisation name (with can be split and include a descriptor) -#}
-{%- macro _serviceLogo(logoSrc, organisation) %}
-{% set ariaLabel = params.logo.ariaLabel | default("NHS") %}
-{% if logoSrc %}
-<img class="nhsuk-header__organisation-logo" src="{{ baseUrl }}{{ logoSrc }}" width="280" alt="{{ ariaLabel }}">
+{%- macro _serviceLogo(logo, organisation) %}
+{% set ariaLabel = logo.ariaLabel | default("NHS") %}
+{% if logo.src %}
+<img class="nhsuk-header__organisation-logo" src="{{ baseUrl }}{{ logo.src }}" width="280" alt="{{ ariaLabel }}">
 {% else %}
 <svg class="nhsuk-header__logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80" height="40" width="100" focusable="false" role="img" aria-label="{{ ariaLabel }}">
   <title>{{ ariaLabel }}</title>
@@ -56,11 +56,11 @@
     <div class="nhsuk-header__service">
     {% if logoHref %}
       <a class="nhsuk-header__service-logo" href="{{ logoHref }}">
-        {{ _serviceLogo(params.logo.src, params.organisation) | indent(8) }}
+        {{ _serviceLogo(params.logo, params.organisation) | indent(8) }}
         {{- _serviceName(params.service.text) if combineLogoAndServiceNameLinks }}
       </a>
     {% else %}
-      {{ _serviceLogo(params.logo.src, params.organisation) | indent(6) }}
+      {{ _serviceLogo(params.logo, params.organisation) | indent(6) }}
       {{- _serviceName(params.service.text) if combineLogoAndServiceNameLinks }}
     {% endif %}
     {% if params.service.text and not combineLogoAndServiceNameLinks %}


### PR DESCRIPTION
## Description
It seems `params.logo` was not in scope within the `_serviceLogo` macro. Passing `ariaLabel` to `_serviceLogo` as a parameter resolves this.

For example, this example was showing just the default "NHS" as the alt text:
https://nhsuk.github.io/nhsuk-frontend/components/header/organisational-white-with-search-navigation-custom-logo/

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
