### PR TITLE
Select enhancement - enable width options

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/select/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/_index.scss
@@ -88,6 +88,23 @@
     }
   }
 
+  // The ex measurements are based on the number of W's that can fit inside the input
+  // Extra space is left on the right hand side to allow for the down arrow icon
+
+  .nhsuk-select--width-30,
+  .nhsuk-select-wrapper--width-30 {
+    max-width: 56ex + 3ex;
+  }
+
+  .nhsuk-select--width-20,
+  .nhsuk-select-wrapper--width-20 {
+    max-width: 38ex + 3ex;
+  }
+
+  .nhsuk-select-wrapper--width-10 {
+    max-width: 20ex + 3ex;
+  }
+
   .nhsuk-select__button:has(~ .nhsuk-select__menu:not([hidden])),
   .nhsuk-form-group--error .nhsuk-select__button:focus,
   .nhsuk-select__input:has(~ .nhsuk-select__menu:not([hidden])),

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/fixtures.mjs
@@ -62,7 +62,27 @@ export const examples = {
           text: 'Last name (Z to A)'
         }
       ]
-    }
+    },
+    variants: [
+      {
+        description: 'with 10 character width',
+        context: {
+          classes: 'nhsuk-select--width-10'
+        }
+      },
+      {
+        description: 'with 20 character width',
+        context: {
+          classes: 'nhsuk-select--width-20'
+        }
+      },
+      {
+        description: 'with 30 character width',
+        context: {
+          classes: 'nhsuk-select--width-30'
+        }
+      }
+    ]
   },
   'with disabled item': {
     context: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/select.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/select.mjs
@@ -64,7 +64,21 @@ export class Select extends ConfigurableComponent {
 
     // Create and append a wrapper to contain input/button and menu
     const $wrapper = document.createElement('div')
-    $wrapper.className = 'nhsuk-select-wrapper'
+    $wrapper.classList.add('nhsuk-select-wrapper')
+
+    const $sizeClassMap = {
+      'nhsuk-select--width-10': 'nhsuk-select-wrapper--width-10',
+      'nhsuk-select--width-20': 'nhsuk-select-wrapper--width-20',
+      'nhsuk-select--width-30': 'nhsuk-select-wrapper--width-30'
+    }
+
+    // Add size class to wrapper if select has size class
+    for (const [selectClass, wrapperClass] of Object.entries($sizeClassMap)) {
+      if (this.$select.classList.contains(selectClass)) {
+        $wrapper.classList.add(wrapperClass)
+      }
+    }
+
     this.$wrapper = $wrapper
     this.$select.insertAdjacentElement('afterend', $wrapper)
 


### PR DESCRIPTION
This is a quick experiment to enhance #1700 by also allowing some custom widths to be set.

Right now the select is always intrinsically sized based on content, but in #1700 it always has `width: 100%`.

I suspect there will remain a need to have smaller sizes.

The code in this PR lets you set `classes: 'nhsuk-select--width-20'`, and then that class is copied to the wrapper class with javascript and transformed into `nhsuk-select-wrapper--width-20`.

This would mean that the width would apply to both no-js and the js-enhanced versions.

Currently I’ve only added 10, 20 and 30 size classes, rather than all the ones `input` supports.