### PR TITLE
Add prefix `preview-` to preview branch package version

### DIFF
--- a/bin/publish-preview.sh
+++ b/bin/publish-preview.sh
@@ -5,7 +5,7 @@ CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_VERSION=$(npm run version --silent --workspace nhsuk-frontend)
 
 BRANCH_NAME="preview-$CURRENT_BRANCH_NAME"
-VERSION="$CURRENT_VERSION-$CURRENT_BRANCH_NAME"
+VERSION="$CURRENT_VERSION-$BRANCH_NAME"
 
 # Build the package as normal
 echo "✨ Install and build branch preview"


### PR DESCRIPTION
## Description

This PR updates our `npx publish-preview` script to add `preview-` to the package version

```patch
- 11.0.0-sortable-table
+ 11.0.0-preview-sortable-table
```

This means we can update the prototype kit to allow `>=11.0.0-preview` branches

```patch
  "peerDependencies": {
    "express": "^5.2.0",
-   "nhsuk-frontend": "^10.3.1",
+   "nhsuk-frontend": "^10.3.1 || >=11.0.0-internal",
    "nunjucks": "^3.2.4"
  },
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
