### PR TITLE
Fix script include instructions to show closing `</body>` tag

### DIFF
--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -93,7 +93,7 @@ Then include the script before the closing `</body>` tag of your page using the 
       import { initAll } from '/javascripts/nhsuk-frontend.min.js'
       initAll()
     </script>
-  </head>
+  </body>
 ```
 
 ### Option 2: Import JavaScript using a bundler


### PR DESCRIPTION
## Description

Fixes a typo reported by @paulrobertlloyd

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
