### PR TITLE
Add support for id param to all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ If you are not using Nunjucks macros, update your HTML markup to:
 
 You can now use the action link component on dark backgrounds by using the `.nhsuk-action-link--reverse` class. Added in [pull request #1542: Add reverse action link modifiers and styles](https://github.com/nhsuk/nhsuk-frontend/pull/1542).
 
+:wrench: **Fixes**
+
+- [#1536: Add support for id param to all components](https://github.com/nhsuk/nhsuk-frontend/pull/1536)
+
 ## 10.0.0-internal.3 - 15 August 2025
 
 :new: **New features**

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Action link'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the action link.'
+  },
   text: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/template.njk
@@ -1,7 +1,7 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 {% from "nhsuk/macros/icon.njk" import nhsukIcon %}
 
-<a class="nhsuk-action-link
+<a {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-action-link
   {%- if params.classes %} {{ params.classes }}{% endif %}" href="
   {%- if params.href %}{{ params.href }}{% else %}#{% endif %}"
   {%- if params.openInNewWindow %} target="_blank"{% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/back-link/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/back-link/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Back link'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the back link.'
+  },
   text: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/back-link/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/back-link/template.njk
@@ -2,7 +2,7 @@
 
 {% set element = "button" if params.element == "button" else "a" %}
 
-<{{element}} class="nhsuk-back-link {%- if params.classes %} {{ params.classes }}{% endif %}"
+<{{element}} {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-back-link {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- if element == "a"%} href="{{ params.href | default("#", true) }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }}>
   {{- params.html | safe if params.html else (params.text | default("Back", true)) -}}

--- a/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Breadcrumb'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the breadcrumb.'
+  },
   items: {
     type: 'array',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/template.njk
@@ -1,7 +1,7 @@
 {% from "nhsuk/components/back-link/macro.njk" import backLink %}
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<nav class="nhsuk-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}" aria-label="{{ params.labelText | default("Breadcrumb") }}"
+<nav {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}" aria-label="{{ params.labelText | default("Breadcrumb") }}"
   {{- nhsukAttributes(params.attributes) }}>
   <ol class="nhsuk-breadcrumb__list">
 {% for item in params.items %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Button'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the button.'
+  },
   element: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/template.njk
@@ -13,7 +13,7 @@
 {% endif %}
 
 {# Define common attributes that we can use across all element types #}
-{% set commonAttributes %} class="nhsuk-button
+{% set commonAttributes %} {%- if params.id %} id="{{ params.id }}" {% endif %} class="nhsuk-button
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   data-module="nhsuk-button"
   {% if params.preventDoubleClick %} data-prevent-double-click="true"{% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Card'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the card.'
+  },
   heading: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
@@ -3,7 +3,7 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
-<div class="nhsuk-card
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-card
 {%- if params.clickable %} nhsuk-card--clickable{% endif %}
 {%- if params.secondary %} nhsuk-card--secondary{% endif %}
 {%- if params.type %} nhsuk-card--care nhsuk-card--care--{{ params.type }}{% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Checkboxes'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the checkboxes component.'
+  },
   describedBy: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -45,7 +45,7 @@
     text: params.errorMessage.text
   }) | indent(2) | trim }}
 {% endif %}
-  <div class="nhsuk-checkboxes
+  <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-checkboxes
     {%- if params.classes %} {{ params.classes }}{% endif %}
     {%- if isConditional %} nhsuk-checkboxes--conditional{% endif %}"
     {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-checkboxes">

--- a/packages/nhsuk-frontend/src/nhsuk/components/contents-list/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/contents-list/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Contents list'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the contents list.'
+  },
   items: {
     type: 'array',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/contents-list/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/contents-list/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<nav class="nhsuk-contents-list
+<nav {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-contents-list
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }} role="navigation" aria-label="Pages in this guide">
   <h2 class="nhsuk-u-visually-hidden">Contents</h2>

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<details {%- if params.id %} id="{{params.id}}"{% endif %} class="nhsuk-details
+<details {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-details
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }} {{- " open" if params.open }}>
   <summary class="nhsuk-details__summary">

--- a/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = "Do and Don't list"
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: "The ID of the do and don't list component."
+  },
   title: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/template.njk
