### PR TITLE
For discussion: Allow tabs to work on mobile

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
@@ -46,87 +46,85 @@
 
   // NHS.UK frontend JavaScript enabled
   .nhsuk-frontend-supported {
-    @include nhsuk-media-query($from: tablet) {
-      .nhsuk-tabs__list {
+    .nhsuk-tabs__list {
+      margin-bottom: 0;
+      border-bottom: 1px solid $nhsuk-border-colour;
+      @include nhsuk-clearfix;
+    }
+
+    .nhsuk-tabs__title {
+      display: none;
+    }
+
+    .nhsuk-tabs__list-item {
+      position: relative;
+
+      margin-right: nhsuk-spacing(1);
+      margin-bottom: 0;
+      margin-left: 0;
+      padding: nhsuk-spacing(2) nhsuk-spacing(4);
+
+      float: left;
+
+      background-color: nhsuk-colour("grey-4");
+
+      text-align: center;
+
+      &::before {
+        content: none;
+      }
+    }
+
+    .nhsuk-tabs__list-item--selected {
+      $border-width: 1px;
+
+      position: relative;
+
+      margin-top: nhsuk-spacing(-1);
+
+      // Compensation for border (otherwise we get a shift)
+      margin-bottom: -$border-width;
+      padding-top: (nhsuk-spacing(2) * 1.5) - $border-width;
+      padding-right: nhsuk-spacing(4) - $border-width;
+      padding-bottom: (nhsuk-spacing(2) * 1.5) + $border-width;
+      padding-left: nhsuk-spacing(4) - $border-width;
+
+      border: $border-width solid $nhsuk-border-colour;
+      border-bottom: 0;
+
+      background-color: $nhsuk-card-background-colour;
+    }
+
+    .nhsuk-tabs__tab {
+      margin-bottom: 0;
+
+      @include nhsuk-link-style-text;
+
+      &::after {
+        content: "";
+
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    }
+
+    .nhsuk-tabs__panel {
+      padding: nhsuk-spacing(6) nhsuk-spacing(4);
+      border: 1px solid $nhsuk-border-colour;
+      border-top: 0;
+      background-color: $nhsuk-card-background-colour;
+      @include nhsuk-responsive-margin(0, "bottom");
+
+      & > :last-child {
         margin-bottom: 0;
-        border-bottom: 1px solid $nhsuk-border-colour;
-        @include nhsuk-clearfix;
       }
+    }
 
-      .nhsuk-tabs__title {
-        display: none;
-      }
-
-      .nhsuk-tabs__list-item {
-        position: relative;
-
-        margin-right: nhsuk-spacing(1);
-        margin-bottom: 0;
-        margin-left: 0;
-        padding: nhsuk-spacing(2) nhsuk-spacing(4);
-
-        float: left;
-
-        background-color: nhsuk-colour("grey-4");
-
-        text-align: center;
-
-        &::before {
-          content: none;
-        }
-      }
-
-      .nhsuk-tabs__list-item--selected {
-        $border-width: 1px;
-
-        position: relative;
-
-        margin-top: nhsuk-spacing(-1);
-
-        // Compensation for border (otherwise we get a shift)
-        margin-bottom: -$border-width;
-        padding-top: (nhsuk-spacing(2) * 1.5) - $border-width;
-        padding-right: nhsuk-spacing(4) - $border-width;
-        padding-bottom: (nhsuk-spacing(2) * 1.5) + $border-width;
-        padding-left: nhsuk-spacing(4) - $border-width;
-
-        border: $border-width solid $nhsuk-border-colour;
-        border-bottom: 0;
-
-        background-color: $nhsuk-card-background-colour;
-      }
-
-      .nhsuk-tabs__tab {
-        margin-bottom: 0;
-
-        @include nhsuk-link-style-text;
-
-        &::after {
-          content: "";
-
-          position: absolute;
-          top: 0;
-          right: 0;
-          bottom: 0;
-          left: 0;
-        }
-      }
-
-      .nhsuk-tabs__panel {
-        padding: nhsuk-spacing(6) nhsuk-spacing(4);
-        border: 1px solid $nhsuk-border-colour;
-        border-top: 0;
-        background-color: $nhsuk-card-background-colour;
-        @include nhsuk-responsive-margin(0, "bottom");
-
-        & > :last-child {
-          margin-bottom: 0;
-        }
-      }
-
-      .nhsuk-tabs__panel--hidden {
-        display: none;
-      }
+    .nhsuk-tabs__panel--hidden {
+      display: none;
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.mjs
@@ -59,47 +59,7 @@ export class Tabs extends ConfigurableComponent {
     this.$tabList = $tabList
     this.$tabListItems = $tabListItems
 
-    this.setupResponsiveChecks()
-  }
-
-  /**
-   * Setup viewport resize check
-   */
-  setupResponsiveChecks() {
-    const breakpoint = getBreakpoint('tablet')
-
-    if (!breakpoint.value) {
-      throw new ElementError({
-        component: Tabs,
-        identifier: `CSS custom property (\`${breakpoint.property}\`) on pseudo-class \`:root\``
-      })
-    }
-
-    // Media query list for NHS.UK frontend tablet breakpoint
-    this.mql = window.matchMedia(`(min-width: ${breakpoint.value})`)
-
-    // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
-    // to be able to fall back to the deprecated MediaQueryList.addListener
-    if ('addEventListener' in this.mql) {
-      this.mql.addEventListener('change', () => this.checkMode())
-    } else {
-      // @ts-expect-error Property 'addListener' does not exist
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      this.mql.addListener(() => this.checkMode())
-    }
-
-    this.checkMode()
-  }
-
-  /**
-   * Setup or teardown handler for viewport resize check
-   */
-  checkMode() {
-    if (this.mql?.matches) {
-      this.setup()
-    } else {
-      this.teardown()
-    }
+    this.setup()
   }
 
   /**


### PR DESCRIPTION
Currently the way our Tabs component is set up mirrors the way the [GOV.UK Tabs](https://design-system.service.gov.uk/components/tabs/) work.

That is, if JavaScript is unavailable OR you’re on a viewport below 641 pixels wide (mostly a mobile, or split-screen on a tablet or laptop), then you don’t see the visual tabs at all but instead see a "Contents" list of links, which are then anchor-linked to plain headings further down the page.

This is great from a progressive enhancement point of view for the no-JavaScript option, but can be unexpected on a mobile, where users might lose the ability to quick switch between tabs, and also face quite a long page.

One additional consideration is that in the GOVUK design system, both the tab panel background and the general page background is white. However in the NHS design system, the general page background is light grey but the tab panel background is white - so this means remembering to design the tab content to work on both background colours.

We could instead change the component so that the tab behaviour is also available on mobile sized screens. This would be particularly advantageous where the tabs are short enough to fit.

## Screenshots

| Before | After |
|--------|-------|
| <img width="265" height="547" alt="Screenshot 2026-02-24 at 12 23 05" src="https://github.com/user-attachments/assets/9aa625ff-3324-4734-bad1-e7256ab49252" /> | <img width="260" height="323" alt="Screenshot 2026-02-24 at 12 22 39" src="https://github.com/user-attachments/assets/65e10c87-e204-410f-b724-ccba326672a1" /> |

## What if they don’t fit?

The tricky bit is deciding what to do if the tabs don’t fit in a single row on your mobile-sized screen, either because you’ve got too many of them or the labels are too long.

Without any further modification, this looks broken:

<img width="264" height="394" alt="Screenshot 2026-02-24 at 12 34 41" src="https://github.com/user-attachments/assets/4b44cc0a-9565-409a-887b-e3dcaf96cabf" />

Possible solutions:

* accept that they’ll flow across multiple row, but tweak the design so that they all start at the left and look better
* as above, but also use JavaScript to dynamically switch the rows around so that the row with the active tab is always at the bottom (might be hard?)
* use JavaScript so that any tabs that don't fit get collapsed into a 'More' item, in the same way as the navigation in the main Header component
* allow horizontal scrolling, possibly with a fade to indicate that there is more to see (sounds crazy, but this is what the [Guardian](https://www.theguardian.com/uk) does) 
* something else?