### PR TITLE
Set default text colour for file upload drop button

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/_index.scss
@@ -115,8 +115,12 @@
     width: 100%;
     // align the padding to be same as notification banner and error summary accounting for the thicker borders
     padding: (nhsuk-spacing(3) + $nhsuk-border-width - $nhsuk-border-width-form-element);
+
     border: $nhsuk-border-width-form-element solid $_button-border-colour;
+
+    color: $nhsuk-text-colour;
     background-color: nhsuk-colour("white");
+
     cursor: pointer;
 
     @include nhsuk-media-query($from: tablet) {


### PR DESCRIPTION
## Description

This PR sets a default text colour for the file upload drop button

No changelog entry added as we've not released the file upload component yet

### Default button colours

Without this change we'd inherit `color: -apple-system-blue` on iOS

```css
input:is([type="button"], [type="submit"], [type="reset"]), input[type="file"]::file-selector-button, button {
  color: -apple-system-blue;
}
```

<img width="565" height="1068" alt="File upload on iOS showing default system blue for text" src="https://github.com/user-attachments/assets/1b649244-b52d-4fb4-a359-64bb289380b0" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
