### PR TITLE
Use British English spelling of 'centre' in comments

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/_index.scss
@@ -8,7 +8,7 @@
 ///
 /// 1. Hide the breadcrumb on print stylesheets.
 /// 2. Don't show the full breadcrumb below tablet size.
-/// 3. Center chevron between breadcrumb items.
+/// 3. Centre chevron between breadcrumb items.
 ///
 /// @group components/breadcrumb
 ////

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -181,9 +181,9 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
   // Conditional reveals
   // =========================================================
 
-  // Calculate the amount of padding needed to keep the border centered against the checkbox.
+  // Calculate the amount of padding needed to keep the border centred against the checkbox.
   $conditional-border-padding: math.div($nhsuk-touch-target-size, 2) - $nhsuk-border-width-form-element;
-  // Move the border centered with the checkbox
+  // Move the border centred with the checkbox
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label
   $conditional-padding-left: $conditional-border-padding + $nhsuk-checkboxes-label-padding-left-right;
@@ -232,7 +232,7 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
 
     // [ ] Check box
     //
-    // Reduce the size of the check box [1], vertically center it within the
+    // Reduce the size of the check box [1], vertically centre it within the
     // touch target [2]
     // Left here is 0 because we've shifted the input into the left margin
     .nhsuk-checkboxes__label::before {

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
@@ -43,7 +43,7 @@
 
   //  Hero component image styles
   //
-  // 3. Center the background image.
+  // 3. Centre the background image.
   // 4. Stop the height affecting print stylesheets.
   // 5. Show more of the image for larger screen sizes
   // 6. Overlay must be min same height as .nhsuk-hero--image to cover the image.

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
@@ -131,7 +131,7 @@
     // non-link items and the first and last items
     display: none;
 
-    // Center align pagination links in their parent list item so that they
+    // Centre align pagination links in their parent list item so that they
     // visually sit in the middle of their touch area
     text-align: center;
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
@@ -199,10 +199,10 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
   // Conditional reveals
   // =========================================================
 
-  // Calculate the amount of padding needed to keep the border centered against
+  // Calculate the amount of padding needed to keep the border centred against
   // the radios.
   $conditional-border-padding: math.div($nhsuk-touch-target-size, 2) - $nhsuk-border-width-form-element;
-  // Move the border centered with the radios
+  // Move the border centred with the radios
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label
   $conditional-padding-left: $conditional-border-padding + $nhsuk-radios-label-padding-left-right;
@@ -251,7 +251,7 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
 
     // ( ) Radio ring
     //
-    // Reduce the size of the control [1], vertically centering it within the
+    // Reduce the size of the control [1], vertically centring it within the
     // touch target [2]
     // Left here is 0 because we've shifted the input into the left margin
     .nhsuk-radios__label::before {
@@ -263,7 +263,7 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
 
     //  •  Radio button
     //
-    // Reduce the size of the 'button' and center it within the ring
+    // Reduce the size of the 'button' and centre it within the ring
     .nhsuk-radios__label::after {
       $radio-button-size: 5px;
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/objects/_width-container.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/objects/_width-container.scss
@@ -62,7 +62,7 @@
     margin-left: auto;
 
     // Since a safe area may have previously been set above,
-    // we need to duplicate this margin that centers the page.
+    // we need to duplicate this margin that centres the page.
     @supports (margin: string.unquote("max(calc(0px))")) {
       margin-right: auto;
       margin-left: auto;


### PR DESCRIPTION
Spotted this and thought I’d update the other instances of it too.