@@ -2,7 +2,7 @@
 {% from "nhsuk/macros/icon.njk" import nhsukIcon %}
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
-<div class="nhsuk-do-dont-list
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-do-dont-list
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="nhsuk-do-dont-list__label">{{ params.title }}</h{{ headingLevel }}>

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Error summary'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the error summary.'
+  },
   titleText: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<div class="nhsuk-error-summary
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-error-summary">

--- a/packages/nhsuk-frontend/src/nhsuk/components/fieldset/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/fieldset/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Fieldset'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the fieldset.'
+  },
   describedBy: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/fieldset/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/fieldset/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<fieldset class="nhsuk-fieldset
+<fieldset {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-fieldset
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }}>

--- a/packages/nhsuk-frontend/src/nhsuk/components/footer/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/footer/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Footer'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the footer.'
+  },
   columns: {
     type: 'integer',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/footer/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/footer/template.njk
@@ -27,7 +27,7 @@
 </ul>
 {% endmacro -%}
 
-<footer class="nhsuk-footer
+<footer {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-footer
   {%- if params.classes %} {{ params.classes }}{% endif %}" role="contentinfo"
   {{- nhsukAttributes(params.attributes) }}>
   <div class="nhsuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Header'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the header.'
+  },
   logo: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -45,7 +45,7 @@
 {{- item.html | safe if item.html else item.text -}}
 {% endmacro %}
 
-<header class="nhsuk-header
+<header {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-header
   {%- if params.organisation %} nhsuk-header--organisation{% endif %}
   {%- if params.classes %} {{ params.classes }}{% endif %}" role="banner"
   {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-header">

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Hero'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the hero.'
+  },
   heading: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/template.njk
@@ -2,7 +2,7 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-<section class="nhsuk-hero
+<section {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-hero
 {%- if params.imageURL and params.heading %} nhsuk-hero--image nhsuk-hero--image-description
 {%- elif params.imageURL %} nhsuk-hero--image{% endif %}
 {%- if params.classes %} {{ params.classes }}{% endif %}"

--- a/packages/nhsuk-frontend/src/nhsuk/components/images/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/images/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Images'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the image.'
+  },
   src: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/images/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/images/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<figure class="nhsuk-image
+<figure {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-image
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }}>
   <img class="nhsuk-image__img" src="{{ params.src }}" alt="{{ params.alt }}" 

--- a/packages/nhsuk-frontend/src/nhsuk/components/inset-text/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/inset-text/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Inset text'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the inset text component.'
+  },
   text: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/inset-text/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/inset-text/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<div class="nhsuk-inset-text
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-inset-text
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }}>
   <span class="nhsuk-u-visually-hidden">Information: </span>

--- a/packages/nhsuk-frontend/src/nhsuk/components/label/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/label/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Label'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the label.'
+  },
   text: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/label/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/label/template.njk
@@ -2,7 +2,7 @@
 
 {% if params.html or params.text %}
 {%- set labelHtml %}
-<label class="nhsuk-label
+<label {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-label
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- if params.for %} for="{{ params.for }}"{% endif %}
 {{- nhsukAttributes(params.attributes) }}>

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Notification banner'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the notification banner.'
+  },
   text: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/template.njk
@@ -28,7 +28,7 @@
   {% set title = "Important" %}
 {%- endif -%}
 
-<div class="nhsuk-notification-banner {%- if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}" aria-labelledby="{{ params.titleId | default("nhsuk-notification-banner-title", true) }}" data-module="nhsuk-notification-banner"
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-notification-banner {%- if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}" aria-labelledby="{{ params.titleId | default("nhsuk-notification-banner-title", true) }}" data-module="nhsuk-notification-banner"
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }}>
   <div class="nhsuk-notification-banner__header">

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Pagination'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the pagination container.'
+  },
   previousUrl: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
@@ -1,7 +1,7 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 {% from "nhsuk/macros/icon.njk" import nhsukIcon %}
 
-<nav class="nhsuk-pagination
+<nav {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-pagination
 {%- if params.classes %} {{ params.classes }}{% endif %}" role="navigation" aria-label="Pagination"
 {{- nhsukAttributes(params.attributes) }}>
   <ul class="nhsuk-list nhsuk-pagination__list">

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Panel'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the panel.'
+  },
   titleText: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/template.njk
@@ -2,7 +2,7 @@
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 1 -%}
 
