### PR TITLE
Support showing dividers between select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,52 @@ For consistency with other components with nested items, we’ve added new Nunju
 
 This was added in [pull request #1683: Update Nunjucks macro options for nested items](https://github.com/nhsuk/nhsuk-frontend/pull/1683).
 
-#### Added a modifier class for text input styles that accept codes and sequences
+#### Add a modifier class for text input styles that accept codes and sequences
 
 We've added a new `.nhsuk-input--code` class for the [text input](https://service-manual.nhs.uk/design-system/components/text-input) component. This improves readability of text inputs that receive codes and sequences (like NHS numbers, security codes or booking references).
 
 You can add it through the classes option when using Nunjucks, or directly in the class attribute of the `<input>` when using HTML.
 
 This was added in [pull request #1617: Add input styling for codes and sequences](https://github.com/nhsuk/nhsuk-frontend/pull/1617).
+
+#### Add a 'divider' Nunjucks option to selects
+
+Newer browsers support [using `<hr>` (horizontal rule) elements inside a `<select>` element](https://developer.chrome.com/blog/hr-in-select/) to help visually break up options for better readability.
+
+We've added a new `divider` Nunjucks option on select items to support this feature. For example:
+
+```njk
+{{ select({
+  label: {
+    text: 'Sort by'
+  },
+  name: 'sort',
+  items: [
+    {
+      value: 'first-name-ascending',
+      text: 'First name (A to Z)'
+    },
+    {
+      value: 'first-name-descending',
+      text: 'First name (Z to A)'
+    },
+    {
+      divider: true
+    },
+    {
+      value: 'last-name-ascending',
+      text: 'Last name (A to Z)'
+    },
+    {
+      value: 'last-name-descending',
+      text: 'Last name (Z to A)'
+    }
+  ]
+}
+}) }}
+```
+
+This was added in [pull request #1701: Support showing dividers between select options](https://github.com/nhsuk/nhsuk-frontend/pull/1701).
 
 ### :wastebasket: **Deprecated features**
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/macro-options.mjs
@@ -34,6 +34,11 @@ export const params = {
         required: true,
         description: 'Text for the option item.'
       },
+      divider: {
+        type: 'boolean',
+        required: false,
+        description: 'Divider line used to separate option items.'
+      },
       selected: {
         type: 'boolean',
         required: false,
@@ -215,6 +220,36 @@ export const examples = {
       ]
     },
     screenshot: true
+  },
+  'with divider': {
+    context: {
+      label: {
+        text: 'Sort by',
+        isPageHeading: true
+      },
+      name: 'example',
+      items: [
+        {
+          value: 'first-name-ascending',
+          text: 'First name (A to Z)'
+        },
+        {
+          value: 'first-name-descending',
+          text: 'First name (Z to A)'
+        },
+        {
+          divider: true
+        },
+        {
+          value: 'last-name-ascending',
+          text: 'Last name (A to Z)'
+        },
+        {
+          value: 'last-name-descending',
+          text: 'Last name (Z to A)'
+        }
+      ]
+    }
   },
   'with disabled item': {
     context: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
@@ -18,7 +18,9 @@
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {{- nhsukAttributes(params.attributes) }}>
   {% for item in params.items %}
-    {% if item %}
+  {%- if item.divider %}
+    <hr>
+  {% elif item %}
     {#- Allow selecting by text content (the value for an option when no value attribute is specified) #}
     {%- set effectiveValue = item.value | default(item.text) %}
     <option {%- if item.value is not undefined %} value="{{ item.value }}"{% endif %}


### PR DESCRIPTION
## Description

The `<select>` element not supports using `<hr>`s to indicate division between options.

This PR adds a new `items[].divider` boolean option, that allows users of the Nunjucks macro to include dividers in select menus.

<img width="300" height="220" alt="Screenshot of a select with divider." src="https://github.com/user-attachments/assets/1eaa8350-a595-4c19-8ae8-87b355b9d042" />

Pulled out from #1700.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
