### PR TITLE
Set default icon sizes in HTML and CSS

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "../../core/settings" as *;
 @use "../../core/tools" as *;
 @use "../../core/helpers" as *;
@@ -13,15 +14,15 @@
 /// @group components
 ////
 
-$_small-icon-size: 24px;
-$_small-icon-spacing: 2px;
+$_small-icon-size: $nhsuk-icon-size;
+$_small-icon-spacing: math.floor(math.div($_small-icon-size, 10));
 
 $_large-icon-size: 36px;
-$_large-icon-spacing: 3px;
+$_large-icon-spacing: math.floor(math.div($_large-icon-size, 10));
 
 .nhsuk-action-link {
   display: inline-block; // [1]
-  padding-left: nhsuk-px-to-rem($_large-icon-size + $_large-icon-spacing); // [2]
+  padding-left: nhsuk-px-to-rem($_small-icon-size + $_small-icon-spacing); // [2]
   position: relative; // [3]
   text-decoration: none; // [4]
 
@@ -31,27 +32,25 @@ $_large-icon-spacing: 3px;
     }
   }
 
-  @include nhsuk-font(22, $weight: bold, $line-height: $_large-icon-size);
+  @include nhsuk-font(22, $weight: bold, $line-height: $_small-icon-size);
   @include nhsuk-print-colour($nhsuk-print-text-colour);
   @include nhsuk-responsive-margin(6, "bottom");
 
-  @include nhsuk-media-query($until: tablet) {
-    line-height: nhsuk-line-height($_small-icon-size, $font-size: 22);
-    padding-left: nhsuk-px-to-rem($_small-icon-size + $_small-icon-spacing); // [2]
+  @include nhsuk-media-query($from: tablet) {
+    line-height: nhsuk-line-height($_large-icon-size, $font-size: 22);
+    padding-left: nhsuk-px-to-rem($_large-icon-size + $_large-icon-spacing); // [2]
   }
 
   .nhsuk-icon {
-    height: nhsuk-px-to-rem($_large-icon-size);
-    width: nhsuk-px-to-rem($_large-icon-size);
     // stylelint-disable-next-line declaration-no-important
     fill: nhsuk-colour("green") !important;
-    left: nhsuk-px-to-rem(-$_large-icon-spacing);
+    left: nhsuk-px-to-rem(-$_small-icon-spacing);
     position: absolute;
 
-    @include nhsuk-media-query($until: tablet) {
-      height: nhsuk-px-to-rem($_small-icon-size);
-      width: nhsuk-px-to-rem($_small-icon-size);
-      left: nhsuk-px-to-rem(-$_small-icon-spacing);
+    @include nhsuk-media-query($from: tablet) {
+      height: nhsuk-px-to-rem($_large-icon-size);
+      width: nhsuk-px-to-rem($_large-icon-size);
+      left: nhsuk-px-to-rem(-$_large-icon-spacing);
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -277,7 +277,9 @@ $card-border-hover-color: $card-border-hover-colour;
   .nhsuk-icon {
     display: block;
     fill: nhsuk-colour("blue");
-    margin-top: math.floor(math.div($nhsuk-icon-size, -2));
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large);
+    margin-top: math.floor(math.div($nhsuk-icon-size-large, -2));
     pointer-events: none;
     position: absolute;
     top: 50%;

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
@@ -14,7 +14,7 @@
 /// @group components
 ////
 
-$_icon-size: nhsuk-em($nhsuk-icon-size, 26px);
+$_icon-size: nhsuk-em($nhsuk-icon-size-large, 26px);
 
 .nhsuk-pagination {
   @include nhsuk-responsive-margin(7, "top");

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
@@ -25,7 +25,8 @@ $nhsuk-base-line-height: 24px !default;
 
 /// Icon default sizing
 
-$nhsuk-icon-size: 32px !default;
+$nhsuk-icon-size: 24px !default;
+$nhsuk-icon-size-large: 32px !default;
 
 /// Grid spacing
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
@@ -13,26 +13,59 @@
   fill: currentcolor;
   height: nhsuk-px-to-rem($nhsuk-icon-size);
   width: nhsuk-px-to-rem($nhsuk-icon-size);
+
+  @include nhsuk-media-query($from: tablet) {
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large);
+  }
 }
 
 /// Icon size adjustments
 
 .nhsuk-icon--size-25 {
-  height: nhsuk-px-to-rem($nhsuk-icon-size * 1.25);
-  width: nhsuk-px-to-rem($nhsuk-icon-size * 1.25);
+  $ratio: 1.25; // 25% larger
+
+  height: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+  width: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+
+  @include nhsuk-media-query($from: tablet) {
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+  }
 }
 
 .nhsuk-icon--size-50 {
-  height: nhsuk-px-to-rem($nhsuk-icon-size * 1.5);
-  width: nhsuk-px-to-rem($nhsuk-icon-size * 1.5);
+  $ratio: 1.5; // 50% larger
+
+  height: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+  width: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+
+  @include nhsuk-media-query($from: tablet) {
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+  }
 }
 
 .nhsuk-icon--size-75 {
-  height: nhsuk-px-to-rem($nhsuk-icon-size * 1.75);
-  width: nhsuk-px-to-rem($nhsuk-icon-size * 1.75);
+  $ratio: 1.75; // 75% larger
+
+  height: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+  width: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+
+  @include nhsuk-media-query($from: tablet) {
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+  }
 }
 
 .nhsuk-icon--size-100 {
-  height: nhsuk-px-to-rem($nhsuk-icon-size * 2);
-  width: nhsuk-px-to-rem($nhsuk-icon-size * 2);
+  $ratio: 2; // 100% larger
+
+  height: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+  width: nhsuk-px-to-rem($nhsuk-icon-size * $ratio);
+
+  @include nhsuk-media-query($from: tablet) {
+    height: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+    width: nhsuk-px-to-rem($nhsuk-icon-size-large * $ratio);
+  }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/macros/icon.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/macros/icon.njk
@@ -24,7 +24,7 @@
   @param {string} params.classes - Classes to add to the icon
 #}
 {% macro nhsukIcon(name, params) -%}
-<svg class="nhsuk-icon nhsuk-icon--{{ name }} {%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" focusable="false"{% if params.title %} role="img" aria-label="{{ params.title }}"{% else %} aria-hidden="true"{% endif %}>
+<svg class="nhsuk-icon nhsuk-icon--{{ name }} {%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false"{% if params.title %} role="img" aria-label="{{ params.title }}"{% else %} aria-hidden="true"{% endif %}>
 {% if params.title %}
   <title>{{ params.title }}</title>
 {% endif %}


### PR DESCRIPTION
## Description

This PR adds a suggestion from @paulrobertlloyd to:

1. Set icon size to 16px in HTML (when CSS is disabled)
2. Set icon size to 24px at mobile viewport
3. Set icon size to 32px at tablet viewport

Existing size overrides for action links, cards and pagination are maintained

<img width="478" height="245" alt="Icon sizes without CSS" src="https://github.com/user-attachments/assets/ec7bb131-91c8-43d9-9748-a1d33133e835" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
