### PR TITLE
Fix description of namePrefix for date input

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/macro-options.mjs
@@ -18,7 +18,7 @@ export const params = {
     type: 'string',
     required: false,
     description:
-      "Optional prefix. This is used to prefix each `item.name` using `'-'`."
+      "Optional prefix. This is used to prefix each `item.name`, with the name then appearing in square brackets, for example `'date[month]'` ."
   },
   items: {
     type: 'array',


### PR DESCRIPTION
The description of how the `namePrefix` is out of date, as in #994 we updated it to use square brackets instead of hyphens, for easier use with Express.js based servers (eg the NHS Prototype kit).