### PR TITLE
Tag v9 releases as `latest-v9` not `latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,6 @@ jobs:
           asset_content_type: application/zip
 
       - name: Publish npm package
-        run: npm publish
+        run: npm publish --tag latest-v9
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

This PR prevents the next v9.x support release from bumping v10.x off the `latest` npm tag

Follows the naming convention from GOV.UK Frontend:

```console
npm install nhsuk-frontend@latest
npm install nhsuk-frontend@10.0.0
```

```console
npm install nhsuk-frontend@latest-v9
npm install nhsuk-frontend@9.6.4
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