-<div class="nhsuk-panel
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-panel
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {{- nhsukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="nhsuk-panel__title">

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Radios'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the radios component.'
+  },
   fieldset: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -42,7 +42,7 @@
     text: params.errorMessage.text
   }) | indent(2) | trim }}
 {% endif %}
-  <div class="nhsuk-radios
+  <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-radios
     {%- if params.classes %} {{ params.classes }}{% endif %}
     {%- if isConditional %} nhsuk-radios--conditional{% endif %}"
     {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-radios">

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Skip link'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the skip link.'
+  },
   text: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/template.njk
@@ -1,6 +1,6 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<a class="nhsuk-skip-link
+<a {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-skip-link
 {%- if params.classes %} {{ params.classes }}{% endif %}" href="
 {%- if params.href %}{{ params.href }}{% else %}#maincontent{% endif %}"
 {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-skip-link">

--- a/packages/nhsuk-frontend/src/nhsuk/components/summary-list/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/summary-list/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Summary list'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the summary list.'
+  },
   rows: {
     type: 'array',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/summary-list/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/summary-list/template.njk
@@ -15,7 +15,7 @@
   {% set anyRowHasActions = true if row.actions.items | length else anyRowHasActions %}
 {% endfor -%}
 
-<dl class="nhsuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
+<dl {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
   {% for row in params.rows %}
     {% if row %}
     <div class="nhsuk-summary-list__row {%- if anyRowHasActions and not row.actions.items %} nhsuk-summary-list__row--no-actions{% endif %} {%- if row.classes %} {{ row.classes }}{% endif %}">

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/macro-options.mjs
@@ -9,6 +9,11 @@ export const name = 'Tables'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the table.'
+  },
   rows: {
     type: 'array',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/template.njk
@@ -8,7 +8,7 @@
     <h{{ headingLevel }} class="nhsuk-table__heading-tab">{{ params.heading | safe }}</h{{ headingLevel }}>
   {%- endif %}
   {%- endif %}
-  <table class="nhsuk-table
+  <table {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-table
     {%- if params.responsive %}-responsive{% endif %}
     {%- if params.tableClasses %} {{ params.tableClasses }}{% endif %}"
     {%- if params.responsive %} role="table"{% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/template.njk
@@ -4,7 +4,7 @@
    instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix -%}
 
-<div {%- if params.id %} id="{{params.id}}"{% endif %} class="nhsuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-tabs">
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }} data-module="nhsuk-tabs">
   <h2 class="nhsuk-tabs__title">
     {{ params.title | default ("Contents") }}
   </h2>

--- a/packages/nhsuk-frontend/src/nhsuk/components/tag/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tag/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Tag'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the tag.'
+  },
   text: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/tag/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tag/template.njk
@@ -1,5 +1,5 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
-<strong class="nhsuk-tag{% if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
+<strong {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-tag{% if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
   {{ params.html | safe if params.html else params.text }}
 </strong>

--- a/packages/nhsuk-frontend/src/nhsuk/components/task-list/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/task-list/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Task list'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the button.'
+  },
   classes: {
     type: 'string',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/task-list/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/task-list/template.njk
@@ -33,7 +33,7 @@
   </li>
 {%- endmacro %}
 
-<ul class="nhsuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
+<ul {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}" {{- nhsukAttributes(params.attributes) }}>
   {% for item in params.items %}
     {{- _taskListItem(params, item, loop.index) }}
   {% endfor %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/macro-options.mjs
@@ -8,6 +8,11 @@ export const name = 'Warning callout'
  * @satisfies {{ [param: string]: MacroParam }}
  */
 export const params = {
+  id: {
+    type: 'string',
+    required: false,
+    description: 'The ID of the warning callout.'
+  },
   heading: {
     type: 'string',
     required: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/template.njk
@@ -1,7 +1,7 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 
 {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
-<div class="nhsuk-warning-callout
+<div {%- if params.id %} id="{{ params.id }}"{% endif %} class="nhsuk-warning-callout
 {%- if params.classes %} {{ params.classes }}{% endif %}"
 {{- nhsukAttributes(params.attributes) }}>
   <h{{ headingLevel }} class="nhsuk-warning-callout__label">


### PR DESCRIPTION
## Description
Adds support for `id` as a param to the majority of components.

Doing this because:
* I had a use case where I wanted to anchor to a section, and couldn't
* It's good to support as a standard thing