### PR TITLE
Update package version to v10.2.0, fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK frontend Changelog
 
-## Unreleased
+## 10.2.0 - 1 December 2025
 
 ### :new: **New features**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28186,7 +28186,7 @@
       }
     },
     "packages/nhsuk-frontend": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.28.5",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "homepage": "https://nhsuk.github.io/nhsuk-frontend/",
   "bugs": {


### PR DESCRIPTION
## Description

Bumps the version number to v10.2.0 ready to release

Also fixes a URL typo from the #1699 changelog entry, ported from GOV.UK Frontend

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
