### PR TITLE
Add npm package trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     name: Create release
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -67,11 +70,7 @@ jobs:
       - name: Publish npm package
         if: ${{ !contains(steps.get_version.outputs.VERSION, '-') }}
         run: npm publish --workspace nhsuk-frontend --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish npm package (pre-release)
         if: ${{ contains(steps.get_version.outputs.VERSION, '-') }}
         run: npm publish --workspace nhsuk-frontend --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Description

This PR removes `NODE_AUTH_TOKEN` usage as [trusted publishing](https://docs.npmjs.com/trusted-publishers) is now enabled

[All classic npm tokens will be revoked](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/) on ~19 November~ 9 December 2025 ([date change info](https://github.com/orgs/community/discussions/179562))

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
