### PR TITLE
Update changelog with newer Nunjucks params for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ You can use it like this:
 pagination({
   previous: {
     href: "#"
-  },  
+  },
   next: {
     href: "#"
   },


### PR DESCRIPTION
This updates the changelog description for the new numbered pagination option to also use the new `previous` and `next` objects rather than `previousUrl` and `nextUrl`, which are deprecated (but still work).