### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,7 +77,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 4
+      default-days: 7
 
     versioning-strategy: increase
 
@@ -98,3 +98,5 @@ updates:
 
     schedule:
       interval: 'monthly'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
See https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

It's possibly less needed here as Dependabot is on a monthly update schedule, but I guess we could be unlucky and it includes a just-released malicious update?