### PR TITLE
[v10] Update input prefix and suffix classes to follow BEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ We've added a new variant of the panel component with a solid blue background an
 
 This was added in [pull request #1196: Add interruption panel variant](https://github.com/nhsuk/nhsuk-frontend/pull/1196).
 
+### :wastebasket: **Deprecated features**
+
+#### Rename input prefix and suffix HTML class
+
+HTML markup for the input component has been updated to align `nhsuk-input-wrapper` with other wrapping classes such as `nhsuk-main-wrapper` and `nhsuk-label-wrapper`.
+
+If you are not using Nunjucks macros, change the input classes as follows:
+
+- Rename the `<div class="nhsuk-input__prefix"` class attribute to match `<div class="nhsuk-input-wrapper__prefix"`.
+- Rename the `<div class="nhsuk-input__suffix"` class attribute to match `<div class="nhsuk-input-wrapper__suffix"`.
+
+The previous class names are deprecated and will be removed in a future release.
+
+This change was introduced in [pull request #1745: Update input prefix and suffix classes to follow BEM](https://github.com/nhsuk/nhsuk-frontend/pull/1745).
+
 ## 10.2.2 - 4 December 2025
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
@@ -97,6 +97,9 @@
     max-width: 5.4ex;
   }
 
+  .nhsuk-input-wrapper__prefix,
+  .nhsuk-input-wrapper__suffix,
+  // Deprecated, to be removed in v11.0
   .nhsuk-input__prefix,
   .nhsuk-input__suffix {
     box-sizing: border-box;
@@ -131,6 +134,8 @@
     }
   }
 
+  .nhsuk-input-wrapper__prefix,
+  // Deprecated, to be removed in v11.0
   .nhsuk-input__prefix {
     @include nhsuk-media-query($until: mobile) {
       border-bottom: 0;
@@ -152,6 +157,8 @@
   }
 
   // Split prefix/suffix onto separate lines on narrow screens
+  .nhsuk-input-wrapper__suffix,
+  // Deprecated, to be removed in v11.0
   .nhsuk-input__suffix {
     @include nhsuk-media-query($until: mobile) {
       border-top: 0;

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -82,7 +82,7 @@
 {%- endmacro -%}
 
 {%- macro _affixItem(affix, type) %}
-  <div class="nhsuk-input__{{ type }} {%- if affix.classes %} {{ affix.classes }}{% endif %}" aria-hidden="true" {{- nhsukAttributes(affix.attributes) }}>
+  <div class="nhsuk-input-wrapper__{{ type }} {%- if affix.classes %} {{ affix.classes }}{% endif %}" aria-hidden="true" {{- nhsukAttributes(affix.attributes) }}>
     {{- affix.html | safe | trim | indent(4) if affix.html else affix.text -}}
   </div>
 {%- endmacro -%}

--- a/packages/nhsuk-frontend/src/nhsuk/core/objects/_input-wrapper.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/objects/_input-wrapper.scss
@@ -3,6 +3,7 @@
 
 @include nhsuk-exports("nhsuk/core/objects/input-wrapper") {
   .nhsuk-input-wrapper,
+  // Deprecated, to be removed in v11.0
   .nhsuk-input__wrapper {
     display: flex;
 


### PR DESCRIPTION
## Description

HTML markup for the input component has been updated to align `nhsuk-input-wrapper` with other wrapping classes such as `nhsuk-main-wrapper` and `nhsuk-label-wrapper`

Following on from [#1643](https://github.com/nhsuk/nhsuk-frontend/pull/1643), this PR renames two more classes to [follow BEM](https://getbem.com) correctly:

* ~✅ `nhsuk-input__wrapper` → `nhsuk-input-wrapper`~ in [#1643](https://github.com/nhsuk/nhsuk-frontend/pull/1643)
* ✅ `nhsuk-input__prefix` → `nhsuk-input-wrapper__prefix`
* ✅ `nhsuk-input__suffix` → `nhsuk-input-wrapper__suffix`

These issues were first raised over in GOV.UK Frontend via:

* https://github.com/alphagov/govuk-frontend/issues/3071

The previous class names are deprecated and will be removed in a future release

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
