### PR TITLE
Add service unavailable pages to review app

### DIFF
--- a/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable-planned.njk
+++ b/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable-planned.njk
@@ -1,0 +1,32 @@
+{% extends "layouts/page.njk" %}
+
+{% set pageName = "Sorry, the service is unavailable" %}
+
+{% block header %}
+  {{ header({
+    service: {
+      href: baseUrl,
+      text: "Service name"
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <div class="nhsuk-u-reading-width nhsuk-u-margin-bottom-9">
+        <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
+
+        <p>You will be able to use the service from 9am on Monday 14 December 2025.</p>
+
+        <p>Contact the hospital if you need to cancel an appointment.</p>
+      </div>
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ footer() }}
+{% endblock %}

--- a/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable-updates.njk
+++ b/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable-updates.njk
@@ -1,0 +1,41 @@
+{% extends "layouts/page.njk" %}
+
+{% set pageName = "Sorry, the service is unavailable" %}
+
+{% block header %}
+  {{ header({
+    service: {
+      href: baseUrl,
+      text: "Service name"
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <div class="nhsuk-u-reading-width nhsuk-u-margin-bottom-9">
+        <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
+
+        <p>The service is experiencing a technical issue. It will be fixed as soon as possible.</p>
+
+        <p>Progress updates will be added to this page.</p>
+
+        {% set insetTextHtml %}
+          <h2 class="nhsuk-heading-s">1:11pm, Thursday 26 February 2026</h2>
+          <p>We have identified the underlying cause of the issue and are working to fix it.</p>
+        {% endset %}
+
+        {{ insetText({
+          html: insetTextHtml
+        }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ footer() }}
+{% endblock %}

--- a/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable.njk
+++ b/packages/nhsuk-frontend-review/src/examples/full-page/service-unavailable.njk
@@ -1,0 +1,30 @@
+{% extends "layouts/page.njk" %}
+
+{% set pageName = "Sorry, the service is unavailable" %}
+
+{% block header %}
+  {{ header({
+    service: {
+      href: baseUrl,
+      text: "Service name"
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      <div class="nhsuk-u-reading-width nhsuk-u-margin-bottom-9">
+        <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
+
+        <p>Contact the hospital if you need to cancel an appointment.</p>
+      </div>
+
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ footer() }}
+{% endblock %}

--- a/packages/nhsuk-frontend-review/src/index.njk
+++ b/packages/nhsuk-frontend-review/src/index.njk
@@ -41,6 +41,9 @@
           <h3 class="nhsuk-heading-m">Full pages</h3>
 
           <ul class="nhsuk-list">
+            <li><a href="examples/full-page/service-unavailable/">Service unavailable</a></li>
+            <li><a href="examples/full-page/service-unavailable-planned/">Service unavailable (planned)</a></li>
+            <li><a href="examples/full-page/service-unavailable-updates/">Service unavailable (updates)</a></li>
             <li><a href="examples/full-page/update-your-account-details/">Update your account details</a></li>
           </ul>
 


### PR DESCRIPTION
## Description

This PR adds the service unavailable full page examples from https://github.com/nhsuk/nhsuk-service-manual/pull/2387

* [Service unavailable](https://nhsuk-frontend-pr-1838.herokuapp.com/nhsuk-frontend/examples/full-page/service-unavailable/)
* [Service unavailable (planned)](https://nhsuk-frontend-pr-1838.herokuapp.com/nhsuk-frontend/examples/full-page/service-unavailable-planned/)
* [Service unavailable (updates)](https://nhsuk-frontend-pr-1838.herokuapp.com/nhsuk-frontend/examples/full-page/service-unavailable-updates/)

Todo: Build step to output standalone version

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
