### PR TITLE
Fix pagination typo from #1620

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
@@ -17,7 +17,7 @@
   <ul class="nhsuk-list nhsuk-pagination__list">
   {% if previous and previous.href %}
     <li class="nhsuk-pagination-item--previous">
-      <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{ previous.href }}" rel="previous"
+      <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{ previous.href }}" rel="prev"
         {{- nhsukAttributes(previous.attributes) }}>
         <span class="nhsuk-pagination__title">
         {% if previous.html or previous.text %}


### PR DESCRIPTION
## Description

Missed a typo in #1620 for ~`rel="previous"`~ `rel="prev"`

Can be superceded by https://github.com/nhsuk/nhsuk-frontend/pull/1026 if we move that into v10.1.0

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
