### PR TITLE
[v11] Fix Nunjucks `describedBy` empty string handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # NHS.UK frontend Changelog
 
+## 10.2.2 - 4 December 2025
+
+Note: This release was created from the `support/10.x` branch.
+
+### :wrench: **Fixes**
+
+- [#1731: Fix Nunjucks `describedBy` empty string handling](https://github.com/nhsuk/nhsuk-frontend/issues/1731)
+
 ## 10.2.1 - 2 December 2025
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/template.njk
@@ -84,12 +84,9 @@
     key: "words-over-limit",
     messages: params.wordsOverLimitText
   }) -}}
-{% endset -%}
 
-{#- Append form group attributes onto attributes set above #}
-{%- for name, value in params.formGroup.attributes %}
-  {% set attributesHtml = attributesHtml ~ " " ~ name | escape ~ '="' ~ value | escape ~ '"' %}
-{% endfor -%}
+  {{- nhsukAttributes(params.formGroup.attributes) -}}
+{% endset -%}
 
 {{ textarea({
   id: id,

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -72,7 +72,7 @@
 {% set innerHtml %}
 {% if params.hint %}
   {% set hintId = idPrefix ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -83,7 +83,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -37,7 +37,7 @@
 {% set innerHtml %}
 {% if params.hint %}
   {% set hintId = params.id ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -48,7 +48,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = params.id ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,

--- a/packages/nhsuk-frontend/src/nhsuk/components/fieldset/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/fieldset/template.njk
@@ -20,7 +20,7 @@
       optional: true
     },
     "aria-describedby": {
-      value: params.describedBy,
+      value: params.describedBy if params.describedBy else false,
       optional: true
     }
   }) -}}

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -27,7 +27,7 @@
 
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
-{% set describedBy = params.describedBy if params.describedBy else undefined -%}
+{% set describedBy = params.describedBy if params.describedBy else "" -%}
 {%- set id = params.id if params.id else params.name -%}
 
 {%- set hasPrefix = true if prefix and (prefix.text or prefix.html) else false %}
@@ -57,7 +57,7 @@
         optional: true
       },
       "aria-describedby": {
-        value: describedBy,
+        value: describedBy if describedBy else false,
         optional: true
       },
       autocomplete: {
@@ -100,7 +100,7 @@
   }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = id ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -111,7 +111,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = id ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/template.njk
@@ -37,12 +37,9 @@
     key: 'password-hidden-announcement',
     message: params.passwordHiddenAnnouncementText
   }) -}}
-{%- endset -%}
 
-{#- Append form group attributes onto attributes set above #}
-{%- for name, value in params.formGroup.attributes %}
-  {% set attributesHtml = attributesHtml ~ " " ~ name | escape ~ '="' ~ value | escape ~ '"' %}
-{% endfor -%}
+  {{- nhsukAttributes(params.formGroup.attributes) -}}
+{%- endset -%}
 
 {%- set buttonHtml %}
 {{ button({

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -64,7 +64,7 @@
 {% set innerHtml %}
 {% if params.hint %}
   {% set hintId = idPrefix ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -75,7 +75,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = idPrefix ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
@@ -47,7 +47,7 @@
   }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = id ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -58,7 +58,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = id ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
@@ -21,7 +21,7 @@
   }) | trim | indent(2) }}
 {% if params.hint %}
   {% set hintId = id ~ "-hint" %}
-  {% set describedBy = describedBy ~ " " ~ hintId if describedBy else hintId %}
+  {% set describedBy = (describedBy ~ " " ~ hintId) | trim %}
   {{ hint({
     id: hintId,
     classes: params.hint.classes,
@@ -32,7 +32,7 @@
 {% endif %}
 {% if params.errorMessage %}
   {% set errorId = id ~ "-error" %}
-  {% set describedBy = describedBy ~ " " ~ errorId if describedBy else errorId %}
+  {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({
     id: errorId,
     classes: params.errorMessage.classes,


### PR DESCRIPTION
## Description

This PR ports https://github.com/nhsuk/nhsuk-frontend/pull/1731 and https://github.com/nhsuk/nhsuk-frontend/pull/1732 into v11 from `support/10.x`

These changes were released in [NHS.UK frontend v10.2.2](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v10.2.2) but are not yet in `main`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
