### PR TITLE
Update package version to v11.0.0-internal.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28186,7 +28186,7 @@
       }
     },
     "packages/nhsuk-frontend": {
-      "version": "10.2.0",
+      "version": "11.0.0-internal.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.28.5",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "10.2.0",
+  "version": "11.0.0-internal.0",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "homepage": "https://nhsuk.github.io/nhsuk-frontend/",
   "bugs": {


### PR DESCRIPTION
## Description

This PR updates `main` to v11 to unblock [link colours, underlines, removal of deprecated features etc](https://github.com/nhsuk/nhsuk-frontend/milestone/6)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
