### PR TITLE
Sortable table tweaks

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/i18n.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/i18n.mjs
@@ -141,7 +141,7 @@ export class I18n {
   hasIntlPluralRulesSupport() {
     return Boolean(
       'PluralRules' in window.Intl &&
-        Intl.PluralRules.supportedLocalesOf(this.locale).length
+      Intl.PluralRules.supportedLocalesOf(this.locale).length
     )
   }
 


### PR DESCRIPTION
This suggests some tweaks to the work-in-progress sortable table design in #1654.

Main changes:

* fix for the bug where the click area doesn't match the hover colour area
* fix for bug showing hover colour on non-sortable column header
* updated with the latest link styles from #1367 (thicker underline and darker blue on hover)
* switch to the background hover colour from the Task list component (a lighter blue rather than light grey)
* the blue border on the bottom of the currently-sorted header column now only extends as far as the content in the column (which has a responsive padding on the right, except for the last column where it’s on the left)

The last bullet is perhaps the most experimental, as it means the blue border doesn't match the width of the hover colour, which looks a bit odd. However when not hovering it perhaps looks better as it matches the content instead of going right up to the next column?