### PR TITLE
Fix to previous javascript filename in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,7 +362,7 @@ Before:
 
 ```html
   <!-- // ... -->
-  <script src="/javascripts/nhsuk-frontend.min.js" defer></script>
+  <script src="/<JAVASCRIPTS-PATH>/nhsuk.min.js" defer></script>
 </head>
 ```
 
@@ -370,9 +370,9 @@ After:
 
 ```html
   <!-- // ... -->
-  <script type="module" src="/javascripts/nhsuk-frontend.min.js"></script>
+  <script type="module" src="/<JAVASCRIPTS-PATH>/nhsuk.min.js"></script>
   <script type="module">
-    import { initAll } from '/javascripts/nhsuk-frontend.min.js'
+    import { initAll } from '/<JAVASCRIPTS-PATH>/nhsuk-frontend.min.js'
     initAll()
   </script>
 </body>
@@ -382,7 +382,7 @@ Or for [JavaScript imported using a bundler](#using-a-javascript-bundler), initi
 
 ```html
   <!-- // ... -->
-  <script type="module" src="/javascripts/application.min.js"></script>
+  <script type="module" src="/<JAVASCRIPTS-PATH>/application.min.js"></script>
 </body>
 ```
 


### PR DESCRIPTION
We made a small mistake in the v10 upgrade guide by saying that the javascripts path in the templates used to be `nhsuk-frontend.min.js` but it actually used to be `nhsuk.min.js`.

We've also realised that the path prefix is not necessarily `/javascripts/` but can vary depending on your setup (eg the NHS prototype kit uses `/nhsuk-frontend/`). So this makes that clearer by using `<JAVASCRIPTS-PATH>` to hopefully make it clear that that bit isn't part of the upgrade guidance.