### PR TITLE
Fix styling of action link when used in emergency cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This change was introduced in [pull request #1594: Always set input `:focus` box
 - [#1594: Always set input `:focus` box-shadow colour](https://github.com/nhsuk/nhsuk-frontend/pull/1594)
 - [#1599: Make border colour on `nhsuk-panel` mixin optional](https://github.com/nhsuk/nhsuk-frontend/pull/1599)
 - [#1601: Fix accessible name for linked logo in header component](https://github.com/nhsuk/nhsuk-frontend/pull/1601)
+- [#1612: Fix styling of action link when used in emergency cards ](https://github.com/nhsuk/nhsuk-frontend/pull/1612)
 
 ## 10.0.0 - 26 August 2025
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -252,7 +252,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
       color: $nhsuk-reverse-text-colour;
       background-color: nhsuk-colour("black");
 
-      a {
+      a:not(.nhsuk-action-link) {
         @include nhsuk-link-style-white;
       }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -252,7 +252,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
       color: $nhsuk-reverse-text-colour;
       background-color: nhsuk-colour("black");
 
-      a:not(.nhsuk-action-link) {
+      a:not(.nhsuk-action-link):not(.nhsuk-button) {
         @include nhsuk-link-style-white;
       }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
@@ -216,13 +216,14 @@ export const examples = {
         <li>you're coughing up more than just a few spots or streaks of blood – this could be a sign of serious bleeding in your lungs</li>
         <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
       </ul>
-      components.render('action-link', {
+
+      ${components.render('action-link', {
         context: {
           classes: 'nhsuk-action-link--reverse',
           text: 'Find your nearest A&E',
           href: '#'
         }
-      })
+      })}
     `
   },
   'primary (with chevron)': {

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
@@ -205,6 +205,26 @@ export const examples = {
       viewports: ['mobile', 'tablet', 'desktop']
     }
   },
+  'emergency (red and black) with action link': {
+    context: {
+      heading: 'Call 999 or go to A&E now if:',
+      headingLevel: 3,
+      type: 'emergency'
+    },
+    callBlock: outdent`
+      <ul>
+        <li>you're coughing up more than just a few spots or streaks of blood – this could be a sign of serious bleeding in your lungs</li>
+        <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
+      </ul>
+      <a class="nhsuk-action-link nhsuk-action-link--reverse" href="#">
+        <svg class="nhsuk-icon nhsuk-icon--arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+          <path d="M12 2a10 10 0 0 0-10 9h11.7l-4-4a1 1 0 0 1 1.5-1.4l5.6 5.7a1 1 0 0 1 0 1.4l-5.6 5.7a1 1 0 0 1-1.5 0 1 1 0 0 1 0-1.4l4-4H2A10 10 0 1 0 12 2z"></path>
+        </svg>
+
+        <span class="nhsuk-action-link__text">Find your nearest A&amp;E</span>
+      </a>
+    `
+  },
   'primary (with chevron)': {
     context: {
       href: '#',

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/macro-options.mjs
@@ -216,13 +216,13 @@ export const examples = {
         <li>you're coughing up more than just a few spots or streaks of blood – this could be a sign of serious bleeding in your lungs</li>
         <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
       </ul>
-      <a class="nhsuk-action-link nhsuk-action-link--reverse" href="#">
-        <svg class="nhsuk-icon nhsuk-icon--arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
-          <path d="M12 2a10 10 0 0 0-10 9h11.7l-4-4a1 1 0 0 1 1.5-1.4l5.6 5.7a1 1 0 0 1 0 1.4l-5.6 5.7a1 1 0 0 1-1.5 0 1 1 0 0 1 0-1.4l4-4H2A10 10 0 1 0 12 2z"></path>
-        </svg>
-
-        <span class="nhsuk-action-link__text">Find your nearest A&amp;E</span>
-      </a>
+      components.render('action-link', {
+        context: {
+          classes: 'nhsuk-action-link--reverse',
+          text: 'Find your nearest A&E',
+          href: '#'
+        }
+      })
     `
   },
   'primary (with chevron)': {

--- a/shared/lib/components.mjs
+++ b/shared/lib/components.mjs
@@ -45,6 +45,9 @@ export async function load(component) {
         // Sort default to top
         ['default', ''],
 
+        // Sort urgent with non-urgent
+        ['non-', ''],
+
         // Sort sizes numerically
         ['size S', 'size 1'],
         ['size M', 'size 2'],


### PR DESCRIPTION
## Description
Remove underline from action link when used in emergency care card. 

Currently, because of the default link styling adding `text-decoration: underline`, there is no hover state.

Before:
<img width="634" height="315" alt="image" src="https://github.com/user-attachments/assets/64824b88-3421-457c-89f3-d0c9d4c783b1" />

After: 
<img width="633" height="315" alt="image" src="https://github.com/user-attachments/assets/6fb7b4b4-66fe-434b-a545-b5a445ca9e8f" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
