### PR TITLE
[v10] Add Puppeteer test `initExample()` and prefer test helpers

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -129,79 +129,15 @@ describe('Button', () => {
     })
   })
 
-  describe('preventing double clicks', () => {
-    describe('using data-attributes', () => {
-      beforeEach(async () => {
-        await initExample('with double click prevented')
-      })
-
-      it('prevents unintentional clicks', async () => {
-        await $component.click({
-          count: 2
-        })
-
-        await expect(getButtonTracking()).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 1
-        })
-      })
-
-      it('does not prevent intentional multiple clicks', async () => {
-        await $component.click({
-          count: 2,
-          delay: debouncedWaitTime
-        })
-
-        await expect(getButtonTracking()).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 0
-        })
-      })
-
-      it('does not prevent subsequent clicks on different buttons', async () => {
-        $component.evaluate(($el) =>
-          $el.parentNode?.appendChild($el.cloneNode(true))
-        )
-
-        // Locate original and cloned button
-        const $button1 = await setButtonTracking(
-          await page.$('button:nth-child(1)')
-        )
-
-        const $button2 = await setButtonTracking(
-          await page.$('button:nth-child(2)')
-        )
-
-        await $button1.click({
-          count: 2
-        })
-
-        await $button2.click()
-
-        // 2nd click on button 1 prevented
-        await expect(getButtonTracking($button1)).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 1
-        })
-
-        // 3rd click on button 2 not prevented
-        await expect(getButtonTracking($button2)).resolves.toMatchObject({
-          clicked: 1,
-          prevented: 0
-        })
-      })
-    })
-
-    describe('using JavaScript configuration', () => {
-      beforeEach(async () => {
+  describe('JavaScript configuration', () => {
+    describe('during initialisation', () => {
+      it("configures 'preventDoubleClick: true' to prevent double clicks", async () => {
         await initExample('default', {
           config: {
             preventDoubleClick: true
           }
         })
-      })
 
-      it('prevents unintentional clicks', async () => {
         await $component.click({
           count: 2
         })
@@ -212,7 +148,13 @@ describe('Button', () => {
         })
       })
 
-      it('does not prevent intentional multiple clicks', async () => {
+      it("configures 'preventDoubleClick: true' but allows multiple intentional clicks", async () => {
+        await initExample('default', {
+          config: {
+            preventDoubleClick: true
+          }
+        })
+
         await $component.click({
           count: 2,
           delay: debouncedWaitTime
@@ -224,7 +166,13 @@ describe('Button', () => {
         })
       })
 
-      it('does not prevent subsequent clicks on different buttons', async () => {
+      it("configures 'preventDoubleClick: true' to prevent double clicks (configured button only)", async () => {
+        await initExample('default', {
+          config: {
+            preventDoubleClick: true
+          }
+        })
+
         $component.evaluate(($el) =>
           $el.parentNode?.appendChild($el.cloneNode(true))
         )
@@ -256,18 +204,57 @@ describe('Button', () => {
           prevented: 0
         })
       })
+
+      it("configures 'preventDoubleClick: false' to explicitly allow double clicks", async () => {
+        await initExample('default', {
+          config: {
+            preventDoubleClick: false
+          }
+        })
+
+        await $component.click()
+        await $component.click()
+
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
+      })
     })
 
-    describe('using JavaScript configuration, but cancelled by data-attributes', () => {
-      beforeEach(async () => {
+    describe('with HTML data attributes', () => {
+      it("configures 'preventDoubleClick: true' to prevent double clicks", async () => {
+        await initExample('with double click prevented')
+        await $component.click({
+          count: 2
+        })
+
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
+      })
+
+      it("configures 'preventDoubleClick: true' but allows multiple intentional clicks", async () => {
+        await initExample('with double click prevented')
+        await $component.click({
+          count: 2,
+          delay: debouncedWaitTime
+        })
+
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
+      })
+
+      it('uses `preventDoubleClick` data attribute instead of JavaScript `preventDoubleClick`', async () => {
         await initExample('with double click not prevented', {
           config: {
             preventDoubleClick: true
           }
         })
-      })
 
-      it('does not prevent multiple clicks', async () => {
         await $component.click({
           count: 2
         })
@@ -278,141 +265,75 @@ describe('Button', () => {
         })
       })
     })
+  })
 
-    describe('using `initAll`', () => {
-      beforeEach(async () => {
-        await initExample('default', {
-          config: {
-            preventDoubleClick: true
+  describe('Error handling', () => {
+    it('can throw a SupportError if appropriate', () => {
+      return expect(
+        initExample('default', {
+          beforeInitialisation() {
+            document.body.classList.remove('nhsuk-frontend-supported')
           }
         })
-      })
-
-      it('prevents unintentional clicks', async () => {
-        await $component.click({
-          count: 2
-        })
-
-        await expect(getButtonTracking()).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 1
-        })
-      })
-
-      it('does not prevent intentional multiple clicks', async () => {
-        await $component.click({
-          count: 2,
-          delay: debouncedWaitTime
-        })
-
-        await expect(getButtonTracking()).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 0
-        })
-      })
-
-      it('does not prevent subsequent clicks on different buttons', async () => {
-        $component.evaluate(($el) =>
-          $el.parentNode?.appendChild($el.cloneNode(true))
-        )
-
-        // Locate original and cloned button
-        const $button1 = await setButtonTracking(
-          await page.$('button:nth-child(1)')
-        )
-
-        const $button2 = await setButtonTracking(
-          await page.$('button:nth-child(2)')
-        )
-
-        await $button1.click({
-          count: 2
-        })
-
-        await $button2.click()
-
-        // 2nd click on button 1 prevented
-        await expect(getButtonTracking($button1)).resolves.toMatchObject({
-          clicked: 2,
-          prevented: 1
-        })
-
-        // 3rd click on button 2 not prevented
-        await expect(getButtonTracking($button2)).resolves.toMatchObject({
-          clicked: 1,
-          prevented: 0
-        })
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'SupportError',
+          message:
+            'NHS.UK frontend initialised without `<body class="nhsuk-frontend-supported">` from template `<script>` snippet'
+        }
       })
     })
 
-    describe('Error handling', () => {
-      it('can throw a SupportError if appropriate', () => {
-        return expect(
-          initExample('default', {
-            beforeInitialisation() {
-              document.body.classList.remove('nhsuk-frontend-supported')
-            }
-          })
-        ).rejects.toMatchObject({
-          cause: {
-            name: 'SupportError',
-            message:
-              'NHS.UK frontend initialised without `<body class="nhsuk-frontend-supported">` from template `<script>` snippet'
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
+          async afterInitialisation($root) {
+            const { Button } = await import('nhsuk-frontend')
+            new Button($root)
           }
         })
+      ).rejects.toMatchObject({
+        name: 'InitError',
+        message: 'nhsuk-button: Root element (`$root`) already initialised'
       })
+    })
 
-      it('throws when initialised twice', () => {
-        return expect(
-          initExample('default', {
-            async afterInitialisation($root) {
-              const { Button } = await import('nhsuk-frontend')
-              new Button($root)
-            }
-          })
-        ).rejects.toMatchObject({
-          name: 'InitError',
-          message: 'nhsuk-button: Root element (`$root`) already initialised'
-        })
-      })
-
-      it('throws when $root is not set', () => {
-        return expect(
-          initExample('default', {
-            beforeInitialisation($root) {
-              $root.remove()
-            }
-          })
-        ).rejects.toMatchObject({
-          cause: {
-            name: 'ElementError',
-            message: 'nhsuk-button: Root element (`$root`) not found'
+    it('throws when $root is not set', () => {
+      return expect(
+        initExample('default', {
+          beforeInitialisation($root) {
+            $root.remove()
           }
         })
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'nhsuk-button: Root element (`$root`) not found'
+        }
       })
+    })
 
-      it('throws when receiving the wrong type for $root', () => {
-        return expect(
-          initExample('default', {
-            beforeInitialisation($root) {
-              const $svg = document.createElementNS(
-                'http://www.w3.org/2000/svg',
-                'svg'
-              )
+    it('throws when receiving the wrong type for $root', () => {
+      return expect(
+        initExample('default', {
+          beforeInitialisation($root) {
+            const $svg = document.createElementNS(
+              'http://www.w3.org/2000/svg',
+              'svg'
+            )
 
-              $svg.setAttribute('data-module', 'nhsuk-button')
+            $svg.setAttribute('data-module', 'nhsuk-button')
 
-              // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $root.replaceWith($svg)
-            }
-          })
-        ).rejects.toMatchObject({
-          cause: {
-            name: 'ElementError',
-            message:
-              'nhsuk-button: Root element (`$root`) is not of type HTMLElement'
+            // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
+            $root.replaceWith($svg)
           }
         })
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'nhsuk-button: Root element (`$root`) is not of type HTMLElement'
+        }
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -26,16 +26,76 @@ describe('Button', () => {
     )
   }
 
+  /**
+   * Sets the number of times a button was clicked
+   *
+   * @param {ElementHandle<HTMLElement> | null} [$button] - Puppeteer button element
+   * @returns {Promise<ElementHandle<HTMLElement>>} Puppeteer button element
+   */
+  async function setButtonTracking($button = $component) {
+    if (!$button) {
+      throw new TypeError('Button is not defined')
+    }
+
+    const counts = {
+      click: 0,
+      debounce: 0
+    }
+
+    // Track number of button clicks
+    await $button.evaluate(($el, counts) => {
+      $el.addEventListener(
+        'click',
+        (event) => {
+          counts.click++
+          $el.dataset.clickCount = `${counts.click}`
+
+          // Track number of button clicks that debounced
+          event.preventDefault = () => {
+            counts.debounce++
+            $el.dataset.debounceCount = `${counts.debounce}`
+          }
+        },
+        // Add listener during capture phase to spy on event
+        { capture: true }
+      )
+    }, counts)
+
+    return $button
+  }
+
+  /**
+   * Gets the number of times the button was clicked
+   *
+   * @param {ElementHandle<HTMLElement>} [$button] - Puppeteer button element
+   * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
+   */
+  function getButtonTracking($button = $component) {
+    return $button.evaluate(($el) => ({
+      click: parseInt($el.dataset.clickCount ?? '0'),
+      debounce: parseInt($el.dataset.debounceCount ?? '0')
+    }))
+  }
+
   describe('Button as a link', () => {
     beforeEach(async () => {
       await initExample('as a link')
     })
 
-    it('triggers the click event when the space key is pressed', async () => {
-      const $button = /** @type {ElementHandle<HTMLAnchorElement>} */ (
-        await page.$('a.nhsuk-button')
-      )
+    it('does not prevent double clicks by default', async () => {
+      await setButtonTracking()
 
+      await $component.click()
+      await $component.click()
+
+      const counts = await getButtonTracking()
+
+      expect(counts.click).toBe(2)
+      expect(counts.debounce).toBe(0)
+    })
+
+    it('triggers the click event when the space key is pressed', async () => {
+      const $button = await $component.toElement('a')
       await $button.focus()
 
       // we need to start the waitForNavigation() before the keyboard action
@@ -53,78 +113,25 @@ describe('Button', () => {
     })
   })
 
-  describe('preventing double clicks', () => {
-    /**
-     * Sets the number of times a button was clicked
-     *
-     * @param {ElementHandle<HTMLElement> | null} [$button] - Puppeteer button element
-     * @returns {Promise<ElementHandle<HTMLElement>>} Puppeteer button element
-     */
-    async function setButtonTracking($button = $component) {
-      if (!$button) {
-        throw new TypeError('Button is not defined')
-      }
-
-      const counts = {
-        click: 0,
-        debounce: 0
-      }
-
-      // Track number of button clicks
-      await $button.evaluate(
-        ($el, counts) =>
-          $el.addEventListener(
-            'click',
-            (event) => {
-              counts.click++
-              $el.dataset.clickCount = `${counts.click}`
-
-              // Track number of button clicks that debounced
-              event.preventDefault = () => {
-                counts.debounce++
-                $el.dataset.debounceCount = `${counts.debounce}`
-              }
-
-              // Add listener during capture phase to spy on event
-            },
-            { capture: true }
-          ),
-        counts
-      )
-
-      return $button
-    }
-
-    /**
-     * Gets the number of times the button was clicked
-     *
-     * @param {ElementHandle<HTMLElement>} [$button] - Puppeteer button element
-     * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
-     */
-    function getButtonTracking($button = $component) {
-      return $button.evaluate(($el) => ({
-        click: parseInt($el.dataset.clickCount ?? '0'),
-        debounce: parseInt($el.dataset.debounceCount ?? '0')
-      }))
-    }
-
-    describe('not enabled', () => {
-      beforeEach(async () => {
-        await initExample('default')
-        await setButtonTracking()
-      })
-
-      it('does not prevent multiple submissions', async () => {
-        await $component.click()
-        await $component.click()
-
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(0)
-      })
+  describe('Button as a button', () => {
+    beforeEach(async () => {
+      await initExample('default')
     })
 
+    it('does not prevent double clicks by default', async () => {
+      await setButtonTracking()
+
+      await $component.click()
+      await $component.click()
+
+      const counts = await getButtonTracking()
+
+      expect(counts.click).toBe(2)
+      expect(counts.debounce).toBe(0)
+    })
+  })
+
+  describe('preventing double clicks', () => {
     describe('using data-attributes', () => {
       beforeEach(async () => {
         await initExample('with double click prevented')

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -131,7 +131,7 @@ describe('Button', () => {
 
   describe('JavaScript configuration', () => {
     describe('during initialisation', () => {
-      it("configures 'preventDoubleClick: true' to prevent double clicks", async () => {
+      it('configures `preventDoubleClick: true` to prevent double clicks', async () => {
         await initExample('default', {
           config: {
             preventDoubleClick: true
@@ -148,7 +148,7 @@ describe('Button', () => {
         })
       })
 
-      it("configures 'preventDoubleClick: true' but allows multiple intentional clicks", async () => {
+      it('configures `preventDoubleClick: true` but allows multiple intentional clicks', async () => {
         await initExample('default', {
           config: {
             preventDoubleClick: true
@@ -166,7 +166,7 @@ describe('Button', () => {
         })
       })
 
-      it("configures 'preventDoubleClick: true' to prevent double clicks (configured button only)", async () => {
+      it('configures `preventDoubleClick: true` to prevent double clicks (configured button only)', async () => {
         await initExample('default', {
           config: {
             preventDoubleClick: true
@@ -205,7 +205,7 @@ describe('Button', () => {
         })
       })
 
-      it("configures 'preventDoubleClick: false' to explicitly allow double clicks", async () => {
+      it('configures `preventDoubleClick: false` to explicitly allow double clicks', async () => {
         await initExample('default', {
           config: {
             preventDoubleClick: false
@@ -223,7 +223,7 @@ describe('Button', () => {
     })
 
     describe('with HTML data attributes', () => {
-      it("configures 'preventDoubleClick: true' to prevent double clicks", async () => {
+      it('configures `preventDoubleClick: true` to prevent double clicks', async () => {
         await initExample('with double click prevented')
         await $component.click({
           count: 2
@@ -235,7 +235,7 @@ describe('Button', () => {
         })
       })
 
-      it("configures 'preventDoubleClick: true' but allows multiple intentional clicks", async () => {
+      it('configures `preventDoubleClick: true` but allows multiple intentional clicks', async () => {
         await initExample('with double click prevented')
         await $component.click({
           count: 2,

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -24,6 +24,8 @@ describe('Button', () => {
     $component = /** @type {ElementHandle<HTMLElement>} */ (
       await page.$(`[data-module="${Button.moduleName}"]`)
     )
+
+    await setButtonTracking()
   }
 
   /**
@@ -38,8 +40,8 @@ describe('Button', () => {
     }
 
     const counts = {
-      click: 0,
-      debounce: 0
+      clicked: 0,
+      prevented: 0
     }
 
     // Track number of button clicks
@@ -47,13 +49,13 @@ describe('Button', () => {
       $el.addEventListener(
         'click',
         (event) => {
-          counts.click++
-          $el.dataset.clickCount = `${counts.click}`
+          counts.clicked++
+          $el.dataset.clickedCount = `${counts.clicked}`
 
           // Track number of button clicks that debounced
           event.preventDefault = () => {
-            counts.debounce++
-            $el.dataset.debounceCount = `${counts.debounce}`
+            counts.prevented++
+            $el.dataset.preventedCount = `${counts.prevented}`
           }
         },
         // Add listener during capture phase to spy on event
@@ -68,12 +70,12 @@ describe('Button', () => {
    * Gets the number of times the button was clicked
    *
    * @param {ElementHandle<HTMLElement>} [$button] - Puppeteer button element
-   * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
+   * @returns {Promise<{ clicked: number; prevented: number; }>} Number of times the button was clicked
    */
   function getButtonTracking($button = $component) {
     return $button.evaluate(($el) => ({
-      click: parseInt($el.dataset.clickCount ?? '0'),
-      debounce: parseInt($el.dataset.debounceCount ?? '0')
+      clicked: parseInt($el.dataset.clickedCount ?? '0'),
+      prevented: parseInt($el.dataset.preventedCount ?? '0')
     }))
   }
 
@@ -83,15 +85,13 @@ describe('Button', () => {
     })
 
     it('does not prevent double clicks by default', async () => {
-      await setButtonTracking()
-
       await $component.click()
       await $component.click()
 
-      const counts = await getButtonTracking()
-
-      expect(counts.click).toBe(2)
-      expect(counts.debounce).toBe(0)
+      await expect(getButtonTracking()).resolves.toMatchObject({
+        clicked: 2,
+        prevented: 0
+      })
     })
 
     it('triggers the click event when the space key is pressed', async () => {
@@ -119,15 +119,13 @@ describe('Button', () => {
     })
 
     it('does not prevent double clicks by default', async () => {
-      await setButtonTracking()
-
       await $component.click()
       await $component.click()
 
-      const counts = await getButtonTracking()
-
-      expect(counts.click).toBe(2)
-      expect(counts.debounce).toBe(0)
+      await expect(getButtonTracking()).resolves.toMatchObject({
+        clicked: 2,
+        prevented: 0
+      })
     })
   })
 
@@ -135,25 +133,24 @@ describe('Button', () => {
     describe('using data-attributes', () => {
       beforeEach(async () => {
         await initExample('with double click prevented')
-        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
         await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(1)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
       })
 
       it('does not prevent intentional multiple clicks', async () => {
         await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(0)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
@@ -173,16 +170,17 @@ describe('Button', () => {
         await $button1.click({ count: 2 })
         await $button2.click()
 
-        const button1Counts = await getButtonTracking($button1)
-        const button2Counts = await getButtonTracking($button2)
-
         // 2nd click on button 1 prevented
-        expect(button1Counts.click).toBe(2)
-        expect(button1Counts.debounce).toBe(1)
+        await expect(getButtonTracking($button1)).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
 
         // 3rd click on button 2 not prevented
-        expect(button2Counts.click).toBe(1)
-        expect(button2Counts.debounce).toBe(0)
+        await expect(getButtonTracking($button2)).resolves.toMatchObject({
+          clicked: 1,
+          prevented: 0
+        })
       })
     })
 
@@ -193,26 +191,24 @@ describe('Button', () => {
             preventDoubleClick: true
           }
         })
-
-        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
         await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(1)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
       })
 
       it('does not prevent intentional multiple clicks', async () => {
         await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(0)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
@@ -232,16 +228,17 @@ describe('Button', () => {
         await $button1.click({ count: 2 })
         await $button2.click()
 
-        const button1Counts = await getButtonTracking($button1)
-        const button2Counts = await getButtonTracking($button2)
-
         // 2nd click on button 1 prevented
-        expect(button1Counts.click).toBe(2)
-        expect(button1Counts.debounce).toBe(1)
+        await expect(getButtonTracking($button1)).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
 
         // 3rd click on button 2 not prevented
-        expect(button2Counts.click).toBe(1)
-        expect(button2Counts.debounce).toBe(0)
+        await expect(getButtonTracking($button2)).resolves.toMatchObject({
+          clicked: 1,
+          prevented: 0
+        })
       })
     })
 
@@ -252,17 +249,15 @@ describe('Button', () => {
             preventDoubleClick: true
           }
         })
-
-        await setButtonTracking()
       })
 
       it('does not prevent multiple clicks', async () => {
         await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(0)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
       })
     })
 
@@ -273,26 +268,24 @@ describe('Button', () => {
             preventDoubleClick: true
           }
         })
-
-        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
         await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(1)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
       })
 
       it('does not prevent intentional multiple clicks', async () => {
         await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking()
-
-        expect(counts.click).toBe(2)
-        expect(counts.debounce).toBe(0)
+        await expect(getButtonTracking()).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 0
+        })
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
@@ -312,16 +305,17 @@ describe('Button', () => {
         await $button1.click({ count: 2 })
         await $button2.click()
 
-        const button1Counts = await getButtonTracking($button1)
-        const button2Counts = await getButtonTracking($button2)
-
         // 2nd click on button 1 prevented
-        expect(button1Counts.click).toBe(2)
-        expect(button1Counts.debounce).toBe(1)
+        await expect(getButtonTracking($button1)).resolves.toMatchObject({
+          clicked: 2,
+          prevented: 1
+        })
 
         // 3rd click on button 2 not prevented
-        expect(button2Counts.click).toBe(1)
-        expect(button2Counts.debounce).toBe(0)
+        await expect(getButtonTracking($button2)).resolves.toMatchObject({
+          clicked: 1,
+          prevented: 0
+        })
       })
     })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -325,7 +325,7 @@ describe('Button', () => {
       })
     })
 
-    describe('errors at instantiation', () => {
+    describe('Error handling', () => {
       it('can throw a SupportError if appropriate', () => {
         return expect(
           initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -136,7 +136,9 @@ describe('Button', () => {
       })
 
       it('prevents unintentional clicks', async () => {
-        await $component.click({ count: 2 })
+        await $component.click({
+          count: 2
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -145,7 +147,10 @@ describe('Button', () => {
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $component.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({
+          count: 2,
+          delay: debouncedWaitTime
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -167,7 +172,10 @@ describe('Button', () => {
           await page.$('button:nth-child(2)')
         )
 
-        await $button1.click({ count: 2 })
+        await $button1.click({
+          count: 2
+        })
+
         await $button2.click()
 
         // 2nd click on button 1 prevented
@@ -194,7 +202,9 @@ describe('Button', () => {
       })
 
       it('prevents unintentional clicks', async () => {
-        await $component.click({ count: 2 })
+        await $component.click({
+          count: 2
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -203,7 +213,10 @@ describe('Button', () => {
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $component.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({
+          count: 2,
+          delay: debouncedWaitTime
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -225,7 +238,10 @@ describe('Button', () => {
           await page.$('button:nth-child(2)')
         )
 
-        await $button1.click({ count: 2 })
+        await $button1.click({
+          count: 2
+        })
+
         await $button2.click()
 
         // 2nd click on button 1 prevented
@@ -252,7 +268,9 @@ describe('Button', () => {
       })
 
       it('does not prevent multiple clicks', async () => {
-        await $component.click({ count: 2 })
+        await $component.click({
+          count: 2
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -271,7 +289,9 @@ describe('Button', () => {
       })
 
       it('prevents unintentional clicks', async () => {
-        await $component.click({ count: 2 })
+        await $component.click({
+          count: 2
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -280,7 +300,10 @@ describe('Button', () => {
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $component.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({
+          count: 2,
+          delay: debouncedWaitTime
+        })
 
         await expect(getButtonTracking()).resolves.toMatchObject({
           clicked: 2,
@@ -302,7 +325,10 @@ describe('Button', () => {
           await page.$('button:nth-child(2)')
         )
 
-        await $button1.click({ count: 2 })
+        await $button1.click({
+          count: 2
+        })
+
         await $button2.click()
 
         // 2nd click on button 1 prevented

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -1,25 +1,42 @@
-import { render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import { getProperty, render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
+import { Button } from './button.mjs'
 import { examples } from './fixtures.mjs'
 
 describe('Button', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
   const clickTimeoutTime = 1000 // ms
 
   // The longest possible time a button will ignore unintentional clicks for
   // until it can be clicked again (+ 100ms to stay outside the total wait time)
   const debouncedWaitTime = clickTimeoutTime + 100
 
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'button', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${Button.moduleName}"]`)
+    )
+  }
+
   describe('Button as a link', () => {
     beforeEach(async () => {
-      await render(page, 'button', examples['as a link'])
+      await initExample('as a link')
     })
 
     it('triggers the click event when the space key is pressed', async () => {
-      const href = await page.evaluate(
-        () => document.body.querySelector('a.nhsuk-button')?.href
+      const $button = /** @type {ElementHandle<HTMLAnchorElement>} */ (
+        await page.$('a.nhsuk-button')
       )
 
-      await page.focus('a[role="button"]')
+      await $button.focus()
 
       // we need to start the waitForNavigation() before the keyboard action
       // so we return a promise that is fulfilled when the navigation and the keyboard action are
@@ -30,8 +47,9 @@ describe('Button', () => {
         page.keyboard.press('Space')
       ])
 
-      const url = new URL(page.url())
-      expect(url.href).toBe(href)
+      const href = await getProperty($button, 'href')
+
+      expect(href).toBe(page.url())
     })
   })
 
@@ -39,10 +57,10 @@ describe('Button', () => {
     /**
      * Sets the number of times a button was clicked
      *
-     * @param {ElementHandle<HTMLButtonElement> | null} $button - Puppeteer button element
-     * @returns {Promise<ElementHandle<HTMLButtonElement>>} Puppeteer button element
+     * @param {ElementHandle<HTMLElement> | null} [$button] - Puppeteer button element
+     * @returns {Promise<ElementHandle<HTMLElement>>} Puppeteer button element
      */
-    async function setButtonTracking($button) {
+    async function setButtonTracking($button = $component) {
       if (!$button) {
         throw new TypeError('Button is not defined')
       }
@@ -54,17 +72,17 @@ describe('Button', () => {
 
       // Track number of button clicks
       await $button.evaluate(
-        (el, counts) =>
-          el.addEventListener(
+        ($el, counts) =>
+          $el.addEventListener(
             'click',
             (event) => {
               counts.click++
-              el.dataset.clickCount = `${counts.click}`
+              $el.dataset.clickCount = `${counts.click}`
 
               // Track number of button clicks that debounced
               event.preventDefault = () => {
                 counts.debounce++
-                el.dataset.debounceCount = `${counts.debounce}`
+                $el.dataset.debounceCount = `${counts.debounce}`
               }
 
               // Add listener during capture phase to spy on event
@@ -80,30 +98,27 @@ describe('Button', () => {
     /**
      * Gets the number of times the button was clicked
      *
-     * @param {ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
+     * @param {ElementHandle<HTMLElement>} [$button] - Puppeteer button element
      * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
      */
-    function getButtonTracking($button) {
-      return $button.evaluate((el) => ({
-        click: parseInt(el.dataset.clickCount ?? '0'),
-        debounce: parseInt(el.dataset.debounceCount ?? '0')
+    function getButtonTracking($button = $component) {
+      return $button.evaluate(($el) => ({
+        click: parseInt($el.dataset.clickCount ?? '0'),
+        debounce: parseInt($el.dataset.debounceCount ?? '0')
       }))
     }
 
     describe('not enabled', () => {
-      /** @type {ElementHandle<HTMLButtonElement>} */
-      let $button
-
       beforeEach(async () => {
-        await render(page, 'button', examples.default)
-        $button = await setButtonTracking(await page.$('button'))
+        await initExample('default')
+        await setButtonTracking()
       })
 
       it('does not prevent multiple submissions', async () => {
-        await $button.click()
-        await $button.click()
+        await $component.click()
+        await $component.click()
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(0)
@@ -111,39 +126,39 @@ describe('Button', () => {
     })
 
     describe('using data-attributes', () => {
-      /** @type {ElementHandle<HTMLButtonElement>} */
-      let $button
-
       beforeEach(async () => {
-        await render(page, 'button', examples['with double click prevented'])
-        $button = await setButtonTracking(await page.$('button'))
+        await initExample('with double click prevented')
+        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
-        await $button.click({ count: 2 })
+        await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(1)
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $button.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(0)
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
-        $button.evaluate((el) => el.parentNode?.appendChild(el.cloneNode(true)))
+        $component.evaluate(($el) =>
+          $el.parentNode?.appendChild($el.cloneNode(true))
+        )
 
         // Locate original and cloned button
         const $button1 = await setButtonTracking(
           await page.$('button:nth-child(1)')
         )
+
         const $button2 = await setButtonTracking(
           await page.$('button:nth-child(2)')
         )
@@ -165,44 +180,44 @@ describe('Button', () => {
     })
 
     describe('using JavaScript configuration', () => {
-      /** @type {ElementHandle<HTMLButtonElement>} */
-      let $button
-
       beforeEach(async () => {
-        await render(page, 'button', examples.default, {
+        await initExample('default', {
           config: {
             preventDoubleClick: true
           }
         })
 
-        $button = await setButtonTracking(await page.$('button'))
+        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
-        await $button.click({ count: 2 })
+        await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(1)
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $button.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(0)
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
-        $button.evaluate((el) => el.parentNode?.appendChild(el.cloneNode(true)))
+        $component.evaluate(($el) =>
+          $el.parentNode?.appendChild($el.cloneNode(true))
+        )
 
         // Locate original and cloned button
         const $button1 = await setButtonTracking(
           await page.$('button:nth-child(1)')
         )
+
         const $button2 = await setButtonTracking(
           await page.$('button:nth-child(2)')
         )
@@ -224,28 +239,20 @@ describe('Button', () => {
     })
 
     describe('using JavaScript configuration, but cancelled by data-attributes', () => {
-      /** @type {ElementHandle<HTMLButtonElement>} */
-      let $button
-
       beforeEach(async () => {
-        await render(
-          page,
-          'button',
-          examples['with double click not prevented'],
-          {
-            config: {
-              preventDoubleClick: true
-            }
+        await initExample('with double click not prevented', {
+          config: {
+            preventDoubleClick: true
           }
-        )
+        })
 
-        $button = await setButtonTracking(await page.$('button'))
+        await setButtonTracking()
       })
 
       it('does not prevent multiple clicks', async () => {
-        await $button.click({ count: 2 })
+        await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(0)
@@ -253,44 +260,44 @@ describe('Button', () => {
     })
 
     describe('using `initAll`', () => {
-      /** @type {ElementHandle<HTMLButtonElement>} */
-      let $button
-
       beforeEach(async () => {
-        await render(page, 'button', examples.default, {
+        await initExample('default', {
           config: {
             preventDoubleClick: true
           }
         })
 
-        $button = await setButtonTracking(await page.$('button'))
+        await setButtonTracking()
       })
 
       it('prevents unintentional clicks', async () => {
-        await $button.click({ count: 2 })
+        await $component.click({ count: 2 })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(1)
       })
 
       it('does not prevent intentional multiple clicks', async () => {
-        await $button.click({ count: 2, delay: debouncedWaitTime })
+        await $component.click({ count: 2, delay: debouncedWaitTime })
 
-        const counts = await getButtonTracking($button)
+        const counts = await getButtonTracking()
 
         expect(counts.click).toBe(2)
         expect(counts.debounce).toBe(0)
       })
 
       it('does not prevent subsequent clicks on different buttons', async () => {
-        $button.evaluate((el) => el.parentNode?.appendChild(el.cloneNode(true)))
+        $component.evaluate(($el) =>
+          $el.parentNode?.appendChild($el.cloneNode(true))
+        )
 
         // Locate original and cloned button
         const $button1 = await setButtonTracking(
           await page.$('button:nth-child(1)')
         )
+
         const $button2 = await setButtonTracking(
           await page.$('button:nth-child(2)')
         )
@@ -312,9 +319,9 @@ describe('Button', () => {
     })
 
     describe('errors at instantiation', () => {
-      it('can throw a SupportError if appropriate', async () => {
-        await expect(
-          render(page, 'button', examples.default, {
+      it('can throw a SupportError if appropriate', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation() {
               document.body.classList.remove('nhsuk-frontend-supported')
             }
@@ -328,9 +335,9 @@ describe('Button', () => {
         })
       })
 
-      it('throws when initialised twice', async () => {
-        await expect(
-          render(page, 'button', examples.default, {
+      it('throws when initialised twice', () => {
+        return expect(
+          initExample('default', {
             async afterInitialisation($root) {
               const { Button } = await import('nhsuk-frontend')
               new Button($root)
@@ -342,9 +349,9 @@ describe('Button', () => {
         })
       })
 
-      it('throws when $root is not set', async () => {
-        await expect(
-          render(page, 'button', examples.default, {
+      it('throws when $root is not set', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               $root.remove()
             }
@@ -357,9 +364,9 @@ describe('Button', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $root', async () => {
-        await expect(
-          render(page, 'button', examples.default, {
+      it('throws when receiving the wrong type for $root', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               const $svg = document.createElementNS(
                 'http://www.w3.org/2000/svg',
@@ -385,5 +392,6 @@ describe('Button', () => {
 })
 
 /**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
  * @import { ElementHandle } from 'puppeteer'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/button.puppeteer.test.mjs
@@ -225,6 +225,7 @@ describe('Button', () => {
     describe('with HTML data attributes', () => {
       it('configures `preventDoubleClick: true` to prevent double clicks', async () => {
         await initExample('with double click prevented')
+
         await $component.click({
           count: 2
         })
@@ -237,6 +238,7 @@ describe('Button', () => {
 
       it('configures `preventDoubleClick: true` but allows multiple intentional clicks', async () => {
         await initExample('with double click prevented')
+
         await $component.click({
           count: 2,
           delay: debouncedWaitTime

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -136,7 +136,7 @@ describe('Character count', () => {
   })
 
   describe('Nunjucks configuration', () => {
-    it('configures the number of characters', () => {
+    it('configures `maxlength`', () => {
       const characterCount = new CharacterCount($root)
       expect(characterCount.config).toEqual({
         ...CharacterCount.defaults,
@@ -145,7 +145,7 @@ describe('Character count', () => {
       })
     })
 
-    it('configures the number of words', () => {
+    it('configures `maxwords`', () => {
       initExample('with word count')
 
       const characterCount = new CharacterCount($root)
@@ -156,7 +156,7 @@ describe('Character count', () => {
       })
     })
 
-    it('configures the threshold', () => {
+    it('configures `threshold`', () => {
       initExample('with threshold')
 
       const characterCount = new CharacterCount($root)

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -457,49 +457,6 @@ describe('Character count', () => {
         })
       })
 
-      describe('via `initAll`', () => {
-        it('configures the number of characters', async () => {
-          await initExample('to configure in JavaScript', {
-            config: {
-              maxlength: 10
-            }
-          })
-
-          await $textarea.type('A'.repeat(11))
-
-          expect(await getText($visibleCountMessage)).toBe(
-            'You have 1 character too many'
-          )
-        })
-
-        it('configures the number of words', async () => {
-          await initExample('to configure in JavaScript', {
-            config: {
-              maxwords: 10
-            }
-          })
-
-          await $textarea.type('Hello '.repeat(11))
-
-          expect(await getText($visibleCountMessage)).toBe(
-            'You have 1 word too many'
-          )
-        })
-
-        it('configures the threshold', async () => {
-          await initExample('to configure in JavaScript', {
-            config: {
-              maxlength: 10,
-              threshold: 75
-            }
-          })
-
-          await $textarea.type('A'.repeat(8))
-
-          expect(await getProperty($visibleCountMessage, 'hidden')).toBe(false)
-        })
-      })
-
       describe('with HTML data attributes', () => {
         it('uses `maxlength` data attribute instead of JavaScript `maxlength`', async () => {
           await initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -392,7 +392,7 @@ describe('Character count', () => {
 
     describe('JavaScript configuration', () => {
       describe('during initialisation', () => {
-        it("configures 'maxlength'", async () => {
+        it('configures `maxlength`', async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxlength: 10
@@ -406,7 +406,7 @@ describe('Character count', () => {
           )
         })
 
-        it("configures 'maxwords'", async () => {
+        it('configures `maxwords`', async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxwords: 10
@@ -420,7 +420,7 @@ describe('Character count', () => {
           )
         })
 
-        it("configures 'threshold'", async () => {
+        it('configures `threshold`', async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxlength: 10,

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -391,8 +391,8 @@ describe('Character count', () => {
     })
 
     describe('JavaScript configuration', () => {
-      describe('at instantiation', () => {
-        it('configures the number of characters', async () => {
+      describe('during initialisation', () => {
+        it("configures 'maxlength'", async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxlength: 10
@@ -406,7 +406,7 @@ describe('Character count', () => {
           )
         })
 
-        it('configures the number of words', async () => {
+        it("configures 'maxwords'", async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxwords: 10
@@ -420,7 +420,7 @@ describe('Character count', () => {
           )
         })
 
-        it('configures the threshold', async () => {
+        it("configures 'threshold'", async () => {
           await initExample('to configure in JavaScript', {
             config: {
               maxlength: 10,
@@ -433,7 +433,7 @@ describe('Character count', () => {
           expect(await getProperty($visibleCountMessage, 'hidden')).toBe(false)
         })
 
-        it('configures the description of the textarea', async () => {
+        it("configures i18n 'textareaDescription'", async () => {
           // This tests that a description can be provided through JavaScript attributes
           // and interpolated with the limit provided to the character count in JS.
 
@@ -629,7 +629,7 @@ describe('Character count', () => {
       })
     })
 
-    describe('errors at instantiation', () => {
+    describe('Error handling', () => {
       it('can throw a SupportError if appropriate', () => {
         return expect(
           initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -105,9 +105,6 @@ describe('Character count', () => {
       it('retains error class if there is already an error', async () => {
         await initExample('with error message')
 
-        // Wait for debounced update to happen
-        await timers.setTimeout(debouncedWaitTime)
-
         expect(await getAttribute($textarea, 'class')).toContain(
           'nhsuk-textarea--error'
         )
@@ -177,9 +174,6 @@ describe('Character count', () => {
         await initExample('with error message')
 
         await $textarea.type('A')
-
-        // Wait for debounced update to happen
-        await timers.setTimeout(debouncedWaitTime)
 
         expect(await getAttribute($textarea, 'class')).toContain(
           'nhsuk-textarea--error'
@@ -269,9 +263,6 @@ describe('Character count', () => {
 
         it('does not show the limit until the threshold is reached', async () => {
           expect(await getProperty($visibleCountMessage, 'hidden')).toBe(true)
-
-          // Wait for debounced update to happen
-          await timers.setTimeout(debouncedWaitTime)
 
           // Ensure threshold is hidden for users of assistive technologies
           expect(

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -1,7 +1,15 @@
 import * as timers from 'node:timers/promises'
 
-import { render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import {
+  getAttribute,
+  getProperty,
+  getHtml,
+  getText,
+  isVisible,
+  render
+} from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
+import { CharacterCount } from './character-count.mjs'
 import { examples } from './fixtures.mjs'
 
 describe('Character count', () => {
@@ -11,6 +19,50 @@ describe('Character count', () => {
   // The longest possible time from a keyboard user ending input and the screen
   // reader counter being updated (+ 100ms to stay outside the total wait time)
   const debouncedWaitTime = focusIntervalTime + lastInputOffsetTime + 100
+
+  /** @type {ElementHandle} */
+  let $component
+
+  /** @type {ElementHandle} */
+  let $screenReaderCountMessage
+
+  /** @type {ElementHandle} */
+  let $textarea
+
+  /** @type {ElementHandle} */
+  let $textareaDescription
+
+  /** @type {ElementHandle<HTMLElement>} */
+  let $visibleCountMessage
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'character-count', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${CharacterCount.moduleName}"]`)
+    )
+
+    $screenReaderCountMessage = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$('div.nhsuk-character-count__sr-status')
+    )
+
+    $textarea = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$('textarea.nhsuk-textarea')
+    )
+
+    $textareaDescription = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$('div.nhsuk-character-count__message')
+    )
+
+    $visibleCountMessage = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$('div.nhsuk-character-count__status')
+    )
+  }
 
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
@@ -22,416 +74,327 @@ describe('Character count', () => {
     })
 
     it('shows the textarea description', async () => {
-      await render(page, 'character-count', examples.default)
+      await initExample('default')
 
-      const message = await page.$eval(
-        '.nhsuk-character-count__message',
-        (el) => el.innerHTML.trim()
+      expect((await getText($textareaDescription))?.trim()).toBe(
+        'You can enter up to 200 characters'
       )
-
-      expect(message).toBe('You can enter up to 200 characters')
     })
   })
 
   describe('when JavaScript is available', () => {
     describe('on page load', () => {
       beforeEach(async () => {
-        await render(page, 'character-count', examples.default)
+        await initExample('default')
       })
 
       it('injects the visual counter', async () => {
-        const message =
-          (await page.$('.nhsuk-character-count__status')) !== null
-        expect(message).toBeTruthy()
+        expect(await isVisible($visibleCountMessage)).toBe(true)
       })
 
       it('injects the screen reader counter', async () => {
-        const srMessage =
-          (await page.$('.nhsuk-character-count__sr-status')) !== null
-        expect(srMessage).toBeTruthy()
+        expect(await isVisible($screenReaderCountMessage)).toBe(true)
       })
 
       it('hides the textarea description', async () => {
-        const messageClasses = await page.$eval(
-          '.nhsuk-character-count__message',
-          (el) => el.className
+        expect(await getAttribute($textareaDescription, 'class')).toContain(
+          'nhsuk-u-visually-hidden'
         )
-        expect(messageClasses).toContain('nhsuk-u-visually-hidden')
       })
 
       it('retains error class if there is already an error', async () => {
-        await render(page, 'character-count', examples['with error message'])
+        await initExample('with error message')
 
-        const textareaClasses = await page.$eval(
-          '.nhsuk-textarea',
-          (el) => el.className
+        // Wait for debounced update to happen
+        await timers.setTimeout(debouncedWaitTime)
+
+        expect(await getAttribute($textarea, 'class')).toContain(
+          'nhsuk-textarea--error'
         )
-        expect(textareaClasses).toContain('nhsuk-textarea--error')
       })
     })
 
     describe('when counting characters', () => {
       it('shows the dynamic message', async () => {
-        await render(page, 'character-count', examples.default)
+        await initExample('default')
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 200 characters remaining'
         )
-        expect(message).toBe('You have 200 characters remaining')
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 200 characters remaining'
         )
-        expect(srMessage).toBe('You have 200 characters remaining')
       })
 
       it('shows the characters remaining if the field is pre-filled', async () => {
-        await render(page, 'character-count', examples['with default value'])
+        await initExample('with default value')
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 57 characters remaining'
         )
-        expect(message).toBe('You have 57 characters remaining')
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 57 characters remaining'
         )
-        expect(srMessage).toBe('You have 57 characters remaining')
       })
 
       it('counts down to the character limit', async () => {
-        await render(page, 'character-count', examples.default)
+        await initExample('default')
 
-        await page.type('.nhsuk-js-character-count', 'A')
+        await $textarea.type('A')
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 199 characters remaining'
         )
-        expect(message).toBe('You have 199 characters remaining')
 
         // Wait for debounced update to happen
         await timers.setTimeout(debouncedWaitTime)
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 199 characters remaining'
         )
-        expect(srMessage).toBe('You have 199 characters remaining')
       })
 
       it('uses the singular when there is only one character remaining', async () => {
-        await render(page, 'character-count', examples.default)
+        await initExample('default')
 
-        await page.type('.nhsuk-js-character-count', 'A'.repeat(199))
+        await $textarea.type('A'.repeat(199))
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 1 character remaining'
         )
-        expect(message).toBe('You have 1 character remaining')
 
         // Wait for debounced update to happen
         await timers.setTimeout(debouncedWaitTime)
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 1 character remaining'
         )
-        expect(srMessage).toBe('You have 1 character remaining')
       })
 
       it('retains error class if there is already an error', async () => {
-        await render(page, 'character-count', examples['with error message'])
+        await initExample('with error message')
 
-        await page.type('.nhsuk-js-character-count', 'A')
+        await $textarea.type('A')
 
         // Wait for debounced update to happen
         await timers.setTimeout(debouncedWaitTime)
 
-        const textareaClasses = await page.$eval(
-          '.nhsuk-textarea',
-          (el) => el.className
+        expect(await getAttribute($textarea, 'class')).toContain(
+          'nhsuk-textarea--error'
         )
-        expect(textareaClasses).toContain('nhsuk-textarea--error')
       })
 
       describe('when the character limit is exceeded', () => {
         beforeEach(async () => {
-          await render(page, 'character-count', examples.default)
+          await initExample('default')
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(201))
-        }, 15000)
+          await $textarea.type('A'.repeat(201))
+        })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(message).toBe('You have 1 character too many')
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
-          const srMessage = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($screenReaderCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(srMessage).toBe('You have 1 character too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
-          await page.type('.nhsuk-js-character-count', 'A')
+          await $textarea.type('A')
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 2 characters too many'
           )
-          expect(message).toBe('You have 2 characters too many')
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
-          const srMessage = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($screenReaderCountMessage)).toBe(
+            'You have 2 characters too many'
           )
-          expect(srMessage).toBe('You have 2 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval(
-            '.nhsuk-js-character-count',
-            (el) => el.className
+          expect(await getAttribute($textarea, 'class')).toContain(
+            'nhsuk-textarea--error'
           )
-          expect(textareaClasses).toContain('nhsuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.className
+          expect(await getAttribute($visibleCountMessage, 'class')).toContain(
+            'nhsuk-error-message'
           )
-          expect(messageClasses).toContain('nhsuk-error-message')
         })
       })
 
       describe('when the character limit is exceeded on page load', () => {
         beforeEach(async () => {
-          await render(page, 'character-count', examples['with hint and error'])
+          await initExample('with hint and error')
         })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 40 characters too many'
           )
-          expect(message).toBe('You have 40 characters too many')
 
-          const srMessage = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($screenReaderCountMessage)).toBe(
+            'You have 40 characters too many'
           )
-          expect(srMessage).toBe('You have 40 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval(
-            '.nhsuk-js-character-count',
-            (el) => el.className
+          expect(await getAttribute($textarea, 'class')).toContain(
+            'nhsuk-textarea--error'
           )
-          expect(textareaClasses).toContain('nhsuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.className
+          expect(await getAttribute($visibleCountMessage, 'class')).toContain(
+            'nhsuk-error-message'
           )
-          expect(messageClasses).toContain('nhsuk-error-message')
         })
       })
 
       describe('when a threshold is set', () => {
         beforeEach(async () => {
-          await render(page, 'character-count', examples['with threshold'])
+          await initExample('with threshold')
         })
 
         it('does not show the limit until the threshold is reached', async () => {
-          const hidden = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.getAttribute('hidden')
-          )
-          expect(hidden).toBe('')
+          expect(await getProperty($visibleCountMessage, 'hidden')).toBe(true)
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
           // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.getAttribute('aria-hidden')
-          )
-          expect(ariaHidden).toBe('true')
+          expect(
+            await getAttribute($screenReaderCountMessage, 'aria-hidden')
+          ).toBe('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(8))
+          await $textarea.type('A'.repeat(8))
 
-          const hidden = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.getAttribute('hidden')
-          )
-          expect(hidden).toBeNull()
+          expect(await getProperty($visibleCountMessage, 'hidden')).toBe(false)
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
           // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.getAttribute('aria-hidden')
-          )
-          expect(ariaHidden).toBeFalsy()
+          expect(
+            await getAttribute($screenReaderCountMessage, 'aria-hidden')
+          ).toBeNull()
         })
       })
 
       describe('when a maxlength attribute is specified on the textarea', () => {
         beforeEach(async () => {
-          await render(
-            page,
-            'character-count',
-            examples['with maxlength attribute']
-          )
+          await initExample('with maxlength attribute')
         })
 
         it('should not have a maxlength attribute once the JS has run', async () => {
-          const textareaMaxLength = await page.$eval('.nhsuk-textarea', (el) =>
-            el.getAttribute('maxlength')
-          )
-          expect(textareaMaxLength).toBeNull()
+          expect(await getAttribute($textarea, 'maxlength')).toBeNull()
         })
       })
     })
 
     describe('when counting words', () => {
       beforeEach(async () => {
-        await render(page, 'character-count', examples['with word count'])
+        await initExample('with word count')
       })
 
       it('shows the dynamic message', async () => {
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 150 words remaining'
         )
-        expect(message).toBe('You have 150 words remaining')
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 150 words remaining'
         )
-        expect(srMessage).toBe('You have 150 words remaining')
       })
 
       it('counts down to the word limit', async () => {
-        await page.type('.nhsuk-js-character-count', 'Hello world')
+        await $textarea.type('Hello world')
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 148 words remaining'
         )
-        expect(message).toBe('You have 148 words remaining')
 
         // Wait for debounced update to happen
         await timers.setTimeout(debouncedWaitTime)
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 148 words remaining'
         )
-        expect(srMessage).toBe('You have 148 words remaining')
       })
 
       it('uses the singular when there is only one word remaining', async () => {
-        await page.type('.nhsuk-js-character-count', 'Hello '.repeat(149))
+        await $textarea.type('Hello '.repeat(149))
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($visibleCountMessage)).toBe(
+          'You have 1 word remaining'
         )
-        expect(message).toBe('You have 1 word remaining')
 
         // Wait for debounced update to happen
         await timers.setTimeout(debouncedWaitTime)
 
-        const srMessage = await page.$eval(
-          '.nhsuk-character-count__sr-status',
-          (el) => el.innerHTML.trim()
+        expect(await getText($screenReaderCountMessage)).toBe(
+          'You have 1 word remaining'
         )
-        expect(srMessage).toBe('You have 1 word remaining')
-      }, 15000)
+      })
 
       describe('when the word limit is exceeded', () => {
         beforeEach(async () => {
-          await render(page, 'character-count', examples['with word count'])
+          await initExample('with word count')
 
-          await page.type('.nhsuk-js-character-count', 'Hello '.repeat(151))
-        }, 15000)
+          await $textarea.type('Hello '.repeat(151))
+        })
 
         it('shows the number of words over the limit', async () => {
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(message).toBe('You have 1 word too many')
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
-          const srMessage = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($screenReaderCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(srMessage).toBe('You have 1 word too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
-          await page.type('.nhsuk-js-character-count', 'World')
+          await $textarea.type('World')
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 2 words too many'
           )
-          expect(message).toBe('You have 2 words too many')
 
           // Wait for debounced update to happen
           await timers.setTimeout(debouncedWaitTime)
 
-          const srMessage = await page.$eval(
-            '.nhsuk-character-count__sr-status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($screenReaderCountMessage)).toBe(
+            'You have 2 words too many'
           )
-          expect(srMessage).toBe('You have 2 words too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval(
-            '.nhsuk-js-character-count',
-            (el) => el.className
+          expect(await getAttribute($textarea, 'class')).toContain(
+            'nhsuk-textarea--error'
           )
-          expect(textareaClasses).toContain('nhsuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.className
+          expect(await getAttribute($visibleCountMessage, 'class')).toContain(
+            'nhsuk-error-message'
           )
-          expect(messageClasses).toContain('nhsuk-error-message')
         })
       })
     })
@@ -439,79 +402,52 @@ describe('Character count', () => {
     describe('JavaScript configuration', () => {
       describe('at instantiation', () => {
         it('configures the number of characters', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxlength: 10
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxlength: 10
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(11))
+          await $textarea.type('A'.repeat(11))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(message).toBe('You have 1 character too many')
         })
 
         it('configures the number of words', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxwords: 10
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxwords: 10
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'Hello '.repeat(11))
+          await $textarea.type('Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(message).toBe('You have 1 word too many')
         })
 
         it('configures the threshold', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxlength: 10,
-                threshold: 75
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxlength: 10,
+              threshold: 75
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(8))
+          await $textarea.type('A'.repeat(8))
 
-          const hidden = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.getAttribute('hidden')
-          )
-          expect(hidden).toBeNull()
+          expect(await getProperty($visibleCountMessage, 'hidden')).toBe(false)
         })
 
         it('configures the description of the textarea', async () => {
           // This tests that a description can be provided through JavaScript attributes
           // and interpolated with the limit provided to the character count in JS.
 
-          await render(
-            page,
-            'character-count',
-            examples[
-              'with neither maxlength, maxwords nor textarea description set'
-            ],
+          await initExample(
+            'with neither maxlength, maxwords nor textarea description set',
             {
               config: {
                 maxlength: 10,
@@ -524,143 +460,110 @@ describe('Character count', () => {
             }
           )
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__message',
-            (el) => el.innerHTML.trim()
+          expect(await getText($textareaDescription)).toBe(
+            'No more than 10 characters'
           )
-          expect(message).toBe('No more than 10 characters')
         })
       })
 
       describe('via `initAll`', () => {
         it('configures the number of characters', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxlength: 10
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxlength: 10
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(11))
+          await $textarea.type('A'.repeat(11))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(message).toBe('You have 1 character too many')
         })
 
         it('configures the number of words', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxwords: 10
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxwords: 10
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'Hello '.repeat(11))
+          await $textarea.type('Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(message).toBe('You have 1 word too many')
         })
 
         it('configures the threshold', async () => {
-          await render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript'],
-            {
-              config: {
-                maxlength: 10,
-                threshold: 75
-              }
+          await initExample('to configure in JavaScript', {
+            config: {
+              maxlength: 10,
+              threshold: 75
             }
-          )
+          })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(8))
+          await $textarea.type('A'.repeat(8))
 
-          const hidden = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.getAttribute('hidden')
-          )
-          expect(hidden).toBeNull()
+          expect(await getProperty($visibleCountMessage, 'hidden')).toBe(false)
         })
       })
 
       describe('when data-attributes are present', () => {
         it('uses `maxlength` data attribute instead of the JS one', async () => {
-          await render(page, 'character-count', examples.default, {
+          await initExample('default', {
             config: {
               maxlength: 202 // JS configuration that would tell 1 character remaining
             }
           })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(201))
+          await $textarea.type('A'.repeat(201))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(message).toBe('You have 1 character too many')
         })
 
         it("uses `maxlength` data attribute instead of JS's `maxwords`", async () => {
-          await render(page, 'character-count', examples.default, {
+          await initExample('default', {
             config: {
               maxwords: 202
             }
           })
 
-          await page.type('.nhsuk-js-character-count', 'A'.repeat(201))
+          await $textarea.type('A'.repeat(201))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 character too many'
           )
-          expect(message).toBe('You have 1 character too many')
         })
 
         it('uses `maxwords` data attribute instead of the JS one', async () => {
-          await render(page, 'character-count', examples['with word count'], {
+          await initExample('with word count', {
             config: {
               maxwords: 152 // JS configuration that would tell 1 word remaining
             }
           })
 
-          await page.type('.nhsuk-js-character-count', 'Hello '.repeat(151))
+          await $textarea.type('Hello '.repeat(151))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(message).toBe('You have 1 word too many')
         })
 
         it("uses `maxwords` data attribute instead of the JS's `maxlength`", async () => {
-          await render(page, 'character-count', examples['with word count'], {
+          await initExample('with word count', {
             config: {
               maxlength: 150
             }
           })
 
-          await page.type('.nhsuk-js-character-count', 'Hello '.repeat(151))
+          await $textarea.type('Hello '.repeat(151))
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__status',
-            (el) => el.innerHTML.trim()
+          expect(await getText($visibleCountMessage)).toBe(
+            'You have 1 word too many'
           )
-          expect(message).toBe('You have 1 word too many')
         })
 
         it('interpolates the textarea description in data attributes with the maximum set in JavaScript', async () => {
@@ -670,56 +573,42 @@ describe('Character count', () => {
           // element holding the textarea's accessible description
           // (and interpolated to replace `%{count}` with the maximum)
 
-          await render(
-            page,
-            'character-count',
-            examples['with neither maxlength nor maxwords set'],
-            {
-              config: {
-                maxlength: 150
-              }
+          await initExample('with neither maxlength nor maxwords set', {
+            config: {
+              maxlength: 150
             }
-          )
+          })
 
-          const message = await page.$eval(
-            '.nhsuk-character-count__message',
-            (el) => el.innerHTML.trim()
+          expect(await getText($textareaDescription)).toBe(
+            'No more than 150 characters'
           )
-          expect(message).toBe('No more than 150 characters')
         })
       })
     })
 
     describe('Cross Side Scripting prevention', () => {
       it('injects the localised strings as text not HTML', async () => {
-        await render(
-          page,
-          'character-count',
-          examples['to configure in JavaScript'],
-          {
-            config: {
-              maxlength: 10,
-              i18n: {
-                charactersUnderLimit: {
-                  other: '<strong>%{count}</strong> characters left'
-                }
+        await initExample('to configure in JavaScript', {
+          config: {
+            maxlength: 10,
+            i18n: {
+              charactersUnderLimit: {
+                other: '<strong>%{count}</strong> characters left'
               }
             }
           }
-        )
+        })
 
-        const message = await page.$eval(
-          '.nhsuk-character-count__status',
-          (el) => el.innerHTML.trim()
+        expect((await getHtml($visibleCountMessage))?.trim()).toBe(
+          '&lt;strong&gt;10&lt;/strong&gt; characters left'
         )
-        expect(message).toBe('&lt;strong&gt;10&lt;/strong&gt; characters left')
       })
     })
 
     describe('errors at instantiation', () => {
-      it('can throw a SupportError if appropriate', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('can throw a SupportError if appropriate', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation() {
               document.body.classList.remove('nhsuk-frontend-supported')
             }
@@ -733,9 +622,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when initialised twice', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when initialised twice', () => {
+        return expect(
+          initExample('default', {
             async afterInitialisation($root) {
               const { CharacterCount } = await import('nhsuk-frontend')
               new CharacterCount($root)
@@ -748,9 +637,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when $root is not set', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when $root is not set', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               $root.remove()
             }
@@ -763,9 +652,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $root', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when receiving the wrong type for $root', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $root.outerHTML = `<svg data-module="nhsuk-character-count"></svg>`
@@ -780,9 +669,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when the textarea is missing', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when the textarea is missing', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               $root.querySelector(selector)?.remove()
             },
@@ -799,9 +688,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when the textarea is not the right type', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when the textarea is not the right type', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               const $div = document.createElement('div')
               $div.classList.add('nhsuk-js-character-count')
@@ -822,9 +711,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when the textarea description is missing', async () => {
-        await expect(
-          render(page, 'character-count', examples.default, {
+      it('throws when the textarea description is missing', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               $root.querySelector(selector)?.remove()
             },
@@ -841,13 +730,9 @@ describe('Character count', () => {
         })
       })
 
-      it('throws when receiving invalid JavaScript configuration', async () => {
-        await expect(
-          render(
-            page,
-            'character-count',
-            examples['to configure in JavaScript']
-          )
+      it('throws when receiving invalid JavaScript configuration', () => {
+        return expect(
+          initExample('to configure in JavaScript')
         ).rejects.toMatchObject({
           cause: {
             name: 'ConfigError',
@@ -865,7 +750,7 @@ describe('Character count', () => {
       const pageErrorListener = jest.fn()
       page.on('pageerror', pageErrorListener)
 
-      await render(page, 'character-count', examples.default, {
+      await initExample('default', {
         config: {
           // Override maxlength to 10
           maxlength: 10
@@ -883,10 +768,15 @@ describe('Character count', () => {
 
       // Type 10 characters so we go 'through' all the different forms as we
       // approach 0 characters remaining.
-      await page.type('.nhsuk-js-character-count', 'A'.repeat(10))
+      await $textarea.type('A'.repeat(10))
 
       // Expect the page error event not to have been fired
       expect(pageErrorListener).not.toHaveBeenCalled()
     })
   })
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.puppeteer.test.mjs
@@ -500,22 +500,31 @@ describe('Character count', () => {
         })
       })
 
-      describe('when data-attributes are present', () => {
-        it('uses `maxlength` data attribute instead of the JS one', async () => {
+      describe('with HTML data attributes', () => {
+        it('uses `maxlength` data attribute instead of JavaScript `maxlength`', async () => {
           await initExample('default', {
             config: {
-              maxlength: 202 // JS configuration that would tell 1 character remaining
+              maxlength: 202
             }
           })
 
           await $textarea.type('A'.repeat(201))
 
+          // Wait for debounced update to happen
+          await timers.setTimeout(debouncedWaitTime)
+
+          expect(await getText($visibleCountMessage)).not.toBe(
+            // JavaScript config `maxlength: 202` above is overridden
+            'You have 1 character remaining'
+          )
+
           expect(await getText($visibleCountMessage)).toBe(
+            // HTML data attribute `maxlength: 200` applied from fixture
             'You have 1 character too many'
           )
         })
 
-        it("uses `maxlength` data attribute instead of JS's `maxwords`", async () => {
+        it('uses `maxlength` data attribute instead of JavaScript `maxwords`', async () => {
           await initExample('default', {
             config: {
               maxwords: 202
@@ -524,26 +533,41 @@ describe('Character count', () => {
 
           await $textarea.type('A'.repeat(201))
 
+          expect(await getText($visibleCountMessage)).not.toBe(
+            // JavaScript config `maxwords: 202` above is overridden
+            'You have 201 words remaining'
+          )
+
           expect(await getText($visibleCountMessage)).toBe(
+            // HTML data attribute `maxlength: 200` applied from fixture
             'You have 1 character too many'
           )
         })
 
-        it('uses `maxwords` data attribute instead of the JS one', async () => {
+        it('uses `maxwords` data attribute instead of JavaScript `maxwords`', async () => {
           await initExample('with word count', {
             config: {
-              maxwords: 152 // JS configuration that would tell 1 word remaining
+              maxwords: 152
             }
           })
 
           await $textarea.type('Hello '.repeat(151))
 
+          // Wait for debounced update to happen
+          await timers.setTimeout(debouncedWaitTime)
+
+          expect(await getText($visibleCountMessage)).not.toBe(
+            // JavaScript config `maxwords: 152` above is overridden
+            'You have 1 word remaining'
+          )
+
           expect(await getText($visibleCountMessage)).toBe(
+            // HTML data attribute `maxwords: 150` applied from fixture
             'You have 1 word too many'
           )
         })
 
-        it("uses `maxwords` data attribute instead of the JS's `maxlength`", async () => {
+        it('uses `maxwords` data attribute instead of JavaScript `maxlength`', async () => {
           await initExample('with word count', {
             config: {
               maxlength: 150
@@ -552,7 +576,16 @@ describe('Character count', () => {
 
           await $textarea.type('Hello '.repeat(151))
 
+          // Wait for debounced update to happen
+          await timers.setTimeout(debouncedWaitTime)
+
+          expect(await getText($visibleCountMessage)).not.toBe(
+            // JavaScript config `maxlength: 150` above is overridden
+            'You have 756 characters too many'
+          )
+
           expect(await getText($visibleCountMessage)).toBe(
+            // HTML data attribute `maxwords: 150` applied from fixture
             'You have 1 word too many'
           )
         })

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
@@ -44,7 +44,7 @@ describe('Checkboxes', () => {
         /** @type {ElementHandle} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         /** @type {ElementHandle[]} */
@@ -57,7 +57,7 @@ describe('Checkboxes', () => {
             await page.$('.nhsuk-checkboxes')
           )
 
-          $inputs = await $component.$$('.nhsuk-checkboxes__input')
+          $inputs = await $component.$$('input.nhsuk-checkboxes__input')
           $conditionals = await $component.$$('.nhsuk-checkboxes__conditional')
         })
 
@@ -70,6 +70,7 @@ describe('Checkboxes', () => {
           const $inputsWithAriaExpanded = await $component?.$$(
             '.nhsuk-checkboxes__input[aria-expanded]'
           )
+
           const $inputsWithAriaControls = await $component?.$$(
             '.nhsuk-checkboxes__input[aria-controls]'
           )
@@ -93,7 +94,7 @@ describe('Checkboxes', () => {
         /** @type {ElementHandle} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeAll(async () => {
@@ -103,7 +104,7 @@ describe('Checkboxes', () => {
             await page.$('.nhsuk-checkboxes')
           )
 
-          $inputs = await $component.$$('.nhsuk-checkboxes__input')
+          $inputs = await $component.$$('input.nhsuk-checkboxes__input')
         })
 
         it('has conditional content revealed that is associated with a checked input', async () => {
@@ -131,7 +132,7 @@ describe('Checkboxes', () => {
         /** @type {ElementHandle} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
@@ -141,7 +142,7 @@ describe('Checkboxes', () => {
             await page.$('.nhsuk-checkboxes')
           )
 
-          $inputs = await $component.$$('.nhsuk-checkboxes__input')
+          $inputs = await $component.$$('input.nhsuk-checkboxes__input')
         })
 
         it('indicates when conditional content is collapsed or revealed', async () => {
@@ -231,7 +232,7 @@ describe('Checkboxes', () => {
       /** @type {ElementHandle} */
       let $component
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputs
 
       beforeEach(async () => {
@@ -245,7 +246,7 @@ describe('Checkboxes', () => {
           await page.$('.nhsuk-checkboxes')
         )
 
-        $inputs = await $component.$$('.nhsuk-checkboxes__input')
+        $inputs = await $component.$$('input.nhsuk-checkboxes__input')
       })
 
       it('unchecks other checkboxes when the "none of the above" option is checked', async () => {
@@ -281,7 +282,7 @@ describe('Checkboxes', () => {
       /** @type {ElementHandle} */
       let $component
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputs
 
       beforeEach(async () => {
@@ -295,7 +296,7 @@ describe('Checkboxes', () => {
           await page.$('.nhsuk-checkboxes')
         )
 
-        $inputs = await $component.$$('.nhsuk-checkboxes__input')
+        $inputs = await $component.$$('input.nhsuk-checkboxes__input')
       })
 
       it('unchecks other checkboxes and hides conditional content when the "none of the above" option is checked', async () => {
@@ -324,26 +325,28 @@ describe('Checkboxes', () => {
 
   describe('with multiple groups and a "none of the above" option and conditional content', () => {
     describe('when JavaScript is available', () => {
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsPrimary
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsSecondary
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsOther
 
       beforeEach(async () => {
         await goToExample(page, 'conditional-reveals')
 
         $inputsPrimary = await page.$$(
-          '.nhsuk-checkboxes__input[id^="colour-primary"]'
+          'input.nhsuk-checkboxes__input[id^="colour-primary"]'
         )
+
         $inputsSecondary = await page.$$(
-          '.nhsuk-checkboxes__input[id^="colour-secondary"]'
+          'input.nhsuk-checkboxes__input[id^="colour-secondary"]'
         )
+
         $inputsOther = await page.$$(
-          '.nhsuk-checkboxes__input[id^="colour-other"]'
+          'input.nhsuk-checkboxes__input[id^="colour-other"]'
         )
       })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
@@ -6,24 +6,41 @@ import {
   render
 } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
+import { Checkboxes } from './checkboxes.mjs'
 import { examples } from './fixtures.mjs'
 
 describe('Checkboxes', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'checkboxes', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${Checkboxes.moduleName}"]`)
+    )
+  }
+
   describe('input position', () => {
     // Check that the input sits above the label, enabling its proper detection
     // when exploring by touch or using automation tools like Selenium
     it('displays the input above the label', async () => {
-      await render(page, 'checkboxes', examples.default)
+      await initExample('default')
 
       const $firstInput = /** @type {ElementHandle} */ (
         await page.$('.nhsuk-checkboxes__input')
       )
 
       const clickPosition = await $firstInput.clickablePoint()
-      const elementTagNames = await page.evaluate(
-        ({ x, y }) => document.elementsFromPoint(x, y).map((el) => el.tagName),
-        clickPosition
-      )
+
+      const elementTagNames = await page.evaluate(({ x, y }) => {
+        return document.elementsFromPoint(x, y).map(($el) => $el.tagName)
+      }, clickPosition)
 
       expect(elementTagNames[0]).toBe('INPUT')
       expect(elementTagNames[1]).toBe('LABEL')
@@ -41,9 +58,6 @@ describe('Checkboxes', () => {
       })
 
       describe('with conditional content', () => {
-        /** @type {ElementHandle} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
@@ -51,11 +65,7 @@ describe('Checkboxes', () => {
         let $conditionals
 
         beforeEach(async () => {
-          await render(page, 'checkboxes', examples['with conditional content'])
-
-          $component = /** @type {ElementHandle} */ (
-            await page.$('.nhsuk-checkboxes')
-          )
+          await initExample('with conditional content')
 
           $inputs = await $component.$$('input.nhsuk-checkboxes__input')
           $conditionals = await $component.$$('.nhsuk-checkboxes__conditional')
@@ -67,11 +77,11 @@ describe('Checkboxes', () => {
         })
 
         it('has no ARIA attributes applied', async () => {
-          const $inputsWithAriaExpanded = await $component?.$$(
+          const $inputsWithAriaExpanded = await $component.$$(
             '.nhsuk-checkboxes__input[aria-expanded]'
           )
 
-          const $inputsWithAriaControls = await $component?.$$(
+          const $inputsWithAriaControls = await $component.$$(
             '.nhsuk-checkboxes__input[aria-controls]'
           )
 
@@ -79,7 +89,7 @@ describe('Checkboxes', () => {
           expect($inputsWithAriaControls).toHaveLength(0)
         })
 
-        it('falls back to making all conditional content visible', async () => {
+        it('falls back to making all conditional content visible', () => {
           return Promise.all(
             $conditionals.map(async ($conditional) => {
               return expect(await isVisible($conditional)).toBe(true)
@@ -91,18 +101,11 @@ describe('Checkboxes', () => {
 
     describe('when JavaScript is available', () => {
       describe('with conditional item checked', () => {
-        /** @type {ElementHandle} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeAll(async () => {
-          await render(page, 'checkboxes', examples['with pre-checked values'])
-
-          $component = /** @type {ElementHandle} */ (
-            await page.$('.nhsuk-checkboxes')
-          )
+          await initExample('with pre-checked values')
 
           $inputs = await $component.$$('input.nhsuk-checkboxes__input')
         })
@@ -129,18 +132,11 @@ describe('Checkboxes', () => {
       })
 
       describe('with conditional content', () => {
-        /** @type {ElementHandle} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
-          await render(page, 'checkboxes', examples['with conditional content'])
-
-          $component = /** @type {ElementHandle} */ (
-            await page.$('.nhsuk-checkboxes')
-          )
+          await initExample('with conditional content')
 
           $inputs = await $component.$$('input.nhsuk-checkboxes__input')
         })
@@ -214,13 +210,9 @@ describe('Checkboxes', () => {
       })
 
       describe('with conditional content, special characters', () => {
-        it('does not error when ID of revealed content contains special characters', async () => {
+        it('does not error when ID of revealed content contains special characters', () => {
           return expect(
-            render(
-              page,
-              'checkboxes',
-              examples['with conditional content, special characters']
-            )
+            initExample('with conditional content, special characters')
           ).resolves.not.toThrow()
         })
       })
@@ -229,22 +221,11 @@ describe('Checkboxes', () => {
 
   describe('with a "none of the above" option', () => {
     describe('when JavaScript is available', () => {
-      /** @type {ElementHandle} */
-      let $component
-
       /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputs
 
       beforeEach(async () => {
-        await render(
-          page,
-          'checkboxes',
-          examples['with "none of the above" option']
-        )
-
-        $component = /** @type {ElementHandle} */ (
-          await page.$('.nhsuk-checkboxes')
-        )
+        await initExample('with "none of the above" option')
 
         $inputs = await $component.$$('input.nhsuk-checkboxes__input')
       })
@@ -279,21 +260,12 @@ describe('Checkboxes', () => {
 
   describe('with a "none of the above" option and conditional content', () => {
     describe('when JavaScript is available', () => {
-      /** @type {ElementHandle} */
-      let $component
-
       /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputs
 
       beforeEach(async () => {
-        await render(
-          page,
-          'checkboxes',
-          examples['with "none of the above" option, conditional content']
-        )
-
-        $component = /** @type {ElementHandle} */ (
-          await page.$('.nhsuk-checkboxes')
+        await initExample(
+          'with "none of the above" option, conditional content'
         )
 
         $inputs = await $component.$$('input.nhsuk-checkboxes__input')
@@ -385,9 +357,9 @@ describe('Checkboxes', () => {
       })
 
       describe('errors at instantiation', () => {
-        it('can throw a SupportError if appropriate', async () => {
-          await expect(
-            render(page, 'checkboxes', examples.default, {
+        it('can throw a SupportError if appropriate', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation() {
                 document.body.classList.remove('nhsuk-frontend-supported')
               }
@@ -401,9 +373,9 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when initialised twice', async () => {
-          await expect(
-            render(page, 'checkboxes', examples.default, {
+        it('throws when initialised twice', () => {
+          return expect(
+            initExample('default', {
               async afterInitialisation($root) {
                 const { Checkboxes } = await import('nhsuk-frontend')
                 new Checkboxes($root)
@@ -416,9 +388,9 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when $root is not set', async () => {
-          await expect(
-            render(page, 'checkboxes', examples.default, {
+        it('throws when $root is not set', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation($root) {
                 $root.remove()
               }
@@ -431,9 +403,9 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when receiving the wrong type for $root', async () => {
-          await expect(
-            render(page, 'checkboxes', examples.default, {
+        it('throws when receiving the wrong type for $root', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation($root) {
                 // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                 $root.outerHTML = `<svg data-module="nhsuk-checkboxes"></svg>`
@@ -448,9 +420,9 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when the input list is empty', async () => {
-          await expect(
-            render(page, 'checkboxes', examples.default, {
+        it('throws when the input list is empty', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation($root, { selector }) {
                 $root
                   .querySelectorAll(selector)
@@ -469,9 +441,9 @@ describe('Checkboxes', () => {
           })
         })
 
-        it('throws when a conditional target element is not found', async () => {
-          await expect(
-            render(page, 'checkboxes', examples['with conditional content'], {
+        it('throws when a conditional target element is not found', () => {
+          return expect(
+            initExample('with conditional content', {
               beforeInitialisation($root, { selector }) {
                 $root.querySelector(selector)?.remove()
               },
@@ -493,5 +465,6 @@ describe('Checkboxes', () => {
 })
 
 /**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
  * @import { ElementHandle } from 'puppeteer'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/checkboxes.puppeteer.test.mjs
@@ -356,7 +356,7 @@ describe('Checkboxes', () => {
         expect(await isVisible($conditionalPrimary)).toBe(false)
       })
 
-      describe('errors at instantiation', () => {
+      describe('Error handling', () => {
         it('can throw a SupportError if appropriate', () => {
           return expect(
             initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/code.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/code.jsdom.test.mjs
@@ -259,7 +259,7 @@ describe('Code', () => {
       initExample('default')
     })
 
-    describe('i18n', () => {
+    describe('during initialisation', () => {
       it('overrides the default translation keys', () => {
         const component = new Code($root, {
           i18n: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
@@ -48,88 +48,6 @@ describe('Error summary', () => {
     expect(await getAttribute($component, 'tabindex')).toBeNull()
   })
 
-  describe('when auto-focus is disabled', () => {
-    describe('using data-attributes', () => {
-      beforeAll(async () => {
-        await initExample('auto-focus disabled')
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus on page load', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
-      })
-    })
-
-    describe('using JavaScript configuration', () => {
-      beforeAll(async () => {
-        await initExample('default', {
-          config: {
-            disableAutoFocus: true
-          }
-        })
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus on page load', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
-      })
-    })
-
-    describe('using JavaScript configuration, but enabled via data-attributes', () => {
-      beforeAll(async () => {
-        await initExample('auto-focus explicitly enabled')
-      })
-
-      it('adds the tabindex attribute on page load', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBe('-1')
-      })
-
-      it('is automatically focused when the page loads', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
-      })
-    })
-
-    describe('using `initAll`', () => {
-      beforeAll(async () => {
-        await initExample('default', {
-          config: {
-            disableAutoFocus: true
-          }
-        })
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus on page load', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
-      })
-    })
-  })
-
   describe.each([
     {
       name: 'an input',
@@ -220,6 +138,94 @@ describe('Error summary', () => {
     it('does not include a hash in the URL', async () => {
       const hash = await page.evaluate(() => window.location.hash)
       expect(hash).toBe('')
+    })
+  })
+
+  describe('JavaScript configuration', () => {
+    describe('during initialisation', () => {
+      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+        await initExample('default', {
+          config: {
+            disableAutoFocus: true
+          }
+        })
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Does not add the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
+
+        // Does not automatically focus on page load
+        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
+      })
+
+      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+        await initExample('default', {
+          config: {
+            disableAutoFocus: false
+          }
+        })
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
+      })
+    })
+
+    describe('with HTML data attributes', () => {
+      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+        await initExample('auto-focus disabled')
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Does not add the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
+
+        // Does not automatically focus on page load
+        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
+      })
+
+      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+        await initExample('auto-focus explicitly enabled')
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
+      })
+
+      it('uses `disableAutoFocus` data attribute instead of JavaScript `disableAutoFocus`', async () => {
+        await initExample('auto-focus explicitly enabled', {
+          config: {
+            disableAutoFocus: false
+          }
+        })
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
+      })
     })
   })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
@@ -1,69 +1,75 @@
-import { goToExample, render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import {
+  getAttribute,
+  goToExample,
+  render
+} from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
+import { ErrorSummary } from './error-summary.mjs'
 import { examples } from './fixtures.mjs'
 
-describe('Error Summary', () => {
-  it('adds the tabindex attribute on page load', async () => {
-    await render(page, 'error-summary', examples.default)
+describe('Error summary', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
 
-    const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-      el.getAttribute('tabindex')
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'error-summary', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${ErrorSummary.moduleName}"]`)
     )
+  }
 
-    expect(tabindex).toBe('-1')
+  it('adds the tabindex attribute on page load', async () => {
+    await initExample('default')
+
+    expect(await getAttribute($component, 'tabindex')).toBe('-1')
   })
 
   it('is automatically focused when the page loads', async () => {
-    await render(page, 'error-summary', examples.default)
+    await initExample('default')
 
-    const moduleName = await page.evaluate(() =>
+    const activeElementModuleName = await page.evaluate(() =>
       document.activeElement?.getAttribute('data-module')
     )
 
-    expect(moduleName).toBe('nhsuk-error-summary')
+    expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
   })
 
   it('removes the tabindex attribute on blur', async () => {
-    await render(page, 'error-summary', examples.default)
+    await initExample('default')
 
-    await page.$eval(
-      '.nhsuk-error-summary',
-      (el) => el instanceof window.HTMLElement && el.blur()
-    )
+    await $component.evaluate(($el) => $el.blur())
 
-    const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-      el.getAttribute('tabindex')
-    )
-
-    expect(tabindex).toBeNull()
+    expect(await getAttribute($component, 'tabindex')).toBeNull()
   })
 
   describe('when auto-focus is disabled', () => {
     describe('using data-attributes', () => {
       beforeAll(async () => {
-        await render(page, 'error-summary', examples['auto-focus disabled'])
+        await initExample('auto-focus disabled')
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-error-summary')
+        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
       })
     })
 
     describe('using JavaScript configuration', () => {
       beforeAll(async () => {
-        await render(page, 'error-summary', examples.default, {
+        await initExample('default', {
           config: {
             disableAutoFocus: true
           }
@@ -71,49 +77,39 @@ describe('Error Summary', () => {
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-error-summary')
+        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
       })
     })
 
     describe('using JavaScript configuration, but enabled via data-attributes', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'error-summary',
-          examples['auto-focus explicitly enabled']
-        )
+        await initExample('auto-focus explicitly enabled')
       })
 
       it('adds the tabindex attribute on page load', async () => {
-        const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-          el.getAttribute('tabindex')
-        )
-        expect(tabindex).toBe('-1')
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
       })
 
       it('is automatically focused when the page loads', async () => {
-        const moduleName = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
-        expect(moduleName).toBe('nhsuk-error-summary')
+
+        expect(activeElementModuleName).toBe(ErrorSummary.moduleName)
       })
     })
 
     describe('using `initAll`', () => {
       beforeAll(async () => {
-        await render(page, 'error-summary', examples.default, {
+        await initExample('default', {
           config: {
             disableAutoFocus: true
           }
@@ -121,19 +117,15 @@ describe('Error Summary', () => {
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-error-summary', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-error-summary')
+        expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
       })
     })
   })
@@ -208,11 +200,11 @@ describe('Error Summary', () => {
     })
 
     it('focuses the target input', async () => {
-      const activeElement = await page.evaluate(
+      const activeElementId = await page.evaluate(
         () => document.activeElement?.id
       )
 
-      expect(activeElement).toBe(inputId)
+      expect(activeElementId).toBe(inputId)
     })
 
     it('scrolls the label or legend to the top of the screen', async () => {
@@ -232,9 +224,9 @@ describe('Error Summary', () => {
   })
 
   describe('errors at instantiation', () => {
-    it('can throw a SupportError if appropriate', async () => {
-      await expect(
-        render(page, 'error-summary', examples.default, {
+    it('can throw a SupportError if appropriate', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation() {
             document.body.classList.remove('nhsuk-frontend-supported')
           }
@@ -248,9 +240,9 @@ describe('Error Summary', () => {
       })
     })
 
-    it('throws when initialised twice', async () => {
-      await expect(
-        render(page, 'error-summary', examples.default, {
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
           async afterInitialisation($root) {
             const { ErrorSummary } = await import('nhsuk-frontend')
             new ErrorSummary($root)
@@ -263,9 +255,9 @@ describe('Error Summary', () => {
       })
     })
 
-    it('throws when $root is not set', async () => {
-      await expect(
-        render(page, 'error-summary', examples.default, {
+    it('throws when $root is not set', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             $root.remove()
           }
@@ -278,9 +270,9 @@ describe('Error Summary', () => {
       })
     })
 
-    it('throws when receiving the wrong type for $root', async () => {
-      await expect(
-        render(page, 'error-summary', examples.default, {
+    it('throws when receiving the wrong type for $root', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $root.outerHTML = `<svg data-module="nhsuk-error-summary"></svg>`
@@ -296,3 +288,8 @@ describe('Error Summary', () => {
     })
   })
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
@@ -143,7 +143,7 @@ describe('Error summary', () => {
 
   describe('JavaScript configuration', () => {
     describe('during initialisation', () => {
-      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+      it('configures `disableAutoFocus: true` to prevent auto-focus', async () => {
         await initExample('default', {
           config: {
             disableAutoFocus: true
@@ -161,7 +161,7 @@ describe('Error summary', () => {
         expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
       })
 
-      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+      it('configures `disableAutoFocus: false` to explicitly enable auto-focus', async () => {
         await initExample('default', {
           config: {
             disableAutoFocus: false
@@ -181,7 +181,7 @@ describe('Error summary', () => {
     })
 
     describe('with HTML data attributes', () => {
-      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+      it('configures `disableAutoFocus: true` to prevent auto-focus', async () => {
         await initExample('auto-focus disabled')
 
         const activeElementModuleName = await page.evaluate(() =>
@@ -195,7 +195,7 @@ describe('Error summary', () => {
         expect(activeElementModuleName).not.toBe(ErrorSummary.moduleName)
       })
 
-      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+      it('configures `disableAutoFocus: false` to explicitly enable auto-focus', async () => {
         await initExample('auto-focus explicitly enabled')
 
         const activeElementModuleName = await page.evaluate(() =>

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/error-summary.puppeteer.test.mjs
@@ -193,7 +193,7 @@ describe('Error summary', () => {
       inputId: 'address-postcode',
       legendOrLabelSelector: 'label[for="address-postcode"]'
     }
-  ])('when linking to $name', ({ inputId, legendOrLabelSelector }) => {
+  ])('Linking to $name', ({ inputId, legendOrLabelSelector }) => {
     beforeAll(async () => {
       await goToExample(page, 'error-summary')
       await page.click(`.nhsuk-error-summary a[href="#${inputId}"]`)
@@ -223,7 +223,7 @@ describe('Error summary', () => {
     })
   })
 
-  describe('errors at instantiation', () => {
+  describe('Error handling', () => {
     it('can throw a SupportError if appropriate', () => {
       return expect(
         initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.jsdom.test.mjs
@@ -202,7 +202,7 @@ describe('File upload', () => {
       initExample('to configure in JavaScript')
     })
 
-    describe('i18n', () => {
+    describe('during initialisation', () => {
       it('overrides the default translation keys', () => {
         const component = new FileUpload($root, {
           i18n: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
@@ -463,7 +463,7 @@ describe('File upload', () => {
       })
     })
 
-    describe('errors at instantiation', () => {
+    describe('Error handling', () => {
       it('can throw a SupportError if appropriate', () => {
         return expect(
           initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
@@ -1,23 +1,77 @@
 import {
   getAccessibleName,
+  getAttribute,
+  getProperty,
+  getText,
   render
 } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
+import { FileUpload } from './file-upload.mjs'
 import { examples } from './fixtures.mjs'
 
 describe('File upload', () => {
-  const moduleSelector = '.nhsuk-file-upload'
-  const inputSelector = '.nhsuk-file-upload__input'
-  const dropZoneSelector = '.nhsuk-file-upload__drop-zone'
-  const dropButtonSelector = '.nhsuk-file-upload__drop-button'
-  const chooseFilesButtonSelector = '.nhsuk-file-upload__choose-files-button'
-  const announcementsSelector = '.nhsuk-file-upload__announcements'
-  const statusSelector = '.nhsuk-file-upload__status'
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /** @type {ElementHandle<HTMLInputElement>} */
+  let $input
+
+  /** @type {ElementHandle<HTMLElement>} */
+  let $dropZone
+
+  /** @type {ElementHandle<HTMLButtonElement>} */
+  let $dropButton
+
+  /** @type {ElementHandle} */
+  let $chooseFilesButton
+
+  /** @type {ElementHandle} */
+  let $status
+
+  /** @type {ElementHandle} */
+  let $announcements
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'file-upload', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${FileUpload.moduleName}"]`)
+    )
+
+    $input = /** @type {ElementHandle<HTMLInputElement>} */ (
+      await $component.$('input')
+    )
+
+    $dropZone = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$(`.${FileUpload.defaults.dropZoneClass}`)
+    )
+
+    $dropButton = /** @type {ElementHandle<HTMLButtonElement>} */ (
+      await $component.$(`.${FileUpload.defaults.dropButtonClass}`)
+    )
+
+    $chooseFilesButton = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$(`.${FileUpload.defaults.chooseFilesButtonClass}`)
+    )
+
+    $status = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$(`.${FileUpload.defaults.statusClass}`)
+    )
+
+    $announcements = /** @type {ElementHandle<HTMLElement>} */ (
+      await $component.$(`.${FileUpload.defaults.announcementsClass}`)
+    )
+  }
 
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
-      await render(page, 'file-upload', examples['with hint'])
+      await initExample('with hint')
     })
 
     afterAll(async () => {
@@ -25,134 +79,98 @@ describe('File upload', () => {
     })
 
     it('still renders an unmodified file input', async () => {
-      const inputType = await page.$eval(inputSelector, (el) =>
-        el.getAttribute('type')
-      )
-      expect(inputType).toBe('file')
+      expect(await getAttribute($input, 'type')).toBe('file')
     })
 
     it('does not inject additional elements', async () => {
-      const $wrapperElement = await page.$(dropZoneSelector)
-      const $buttonElement = await page.$(dropButtonSelector)
-      const $statusElement = await page.$(statusSelector)
-
-      expect($wrapperElement).toBeNull()
-      expect($buttonElement).toBeNull()
-      expect($statusElement).toBeNull()
+      expect($dropZone).toBeNull()
+      expect($dropButton).toBeNull()
+      expect($status).toBeNull()
     })
   })
 
   describe('when JavaScript is available', () => {
     describe('on page load', () => {
       beforeAll(async () => {
-        await render(page, 'file-upload', examples['with hint'])
+        await initExample('with hint')
       })
 
       describe('wrapper element', () => {
         it('renders the wrapper element', async () => {
-          const wrapperElement = await page.$eval(dropZoneSelector, (el) => el)
-
-          expect(wrapperElement).toBeDefined()
+          expect($dropZone).toBeDefined()
         })
 
         it('moves the file input inside of the wrapper element', async () => {
-          const inputElementParent = await page.$eval(
-            inputSelector,
-            (el) => el.parentElement
+          const isDropZoneInputParent = await page.evaluate(
+            ($el1, $el2) => $el1 === $el2.parentElement,
+            $dropZone,
+            $input
           )
 
-          const wrapperElement = await page.$eval(dropZoneSelector, (el) => el)
-
-          expect(inputElementParent).toStrictEqual(wrapperElement)
+          expect(isDropZoneInputParent).toBe(true)
         })
       })
 
       describe('file input', () => {
         it('sets tabindex to -1', async () => {
-          const inputElementTabindex = await page.$eval(inputSelector, (el) =>
-            el.getAttribute('tabindex')
-          )
-
-          expect(inputElementTabindex).toBe('-1')
+          expect(await getAttribute($input, 'tabindex')).toBe('-1')
         })
       })
 
       describe('label element', () => {
         it('targets the button in its `for` attribute', async () => {
-          const buttonId = await page.$eval(dropButtonSelector, (el) => el.id)
-          const label = await page.$(`[for="${buttonId}"]`)
+          const buttonId = await getProperty($dropButton, 'id')
+          const $label = await $component.$(`[for="${buttonId}"]`)
 
-          expect(label).not.toBeNull()
+          expect($label).not.toBeNull()
         })
       })
 
       describe('choose file button', () => {
         it('renders the button element', async () => {
-          const buttonElement = await page.$eval(dropButtonSelector, (el) => el)
-          const buttonElementType = await page.$eval(dropButtonSelector, (el) =>
-            el.getAttribute('type')
-          )
-
-          expect(buttonElement).toBeDefined()
-          expect(buttonElementType).toBe('button')
+          expect($dropButton).toBeDefined()
+          expect(await getAttribute($dropButton, 'type')).toBe('button')
         })
 
         it('has same aria-describedby value as input', async () => {
-          const buttonElementAriaDescribedBy = await page.$eval(
-            dropButtonSelector,
-            (el) => el.getAttribute('aria-describedby')
+          expect(await getAttribute($dropButton, 'aria-describedby')).toBe(
+            'file-upload-hint'
           )
-
-          expect(buttonElementAriaDescribedBy).toBe('file-upload-hint')
         })
 
         it('renders the button with default text', async () => {
-          const buttonElementText = await page.$eval(
-            `${dropButtonSelector} ${chooseFilesButtonSelector}`,
-            (el) => el.innerHTML.trim()
-          )
-
-          const [statusElementText, statusElementAriaLiveAttribute] =
-            await page.$eval(
-              `${dropButtonSelector} ${statusSelector}`,
-              (el) => [el.innerHTML.trim(), el.getAttribute('aria-live')]
-            )
-
-          expect(buttonElementText).toBe('Choose file')
-          expect(statusElementText).toBe('No file chosen')
-          expect(statusElementAriaLiveAttribute).toBe('polite')
+          expect(await getText($chooseFilesButton)).toBe('Choose file')
+          expect(await getText($status)).toBe('No file chosen')
+          expect(await getAttribute($status, 'aria-live')).toBe('polite')
         })
       })
     })
 
     describe('when clicking the choose file button', () => {
-      it.each([dropButtonSelector, chooseFilesButtonSelector, statusSelector])(
-        'opens the file picker',
-        async (selector) => {
-          // It doesn't seem to be possible to check if the file picker dialog
-          // opens as an isolated test, so this test clicks the button, tries to
-          // set a value in the file chooser, then checks if that value was set
-          // on the input as expected.
-          const testFilename = 'test.gif'
+      it.each([
+        `.${FileUpload.defaults.dropButtonClass}`,
+        `.${FileUpload.defaults.chooseFilesButtonClass}`,
+        `.${FileUpload.defaults.statusClass}`
+      ])('opens the file picker', async (selector) => {
+        // It doesn't seem to be possible to check if the file picker dialog
+        // opens as an isolated test, so this test clicks the button, tries to
+        // set a value in the file chooser, then checks if that value was set
+        // on the input as expected.
+        const testFilename = 'test.gif'
 
-          const [fileChooser] = await Promise.all([
-            page.waitForFileChooser(),
-            page.click(selector)
-          ])
+        const [fileChooser] = await Promise.all([
+          page.waitForFileChooser(),
+          page.click(selector)
+        ])
 
-          await fileChooser.accept([testFilename])
+        await fileChooser.accept([testFilename])
 
-          const inputElementValue = await page.$eval(
-            inputSelector,
-            // @ts-expect-error - Property 'value' does not exist
-            (el) => el.value
-          )
-
-          // For Windows and backward compatibility, the values of file inputs
-          // are always formatted starting with `C:\\fakepath\\`
-          expect(inputElementValue).toBe(`C:\\fakepath\\${testFilename}`)
-        }
-      )
+        // For Windows and backward compatibility, the values of file inputs
+        // are always formatted starting with `C:\\fakepath\\`
+        expect(await getProperty($input, 'value')).toBe(
+          `C:\\fakepath\\${testFilename}`
+        )
+      })
     })
 
     describe('when selecting a file', () => {
@@ -161,92 +179,64 @@ describe('File upload', () => {
       beforeEach(async () => {
         const [fileChooser] = await Promise.all([
           page.waitForFileChooser(),
-          page.click(dropButtonSelector)
+          $dropButton?.click()
         ])
+
         await fileChooser.accept([testFilename])
       })
 
       it('updates the file input value', async () => {
-        const inputElementValue = await page.$eval(
-          inputSelector,
-          // @ts-expect-error - Property 'value' does not exist
-          (el) => el.value
-        )
-
-        const inputElementFiles = await page.$eval(
-          inputSelector,
-          // @ts-expect-error - Property 'files' does not exist
-          (el) => el.files
-        )
+        const inputElementFiles = await $input.evaluate(($el) => $el.files)
 
         // For Windows and backward compatibility, the values of file inputs
         // are always formatted starting with `C:\\fakepath\\`
-        expect(inputElementValue).toBe(`C:\\fakepath\\${testFilename}`)
+        expect(await getProperty($input, 'value')).toBe(
+          `C:\\fakepath\\${testFilename}`
+        )
 
         // Also check the files object
-        expect(inputElementFiles[0]).toBeDefined()
+        expect(inputElementFiles?.[0]).toBeDefined()
       })
 
       it('updates the filename in the status element', async () => {
-        const statusElementText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-
-        expect(statusElementText).toBe(testFilename)
+        expect(await getText($status)).toBe(testFilename)
       })
     })
 
     describe('when selecting multiple files', () => {
       beforeEach(async () => {
-        await render(page, 'file-upload', examples['with multiple'])
+        await initExample('with multiple')
 
         const [fileChooser] = await Promise.all([
           page.waitForFileChooser(),
-          page.click(dropButtonSelector)
+          $dropButton?.click()
         ])
+
         await fileChooser.accept(['testfile1.txt', 'testfile2.pdf'])
       })
 
       it('updates the file input value', async () => {
-        const inputElementValue = await page.$eval(
-          inputSelector,
-          // @ts-expect-error - Property 'value' does not exist
-          (el) => el.value
-        )
-
-        const inputElementFiles = await page.$eval(
-          inputSelector,
-          // @ts-expect-error - Property 'files' does not exist
-          (el) => el.files
-        )
+        const inputElementFiles = await $input.evaluate(($el) => $el.files)
 
         // For Windows and backward compatibility, the values of file inputs
         // are always formatted starting with `C:\\fakepath\\`
         //
         // Additionally, `value` will only ever return the first file selected
-        expect(inputElementValue).toBe(`C:\\fakepath\\testfile1.txt`)
+        expect(await getProperty($input, 'value')).toBe(
+          `C:\\fakepath\\testfile1.txt`
+        )
 
         // Also check the files object
-        expect(inputElementFiles[0]).toBeDefined()
-        expect(inputElementFiles[1]).toBeDefined()
+        expect(inputElementFiles?.[0]).toBeDefined()
+        expect(inputElementFiles?.[1]).toBeDefined()
       })
 
       it('shows the number of files selected in the status element', async () => {
-        const statusElementText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-
-        expect(statusElementText).toBe('2 files chosen')
+        expect(await getText($status)).toBe('2 files chosen')
       })
     })
 
     describe('dropzone', () => {
-      /** @type {ElementHandle} */
-      let $wrapper
-
-      /** @type {ElementHandle} */
-      let $announcements
-
       /** @type {BoundingBox} */
       let wrapperBoundingBox
 
@@ -261,36 +251,25 @@ describe('File upload', () => {
         dragOperationsMask: 1 // Copy
       }
 
-      const selectorDropzoneVisible = `${dropButtonSelector}${dropButtonSelector}--dragging`
-      const selectorDropzoneHidden = `${dropButtonSelector}:not(${dropButtonSelector}--dragging)`
-
       beforeEach(async () => {
-        await render(page, 'file-upload', examples.default)
-
-        $wrapper = /** @type {ElementHandle} */ (await page.$(dropZoneSelector))
+        await initExample('default')
 
         wrapperBoundingBox = /** @type {BoundingBox} */ (
-          await $wrapper.boundingBox()
-        )
-
-        $announcements = /** @type {ElementHandle} */ (
-          await page.$(announcementsSelector)
+          await $dropZone?.boundingBox()
         )
       })
 
       it('is not shown by default', async () => {
-        await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
+        expect(await getAttribute($dropButton, 'class')).not.toContain(
+          'nhsuk-file-upload__drop-button--dragging'
+        )
 
-        const [announcementsText, announcementsAriaLive] =
-          await $announcements.evaluate((e) => [
-            e.textContent,
-            e.getAttribute('aria-live')
-          ])
-
-        expect(announcementsText).toBe('')
+        expect(await getText($announcements)).toBe('')
         // As the announcement is feedback while user is dragging,
         // best to announce it as soon as the user enters the zone
-        expect(announcementsAriaLive).toBe('assertive')
+        expect(await getAttribute($announcements, 'aria-live')).toBe(
+          'assertive'
+        )
       })
 
       it('gets shown when entering the field', async () => {
@@ -300,10 +279,11 @@ describe('File upload', () => {
           structuredClone(dragData)
         )
 
-        await expect(page.$(selectorDropzoneVisible)).resolves.toBeTruthy()
-        await expect(
-          $announcements.evaluate((e) => e.textContent)
-        ).resolves.toBe('Entered drop zone')
+        expect(await getAttribute($dropButton, 'class')).toContain(
+          'nhsuk-file-upload__drop-button--dragging'
+        )
+
+        await expect(getText($announcements)).resolves.toBe('Entered drop zone')
       })
 
       it('gets hidden when dropping on the field', async () => {
@@ -320,12 +300,13 @@ describe('File upload', () => {
           structuredClone(dragData)
         )
 
-        await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
+        expect(await getAttribute($dropButton, 'class')).not.toContain(
+          'nhsuk-file-upload__drop-button--dragging'
+        )
+
         // The presence of 'Entered drop zone' confirms we entered the drop zone
         // rather than being in the initial state
-        await expect(
-          $announcements.evaluate((e) => e.textContent)
-        ).resolves.toBe('Entered drop zone')
+        await expect(getText($announcements)).resolves.toBe('Entered drop zone')
       })
 
       it('gets hidden when dragging a file and leaving the field', async () => {
@@ -342,10 +323,11 @@ describe('File upload', () => {
           structuredClone(dragData)
         )
 
-        await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
-        await expect(
-          $announcements.evaluate((e) => e.textContent)
-        ).resolves.toBe('Left drop zone')
+        expect(await getAttribute($dropButton, 'class')).not.toContain(
+          'nhsuk-file-upload__drop-button--dragging'
+        )
+
+        await expect(getText($announcements)).resolves.toBe('Left drop zone')
       })
 
       it('gets hidden when dragging a file and leaving the document', async () => {
@@ -357,33 +339,31 @@ describe('File upload', () => {
 
         // It doesn't seem doable to make Puppeteer drag outside the viewport
         // so instead, we can only mock two 'dragleave' events
-        await page.$eval(dropZoneSelector, ($el) => {
+        await $dropZone?.evaluate(($el) => {
           $el.dispatchEvent(new Event('dragleave', { bubbles: true }))
           $el.dispatchEvent(new Event('dragleave', { bubbles: true }))
         })
 
-        await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
-        await expect(
-          $announcements.evaluate((e) => e.textContent)
-        ).resolves.toBe('Left drop zone')
+        expect(await getAttribute($dropButton, 'class')).not.toContain(
+          'nhsuk-file-upload__drop-button--dragging'
+        )
+
+        await expect(getText($announcements)).resolves.toBe('Left drop zone')
       })
 
       it('does not appear if button disabled', async () => {
-        await render(page, 'file-upload', examples.disabled)
+        await initExample('disabled')
 
         await page.mouse.dragEnter(
           { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
           structuredClone(dragData)
         )
 
-        const disabledAnnouncement = /** @type {ElementHandle} */ (
-          await page.$(announcementsSelector)
+        expect(await getAttribute($dropButton, 'class')).not.toContain(
+          'nhsuk-file-upload__drop-button--dragging'
         )
 
-        await expect(page.$(selectorDropzoneHidden)).resolves.toBeTruthy()
-        await expect(
-          disabledAnnouncement.evaluate((e) => e.textContent)
-        ).resolves.toBe('')
+        await expect(getText($announcements)).resolves.toBe('')
       })
     })
 
@@ -391,171 +371,125 @@ describe('File upload', () => {
       beforeEach(async () => {})
 
       it('includes the label, the status, the pseudo button and instruction', async () => {
-        await render(page, 'file-upload', examples.default)
+        await initExample('default')
 
-        const $element = await page.$(dropButtonSelector)
-
-        const accessibleName = await getAccessibleName(page, $element)
-        await expect(accessibleName.replaceAll(/\s+/g, ' ')).toBe(
-          'Upload a file , No file chosen , Choose file or drop file'
+        expect(await getAccessibleName(page, $dropButton)).toBe(
+          'Upload a file  ,   No file chosen  ,   Choose file or drop file'
         )
       })
 
       it('includes the label, file name, pseudo button and instruction once a file is selected', async () => {
-        await render(page, 'file-upload', examples.default)
-
-        const $element = await page.$(dropButtonSelector)
+        await initExample('default')
 
         const [fileChooser] = await Promise.all([
           page.waitForFileChooser(),
-          page.click(dropButtonSelector)
+          $dropButton?.click()
         ])
+
         await fileChooser.accept(['fakefile.txt'])
 
-        const accessibleName = await getAccessibleName(page, $element)
-        await expect(accessibleName.replaceAll(/\s+/g, ' ')).toBe(
-          'Upload a file , fakefile.txt , Choose file or drop file'
+        expect(await getAccessibleName(page, $dropButton)).toBe(
+          'Upload a file  ,   fakefile.txt  ,   Choose file or drop file'
         )
       })
 
       it('includes the label, file name, pseudo button and instruction once multiple files are selected', async () => {
-        await render(page, 'file-upload', examples['with multiple'])
-
-        const $element = await page.$(dropButtonSelector)
+        await initExample('with multiple')
 
         const [fileChooser] = await Promise.all([
           page.waitForFileChooser(),
-          page.click(dropButtonSelector)
+          $dropButton?.click()
         ])
+
         await fileChooser.accept(['fakefile1.txt', 'fakefile2.txt'])
 
-        const accessibleName = await getAccessibleName(page, $element)
-        await expect(accessibleName.replaceAll(/\s+/g, ' ')).toBe(
-          'Upload multiple files , 2 files chosen , Choose files or drop files'
+        expect(await getAccessibleName(page, $dropButton)).toBe(
+          'Upload multiple files  ,   2 files chosen  ,   Choose files or drop files'
         )
       })
     })
 
     describe('i18n', () => {
       beforeEach(async () => {
-        await render(page, 'file-upload', examples['with translations'])
+        await initExample('with translations')
       })
 
       it('uses the correct translation for the choose file button', async () => {
-        const buttonElementText = await page.$eval(
-          chooseFilesButtonSelector,
-          (el) => el.innerHTML.trim()
-        )
-
-        const statusElementText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-
-        expect(buttonElementText).toBe('Dewiswch ffeil')
-        expect(statusElementText).toBe("Dim ffeil wedi'i dewis")
+        expect(await getText($chooseFilesButton)).toBe('Dewiswch ffeil')
+        expect(await getText($status)).toBe("Dim ffeil wedi'i dewis")
       })
 
       describe('status element', () => {
         it('uses the correct translation when no files are selected', async () => {
-          const statusText = await page.$eval(statusSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(statusText).toBe("Dim ffeil wedi'i dewis")
+          expect(await getText($status)).toBe("Dim ffeil wedi'i dewis")
         })
 
         it('uses the correct translation when multiple files are selected', async () => {
           const [fileChooser] = await Promise.all([
             page.waitForFileChooser(),
-            page.click(dropButtonSelector)
+            $dropButton?.click()
           ])
+
           await fileChooser.accept(['testfile1.txt', 'testfile2.pdf'])
 
-          const statusText = await page.$eval(statusSelector, (el) =>
-            el.innerHTML.trim()
-          )
-
-          expect(statusText).toBe("2 ffeil wedi'u dewis")
+          expect(await getText($status)).toBe("2 ffeil wedi'u dewis")
         })
       })
     })
 
     describe('disabled state syncing', () => {
       it('disables the button if the input is disabled on page load', async () => {
-        await render(page, 'file-upload', examples.disabled)
+        await initExample('disabled')
 
-        const buttonDisabled = await page.$eval(dropButtonSelector, (el) =>
-          el.hasAttribute('disabled')
+        expect(await getProperty($dropButton, 'disabled')).toBe(true)
+        expect(await getAttribute($component, 'class')).toContain(
+          'nhsuk-file-upload--disabled'
         )
-        const dropZoneDisabled = await page.$eval(moduleSelector, (el) =>
-          el.classList.contains('nhsuk-file-upload--disabled')
-        )
-
-        expect(buttonDisabled).toBeTruthy()
-        expect(dropZoneDisabled).toBeTruthy()
       })
 
       it('disables the button if the input is disabled programmatically', async () => {
-        await render(page, 'file-upload', examples.default)
+        await initExample('default')
 
-        await page.$eval(inputSelector, (el) => el.setAttribute('disabled', ''))
+        await $input.evaluate(($el) => $el.setAttribute('disabled', ''))
 
-        const buttonDisabledAfter = await page.$eval(dropButtonSelector, (el) =>
-          el.hasAttribute('disabled')
+        expect(await getProperty($dropButton, 'disabled')).toBe(true)
+        expect(await getAttribute($component, 'class')).toContain(
+          'nhsuk-file-upload--disabled'
         )
-        const dropZoneDisabled = await page.$eval(moduleSelector, (el) =>
-          el.classList.contains('nhsuk-file-upload--disabled')
-        )
-
-        expect(buttonDisabledAfter).toBeTruthy()
-        expect(dropZoneDisabled).toBeTruthy()
       })
 
       it('enables the button if the input is enabled programmatically', async () => {
-        await render(page, 'file-upload', examples.disabled)
+        await initExample('disabled')
 
-        await page.$eval(inputSelector, (el) => el.removeAttribute('disabled'))
+        await $input.evaluate(($el) => $el.removeAttribute('disabled'))
 
-        const buttonDisabled = await page.$eval(dropButtonSelector, (el) =>
-          el.hasAttribute('disabled')
+        expect(await getProperty($dropButton, 'disabled')).toBe(false)
+        expect(await getAttribute($component, 'class')).not.toContain(
+          'nhsuk-file-upload--disabled'
         )
-        const dropZoneDisabled = await page.$eval(moduleSelector, (el) =>
-          el.classList.contains('nhsuk-file-upload--disabled')
-        )
-
-        expect(buttonDisabled).toBeFalsy()
-        expect(dropZoneDisabled).toBeFalsy()
       })
     })
 
     describe('aria-describedby', () => {
       it('copies the `aria-describedby` attribute from the `<input>` to the `<button>`', async () => {
-        await render(page, 'file-upload', examples['with hint and error'])
+        await initExample('with hint and error')
 
-        const $button = await page.$(dropButtonSelector)
-        const ariaDescribedBy = await $button?.evaluate((el) =>
-          el.getAttribute('aria-describedby')
+        expect(await getAttribute($dropButton, 'aria-describedby')).toBe(
+          'file-upload-hint file-upload-error'
         )
-
-        expect(ariaDescribedBy).toBe('file-upload-hint file-upload-error')
       })
 
       it('does not add an `aria-describedby` attribute to the `<button>` if there is none on the `<input>`', async () => {
-        await render(page, 'file-upload', examples.default)
+        await initExample('default')
 
-        const $button = await page.$(dropButtonSelector)
-        const ariaDescribedBy = await $button?.evaluate((el) =>
-          el.getAttribute('aria-describedby')
-        )
-
-        expect(ariaDescribedBy).toBeNull()
+        expect(await getAttribute($dropButton, 'aria-describedby')).toBeNull()
       })
     })
 
     describe('errors at instantiation', () => {
-      it('can throw a SupportError if appropriate', async () => {
-        await expect(
-          render(page, 'file-upload', examples.default, {
+      it('can throw a SupportError if appropriate', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation() {
               document.body.classList.remove('nhsuk-frontend-supported')
             }
@@ -569,9 +503,9 @@ describe('File upload', () => {
         })
       })
 
-      it('throws when initialised twice', async () => {
-        await expect(
-          render(page, 'file-upload', examples.default, {
+      it('throws when initialised twice', () => {
+        return expect(
+          initExample('default', {
             async afterInitialisation($root) {
               const { FileUpload } = await import('nhsuk-frontend')
               new FileUpload($root)
@@ -584,9 +518,9 @@ describe('File upload', () => {
         })
       })
 
-      it('throws when $root is not set', async () => {
-        await expect(
-          render(page, 'file-upload', examples.default, {
+      it('throws when $root is not set', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               $root.remove()
             }
@@ -599,9 +533,9 @@ describe('File upload', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $root', async () => {
-        await expect(
-          render(page, 'file-upload', examples.default, {
+      it('throws when receiving the wrong type for $root', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $root.outerHTML = `<svg data-module="nhsuk-file-upload"></svg>`
@@ -617,9 +551,9 @@ describe('File upload', () => {
       })
 
       describe('missing or misconfigured elements', () => {
-        it('throws if the input is missing', async () => {
-          await expect(
-            render(page, 'file-upload', examples.default, {
+        it('throws if the input is missing', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation() {
                 document.querySelector('[type="file"]')?.remove()
               }
@@ -632,9 +566,9 @@ describe('File upload', () => {
           })
         })
 
-        it('throws if the input has no `id` attribute', async () => {
-          await expect(
-            render(page, 'file-upload', examples.default, {
+        it('throws if the input has no `id` attribute', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation() {
                 document.querySelector('[type="file"]')?.removeAttribute('id')
               }
@@ -648,9 +582,9 @@ describe('File upload', () => {
           })
         })
 
-        it('throws if the input type is not "file"', async () => {
-          await expect(
-            render(page, 'file-upload', examples.default, {
+        it('throws if the input type is not "file"', () => {
+          return expect(
+            initExample('default', {
               beforeInitialisation() {
                 document
                   .querySelector('[type="file"]')
@@ -668,7 +602,7 @@ describe('File upload', () => {
 
         it('throws if no label is present', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
+            initExample('default', {
               beforeInitialisation() {
                 document.querySelector('label')?.remove()
               }
@@ -687,22 +621,23 @@ describe('File upload', () => {
 
         it('does not throw if the drop zone already exists', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
-              beforeInitialisation($root, { selector }) {
+            initExample('default', {
+              beforeInitialisation($root, { dropZoneSelector, inputSelector }) {
                 const $input = /** @type {HTMLElement} */ (
-                  $root.querySelector(selector)
+                  $root.querySelector(inputSelector)
                 )
 
                 // 1. Create drop zone
                 const $dropZone = document.createElement('div')
-                $dropZone.classList.add('nhsuk-file-upload__drop-zone')
+                $dropZone.classList.add(dropZoneSelector)
 
                 // 2. Move input into drop zone
                 $input.replaceWith($dropZone)
                 $dropZone.appendChild($input)
               },
               context: {
-                selector: inputSelector
+                dropZoneSelector: FileUpload.defaults.dropZoneClass,
+                inputSelector: 'input'
               }
             })
           ).resolves.not.toThrow()
@@ -713,15 +648,15 @@ describe('File upload', () => {
 
         it('does not throw if the drop zone has `data-module` attribute', async () => {
           await expect(
-            render(page, 'file-upload', examples.default, {
-              beforeInitialisation($root, { selector }) {
+            initExample('default', {
+              beforeInitialisation($root, { dropZoneSelector, inputSelector }) {
                 const $input = /** @type {HTMLElement} */ (
-                  $root.querySelector(selector)
+                  $root.querySelector(inputSelector)
                 )
 
                 // 1. Create drop zone
                 const $dropZone = document.createElement('div')
-                $dropZone.classList.add('nhsuk-file-upload__drop-zone')
+                $dropZone.classList.add(dropZoneSelector)
 
                 // 2. Move input into drop zone
                 $input.replaceWith($dropZone)
@@ -732,7 +667,8 @@ describe('File upload', () => {
                 $dropZone.setAttribute('data-module', 'nhsuk-file-upload')
               },
               context: {
-                selector: inputSelector
+                dropZoneSelector: FileUpload.defaults.dropZoneClass,
+                inputSelector: 'input'
               }
             })
           ).resolves.not.toThrow()
@@ -746,5 +682,6 @@ describe('File upload', () => {
 })
 
 /**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
  * @import { BoundingBox, ElementHandle, Protocol } from 'puppeteer'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/file-upload.puppeteer.test.mjs
@@ -237,26 +237,26 @@ describe('File upload', () => {
     })
 
     describe('dropzone', () => {
-      /** @type {BoundingBox} */
-      let wrapperBoundingBox
-
       /**
        * Shared data to drag on the element
        *
        * @type {Protocol.Input.DragData}
        */
-      const dragData = {
-        items: [],
-        files: [__filename],
-        dragOperationsMask: 1 // Copy
-      }
+      let dragData
+
+      /** @type {Point} */
+      let dragPosition
 
       beforeEach(async () => {
         await initExample('default')
 
-        wrapperBoundingBox = /** @type {BoundingBox} */ (
-          await $dropZone?.boundingBox()
-        )
+        dragData = {
+          items: [],
+          files: [import.meta.filename],
+          dragOperationsMask: 1 // Copy
+        }
+
+        dragPosition = await $dropZone.clickablePoint({ x: 0, y: 0 })
       })
 
       it('is not shown by default', async () => {
@@ -273,11 +273,7 @@ describe('File upload', () => {
       })
 
       it('gets shown when entering the field', async () => {
-        // Add a little pixel to make sure we're effectively within the element
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
+        await page.mouse.dragEnter(dragPosition, dragData)
 
         expect(await getAttribute($dropButton, 'class')).toContain(
           'nhsuk-file-upload__drop-button--dragging'
@@ -290,15 +286,8 @@ describe('File upload', () => {
         // Puppeteer's Mouse.drop is meant to do both the `dragEnter` and
         // `drop` in a row but it seems to do this too quickly for the
         // `<input>` to effectively receive the drop
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
-
-        await page.mouse.drop(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
+        await page.mouse.dragEnter(dragPosition, dragData)
+        await page.mouse.drop(dragPosition, dragData)
 
         expect(await getAttribute($dropButton, 'class')).not.toContain(
           'nhsuk-file-upload__drop-button--dragging'
@@ -310,18 +299,13 @@ describe('File upload', () => {
       })
 
       it('gets hidden when dragging a file and leaving the field', async () => {
-        // Add a little pixel to make sure we're effectively within the element
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
+        await page.mouse.dragEnter(dragPosition, dragData)
 
         // Move enough to the left to be out of the wrapper properly
         // but not up or down in case there's other elements in the flow of the page
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x - 20, y: wrapperBoundingBox.y },
-          structuredClone(dragData)
-        )
+        dragPosition.x -= 20
+
+        await page.mouse.dragEnter(dragPosition, dragData)
 
         expect(await getAttribute($dropButton, 'class')).not.toContain(
           'nhsuk-file-upload__drop-button--dragging'
@@ -331,11 +315,7 @@ describe('File upload', () => {
       })
 
       it('gets hidden when dragging a file and leaving the document', async () => {
-        // Add a little pixel to make sure we're effectively within the element
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
+        await page.mouse.dragEnter(dragPosition, dragData)
 
         // It doesn't seem doable to make Puppeteer drag outside the viewport
         // so instead, we can only mock two 'dragleave' events
@@ -354,10 +334,7 @@ describe('File upload', () => {
       it('does not appear if button disabled', async () => {
         await initExample('disabled')
 
-        await page.mouse.dragEnter(
-          { x: wrapperBoundingBox.x + 1, y: wrapperBoundingBox.y + 1 },
-          structuredClone(dragData)
-        )
+        await page.mouse.dragEnter(dragPosition, dragData)
 
         expect(await getAttribute($dropButton, 'class')).not.toContain(
           'nhsuk-file-upload__drop-button--dragging'
@@ -683,5 +660,5 @@ describe('File upload', () => {
 
 /**
  * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
- * @import { BoundingBox, ElementHandle, Protocol } from 'puppeteer'
+ * @import { ElementHandle, Point, Protocol } from 'puppeteer'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
@@ -45,93 +45,6 @@ describe('Notification banner', () => {
       expect(await getAttribute($component, 'tabindex')).toBeNull()
     })
 
-    describe('and auto-focus is disabled using data attributes', () => {
-      beforeAll(async () => {
-        await initExample('auto-focus disabled, with success variant')
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus the notification banner', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
-      })
-    })
-
-    describe('and auto-focus is disabled using JavaScript configuration', () => {
-      beforeAll(async () => {
-        await initExample('with success variant', {
-          config: {
-            disableAutoFocus: true
-          }
-        })
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus the notification banner', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
-      })
-    })
-
-    describe('and auto-focus is disabled using options passed to initAll', () => {
-      beforeAll(async () => {
-        await initExample('with success variant', {
-          config: {
-            disableAutoFocus: true
-          }
-        })
-      })
-
-      it('does not have a tabindex attribute', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBeNull()
-      })
-
-      it('does not focus the notification banner', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
-      })
-    })
-
-    describe('and autofocus is disabled in JS but enabled in data attributes', () => {
-      beforeAll(async () => {
-        await initExample(
-          'auto-focus explicitly enabled, with success variant',
-          {
-            config: {
-              disableAutoFocus: true
-            }
-          }
-        )
-      })
-
-      it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-        expect(await getAttribute($component, 'tabindex')).toBe('-1')
-      })
-
-      it('is automatically focused when the page loads', async () => {
-        const activeElementModuleName = await page.evaluate(() =>
-          document.activeElement?.getAttribute('data-module')
-        )
-
-        expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
-      })
-    })
-
     describe('and role is overridden to "region"', () => {
       beforeAll(async () => {
         await initExample(
@@ -161,6 +74,97 @@ describe('Notification banner', () => {
         await $component.evaluate(($el) => $el.blur())
 
         expect(await getAttribute($component, 'tabindex')).toBe('2')
+      })
+    })
+  })
+
+  describe('JavaScript configuration', () => {
+    describe('during initialisation', () => {
+      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+        await initExample('with success variant', {
+          config: {
+            disableAutoFocus: true
+          }
+        })
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Does not add the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
+
+        // Does not automatically focus on page load
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
+      })
+
+      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+        await initExample('with success variant', {
+          config: {
+            disableAutoFocus: false
+          }
+        })
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
+      })
+    })
+
+    describe('with HTML data attributes', () => {
+      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+        await initExample('auto-focus disabled, with success variant')
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Does not add the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
+
+        // Does not automatically focus on page load
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
+      })
+
+      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+        await initExample('auto-focus explicitly enabled, with success variant')
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
+      })
+
+      it('uses `disableAutoFocus` data attribute instead of JavaScript `disableAutoFocus`', async () => {
+        await initExample(
+          'auto-focus explicitly enabled, with success variant',
+          {
+            config: {
+              disableAutoFocus: false
+            }
+          }
+        )
+
+        const activeElementModuleName = await page.evaluate(() =>
+          document.activeElement?.getAttribute('data-module')
+        )
+
+        // Adds the tabindex attribute on page load
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
+
+        // Automatically focused on page load
+        expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
@@ -80,7 +80,7 @@ describe('Notification banner', () => {
 
   describe('JavaScript configuration', () => {
     describe('during initialisation', () => {
-      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+      it('configures `disableAutoFocus: true` to prevent auto-focus', async () => {
         await initExample('with success variant', {
           config: {
             disableAutoFocus: true
@@ -98,7 +98,7 @@ describe('Notification banner', () => {
         expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
 
-      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+      it('configures `disableAutoFocus: false` to explicitly enable auto-focus', async () => {
         await initExample('with success variant', {
           config: {
             disableAutoFocus: false
@@ -118,7 +118,7 @@ describe('Notification banner', () => {
     })
 
     describe('with HTML data attributes', () => {
-      it("configures 'disableAutoFocus: true' to prevent auto-focus", async () => {
+      it('configures `disableAutoFocus: true` to prevent auto-focus', async () => {
         await initExample('auto-focus disabled, with success variant')
 
         const activeElementModuleName = await page.evaluate(() =>
@@ -132,7 +132,7 @@ describe('Notification banner', () => {
         expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
 
-      it("configures 'disableAutoFocus: false' to explicitly enable auto-focus", async () => {
+      it('configures `disableAutoFocus: false` to explicitly enable auto-focus', async () => {
         await initExample('auto-focus explicitly enabled, with success variant')
 
         const activeElementModuleName = await page.evaluate(() =>

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
@@ -1,149 +1,116 @@
-import { render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import { getAttribute, render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
 import { examples } from './fixtures.mjs'
+import { NotificationBanner } from './notification-banner.mjs'
 
 describe('Notification banner', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'notification-banner', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${NotificationBanner.moduleName}"]`)
+    )
+  }
+
   describe('when variant is set to "success"', () => {
     it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-      await render(
-        page,
-        'notification-banner',
-        examples['with success variant']
-      )
+      await initExample('with success variant')
 
-      const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBe('-1')
+      expect(await getAttribute($component, 'tabindex')).toBe('-1')
     })
 
     it('is automatically focused when the page loads', async () => {
-      await render(
-        page,
-        'notification-banner',
-        examples['with success variant']
-      )
+      await initExample('with success variant')
 
-      const activeElement = await page.evaluate(() =>
+      const activeElementModuleName = await page.evaluate(() =>
         document.activeElement?.getAttribute('data-module')
       )
 
-      expect(activeElement).toBe('nhsuk-notification-banner')
+      expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
     })
 
     it('removes the tabindex attribute on blur', async () => {
-      await render(
-        page,
-        'notification-banner',
-        examples['with success variant']
-      )
+      await initExample('with success variant')
 
-      await page.$eval(
-        '.nhsuk-notification-banner',
-        (el) => el instanceof window.HTMLElement && el.blur()
-      )
+      await $component.evaluate(($el) => $el.blur())
 
-      const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-      expect(tabindex).toBeNull()
+      expect(await getAttribute($component, 'tabindex')).toBeNull()
     })
 
     describe('and auto-focus is disabled using data attributes', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'notification-banner',
-          examples['auto-focus disabled, with success variant']
-        )
+        await initExample('auto-focus disabled, with success variant')
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus the notification banner', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-notification-banner')
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
     })
 
     describe('and auto-focus is disabled using JavaScript configuration', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'notification-banner',
-          examples['with success variant'],
-          {
-            config: {
-              disableAutoFocus: true
-            }
+        await initExample('with success variant', {
+          config: {
+            disableAutoFocus: true
           }
-        )
+        })
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus the notification banner', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-notification-banner')
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
     })
 
     describe('and auto-focus is disabled using options passed to initAll', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'notification-banner',
-          examples['with success variant'],
-          {
-            config: {
-              disableAutoFocus: true
-            }
+        await initExample('with success variant', {
+          config: {
+            disableAutoFocus: true
           }
-        )
+        })
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus the notification banner', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-notification-banner')
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
     })
 
     describe('and autofocus is disabled in JS but enabled in data attributes', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'notification-banner',
-          examples['auto-focus explicitly enabled, with success variant'],
+        await initExample(
+          'auto-focus explicitly enabled, with success variant',
           {
             config: {
               disableAutoFocus: true
@@ -153,71 +120,55 @@ describe('Notification banner', () => {
       })
 
       it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBe('-1')
+        expect(await getAttribute($component, 'tabindex')).toBe('-1')
       })
 
       it('is automatically focused when the page loads', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).toBe('nhsuk-notification-banner')
+        expect(activeElementModuleName).toBe(NotificationBanner.moduleName)
       })
     })
 
     describe('and role is overridden to "region"', () => {
       beforeAll(async () => {
-        await render(
-          page,
-          'notification-banner',
-          examples['role=alert overridden to role=region, with success variant']
+        await initExample(
+          'role=alert overridden to role=region, with success variant'
         )
       })
 
       it('does not have a tabindex attribute', async () => {
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-
-        expect(tabindex).toBeNull()
+        expect(await getAttribute($component, 'tabindex')).toBeNull()
       })
 
       it('does not focus the notification banner', async () => {
-        const activeElement = await page.evaluate(() =>
+        const activeElementModuleName = await page.evaluate(() =>
           document.activeElement?.getAttribute('data-module')
         )
 
-        expect(activeElement).not.toBe('nhsuk-notification-banner')
+        expect(activeElementModuleName).not.toBe(NotificationBanner.moduleName)
       })
     })
 
     describe('and a custom tabindex is set', () => {
       beforeAll(async () => {
-        await render(page, 'notification-banner', examples['custom tabindex'])
+        await initExample('custom tabindex')
       })
 
       it('does not remove the tabindex attribute on blur', async () => {
-        await page.$eval(
-          '.nhsuk-notification-banner',
-          (el) => el instanceof window.HTMLElement && el.blur()
-        )
+        await $component.evaluate(($el) => $el.blur())
 
-        const tabindex = await page.$eval('.nhsuk-notification-banner', (el) =>
-          el.getAttribute('tabindex')
-        )
-        expect(tabindex).toBe('2')
+        expect(await getAttribute($component, 'tabindex')).toBe('2')
       })
     })
   })
 
   describe('errors at instantiation', () => {
-    it('can throw a SupportError if appropriate', async () => {
-      await expect(
-        render(page, 'notification-banner', examples.default, {
+    it('can throw a SupportError if appropriate', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation() {
             document.body.classList.remove('nhsuk-frontend-supported')
           }
@@ -231,9 +182,9 @@ describe('Notification banner', () => {
       })
     })
 
-    it('throws when initialised twice', async () => {
-      await expect(
-        render(page, 'notification-banner', examples.default, {
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
           async afterInitialisation($root) {
             const { NotificationBanner } = await import('nhsuk-frontend')
             new NotificationBanner($root)
@@ -246,9 +197,9 @@ describe('Notification banner', () => {
       })
     })
 
-    it('throws when $root is not set', async () => {
-      await expect(
-        render(page, 'notification-banner', examples.default, {
+    it('throws when $root is not set', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             $root.remove()
           }
@@ -261,9 +212,9 @@ describe('Notification banner', () => {
       })
     })
 
-    it('throws when receiving the wrong type for $root', async () => {
-      await expect(
-        render(page, 'notification-banner', examples.default, {
+    it('throws when receiving the wrong type for $root', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $root.outerHTML = `<svg data-module="nhsuk-notification-banner"></svg>`
@@ -279,3 +230,8 @@ describe('Notification banner', () => {
     })
   })
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/notification-banner.puppeteer.test.mjs
@@ -165,7 +165,7 @@ describe('Notification banner', () => {
     })
   })
 
-  describe('errors at instantiation', () => {
+  describe('Error handling', () => {
     it('can throw a SupportError if appropriate', () => {
       return expect(
         initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.jsdom.test.mjs
@@ -225,7 +225,7 @@ describe('Password input', () => {
       initExample('default')
     })
 
-    describe('i18n', () => {
+    describe('during initialisation', () => {
       it('overrides the default translation keys', () => {
         const component = new PasswordInput($root, {
           i18n: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.puppeteer.test.mjs
@@ -1,11 +1,55 @@
-import { goToExample, render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import {
+  getAttribute,
+  getProperty,
+  getText,
+  goToExample,
+  render
+} from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
 import { examples } from './fixtures.mjs'
+import { PasswordInput } from './password-input.mjs'
 
 describe('Password input', () => {
   const inputSelector = '.nhsuk-js-password-input-input'
   const buttonSelector = '.nhsuk-js-password-input-toggle'
   const statusSelector = '.nhsuk-password-input__sr-status'
+
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /** @type {ElementHandle<HTMLInputElement>} */
+  let $input
+
+  /** @type {ElementHandle<HTMLButtonElement>} */
+  let $button
+
+  /** @type {ElementHandle<HTMLElement> | null} */
+  let $status
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'password-input', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${PasswordInput.moduleName}"]`)
+    )
+
+    $input = /** @type {ElementHandle<HTMLInputElement>} */ (
+      await $component.$(inputSelector)
+    )
+
+    $button = /** @type {ElementHandle<HTMLButtonElement>} */ (
+      await $component.$(buttonSelector)
+    )
+
+    $status = /** @type {ElementHandle<HTMLElement> | null} */ (
+      await $component.$(statusSelector)
+    )
+  }
 
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
@@ -17,58 +61,38 @@ describe('Password input', () => {
     })
 
     it('still renders an unmodified password input', async () => {
-      await render(page, 'password-input', examples.default)
+      await initExample('default')
 
-      const inputType = await page.$eval(inputSelector, (el) =>
-        el.getAttribute('type')
-      )
-      expect(inputType).toBe('password')
+      expect(await getAttribute($input, 'type')).toBe('password')
     })
 
     it('renders the toggle button hidden', async () => {
-      await render(page, 'password-input', examples.default)
+      await initExample('default')
 
-      const buttonHiddenAttribute = await page.$eval(buttonSelector, (el) =>
-        el.hasAttribute('hidden')
-      )
-      expect(buttonHiddenAttribute).toBeTruthy()
+      expect(await getProperty($button, 'hidden')).toBe(true)
     })
   })
 
   describe('when JavaScript is available', () => {
     describe('on page load', () => {
       beforeAll(async () => {
-        await render(page, 'password-input', examples.default)
+        await initExample('default')
       })
 
       it('renders the status element', async () => {
-        const statusElement = await page.$eval(statusSelector, (el) => el)
-
-        expect(statusElement).toBeDefined()
+        expect($status).toBeDefined()
       })
 
       it('renders the status element with aria-live', async () => {
-        const statusAriaLiveAttribute = await page.$eval(statusSelector, (el) =>
-          el.getAttribute('aria-live')
-        )
-
-        expect(statusAriaLiveAttribute).toBe('polite')
+        expect(await getAttribute($status, 'aria-live')).toBe('polite')
       })
 
       it('renders the status element empty', async () => {
-        const statusText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-
-        expect(statusText).toBe('')
+        expect(await getText($status)).toBe('')
       })
 
       it('shows the toggle button', async () => {
-        const buttonHiddenAttribute = await page.$eval(buttonSelector, (el) =>
-          el.hasAttribute('hidden')
-        )
-
-        expect(buttonHiddenAttribute).toBeFalsy()
+        expect(await getProperty($button, 'hidden')).toBe(false)
       })
     })
 
@@ -78,9 +102,9 @@ describe('Password input', () => {
       [3, itShowsThePassword]
     ])('when clicked %i time(s)', (clicks, expectation) => {
       beforeAll(async () => {
-        await render(page, 'password-input', examples.default)
+        await initExample('default')
         for (let i = 0; i < clicks; i++) {
-          await page.click(buttonSelector)
+          await $button.click()
         }
       })
 
@@ -106,17 +130,17 @@ describe('Password input', () => {
         await page.click(buttonSelector)
 
         // Check that the type change has occurred as expected
-        const beforeSubmitType = await page.$eval(inputSelector, (el) =>
-          el.getAttribute('type')
+        const $formInput = /** @type {ElementHandle<HTMLInputElement>} */ (
+          await page.$(inputSelector)
         )
+
+        const beforeSubmitType = await getAttribute($formInput, 'type')
 
         // Submit the form
         await page.click('main [type="submit"]')
 
         // Check the input type again
-        const afterSubmitType = await page.$eval(inputSelector, (el) =>
-          el.getAttribute('type')
-        )
+        const afterSubmitType = await getAttribute($formInput, 'type')
 
         expect(beforeSubmitType).toBe('text')
         expect(afterSubmitType).toBe('password')
@@ -125,62 +149,47 @@ describe('Password input', () => {
 
     describe('i18n', () => {
       it('uses the correct translations when the password is visible', async () => {
-        await render(page, 'password-input', examples['with translations'])
-        await page.click(buttonSelector)
+        await initExample('with translations')
 
-        const statusText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-        const buttonText = await page.$eval(buttonSelector, (el) =>
-          el.innerHTML.trim()
-        )
-        const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-          el.getAttribute('aria-label')
-        )
+        await $button.click()
 
         // Expect: passwordShownAnnouncementText
-        expect(statusText).toBe('Mae eich cyfrinair yn weladwy.')
+        expect(await getText($status)).toBe('Mae eich cyfrinair yn weladwy.')
 
         // Expect: hidePasswordText
-        expect(buttonText).toBe('Cuddio')
+        expect(await getText($button)).toBe('Cuddio')
 
         // Expect: hidePasswordAriaLabelText
-        expect(buttonAriaLabel).toBe('Cuddio cyfrinair')
+        expect(await getAttribute($button, 'aria-label')).toBe(
+          'Cuddio cyfrinair'
+        )
       })
 
       it('uses the correct translations when the password is hidden', async () => {
-        await render(page, 'password-input', examples['with translations'])
+        await initExample('with translations')
 
         // This test clicks the toggle twice because the status element is not populated when
         // the component is initialised, it only becomes populated after the first toggle.
-        await page.click(buttonSelector)
-        await page.click(buttonSelector)
-
-        const statusText = await page.$eval(statusSelector, (el) =>
-          el.innerHTML.trim()
-        )
-        const buttonText = await page.$eval(buttonSelector, (el) =>
-          el.innerHTML.trim()
-        )
-        const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-          el.getAttribute('aria-label')
-        )
+        await $button.click()
+        await $button.click()
 
         // Expect: passwordHiddenAnnouncementText
-        expect(statusText).toBe("Mae eich cyfrinair wedi'i guddio.")
+        expect(await getText($status)).toBe("Mae eich cyfrinair wedi'i guddio.")
 
         // Expect: showPasswordText
-        expect(buttonText).toBe('Datguddia')
+        expect(await getText($button)).toBe('Datguddia')
 
         // Expect: showPasswordAriaLabelText
-        expect(buttonAriaLabel).toBe('Datgelu cyfrinair')
+        expect(await getAttribute($button, 'aria-label')).toBe(
+          'Datgelu cyfrinair'
+        )
       })
     })
 
     describe('errors at instantiation', () => {
-      it('can throw a SupportError if appropriate', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('can throw a SupportError if appropriate', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation() {
               document.body.classList.remove('nhsuk-frontend-supported')
             }
@@ -194,9 +203,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when $root is not set', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when $root is not set', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               $root.remove()
             }
@@ -209,9 +218,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $root', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when receiving the wrong type for $root', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $root.outerHTML = `<svg data-module="nhsuk-password-input"></svg>`
@@ -226,9 +235,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the input element is missing', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the input element is missing', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               $root.querySelector(selector)?.remove()
             },
@@ -245,9 +254,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the input is not an <input> element', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the input is not an <input> element', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               const $textarea = document.createElement('textarea')
               $textarea.classList.add('nhsuk-js-password-input-input')
@@ -268,9 +277,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the input is not a `password` type', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the input is not a `password` type', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               // Make the input a number input instead
               $root.querySelector(selector)?.setAttribute('type', 'number')
@@ -288,9 +297,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the button is missing', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the button is missing', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               $root.querySelector(selector)?.remove()
             },
@@ -307,9 +316,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the button is not a <button> element', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the button is not a <button> element', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               const $div = document.createElement('div')
               $div.classList.add('nhsuk-js-password-input-toggle')
@@ -330,9 +339,9 @@ describe('Password input', () => {
         })
       })
 
-      it('throws when the button is not a `button` type', async () => {
-        await expect(
-          render(page, 'password-input', examples.default, {
+      it('throws when the button is not a `button` type', () => {
+        return expect(
+          initExample('default', {
             beforeInitialisation($root, { selector }) {
               // Make the button a submit button
               $root.querySelector(selector)?.setAttribute('type', 'submit')
@@ -356,43 +365,23 @@ describe('Password input', () => {
   // It's been extracted out as multiple tests check for this state.
   function itShowsThePassword() {
     it('changes the input to type="text"', async () => {
-      const inputType = await page.$eval(inputSelector, (el) =>
-        el.getAttribute('type')
-      )
-
-      expect(inputType).toBe('text')
+      expect(await getAttribute($input, 'type')).toBe('text')
     })
 
     it('changes the status to aria-live="polite"', async () => {
-      const statusAriaLiveAttribute = await page.$eval(statusSelector, (el) =>
-        el.getAttribute('aria-live')
-      )
-
-      expect(statusAriaLiveAttribute).toBe('polite')
+      expect(await getAttribute($status, 'aria-live')).toBe('polite')
     })
 
     it('changes the status to say the password is visible', async () => {
-      const statusText = await page.$eval(statusSelector, (el) =>
-        el.innerHTML.trim()
-      )
-
-      expect(statusText).toBe('Your password is visible')
+      expect(await getText($status)).toBe('Your password is visible')
     })
 
     it('changes the button text to "hide"', async () => {
-      const buttonText = await page.$eval(buttonSelector, (el) =>
-        el.innerHTML.trim()
-      )
-
-      expect(buttonText).toBe('Hide')
+      expect(await getText($button)).toBe('Hide')
     })
 
     it('changes the button aria-label to "hide password"', async () => {
-      const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-        el.getAttribute('aria-label')
-      )
-
-      expect(buttonAriaLabel).toBe('Hide password')
+      expect(await getAttribute($button, 'aria-label')).toBe('Hide password')
     })
   }
 
@@ -401,35 +390,24 @@ describe('Password input', () => {
   // It's been extracted out as multiple tests check for this state.
   function itHidesThePassword() {
     it('changes the input to type="password"', async () => {
-      const inputType = await page.$eval(inputSelector, (el) =>
-        el.getAttribute('type')
-      )
-
-      expect(inputType).toBe('password')
+      expect(await getAttribute($input, 'type')).toBe('password')
     })
 
     it('changes the status to say the password is hidden', async () => {
-      const statusText = await page.$eval(statusSelector, (el) =>
-        el.innerHTML.trim()
-      )
-
-      expect(statusText).toBe('Your password is hidden')
+      expect(await getText($status)).toBe('Your password is hidden')
     })
 
     it('changes the button text to "show"', async () => {
-      const buttonText = await page.$eval(buttonSelector, (el) =>
-        el.innerHTML.trim()
-      )
-
-      expect(buttonText).toBe('Show')
+      expect(await getText($button)).toBe('Show')
     })
 
     it('changes the button aria-label to "show password"', async () => {
-      const buttonAriaLabel = await page.$eval(buttonSelector, (el) =>
-        el.getAttribute('aria-label')
-      )
-
-      expect(buttonAriaLabel).toBe('Show password')
+      expect(await getAttribute($button, 'aria-label')).toBe('Show password')
     })
   }
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/password-input.puppeteer.test.mjs
@@ -186,7 +186,7 @@ describe('Password input', () => {
       })
     })
 
-    describe('errors at instantiation', () => {
+    describe('Error handling', () => {
       it('can throw a SupportError if appropriate', () => {
         return expect(
           initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
@@ -234,7 +234,6 @@ describe('Radios', () => {
         await goToExample(page, 'multiple-radio-groups')
 
         $inputsWarm = await page.$$('input.nhsuk-radios__input[id^="warm"]')
-
         $inputsCool = await page.$$('input.nhsuk-radios__input[id^="cool"]')
 
         $inputsNotInForm = await page.$$(

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
@@ -7,13 +7,30 @@ import {
 } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
 import { examples } from './fixtures.mjs'
+import { Radios } from './radios.mjs'
 
 describe('Radios', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'radios', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${Radios.moduleName}"]`)
+    )
+  }
+
   describe('input position', () => {
     // Check that the input sits above the label, enabling its proper detection
     // when exploring by touch or using automation tools like Selenium
     it('displays the input above the label', async () => {
-      await render(page, 'radios', examples.default)
+      await initExample('default')
 
       const $firstInput = /** @type {ElementHandle} */ (
         await page.$('.nhsuk-radios__input')
@@ -21,10 +38,9 @@ describe('Radios', () => {
 
       const clickPosition = await $firstInput.clickablePoint()
 
-      const elementTagNames = await page.evaluate(
-        ({ x, y }) => document.elementsFromPoint(x, y).map((el) => el.tagName),
-        clickPosition
-      )
+      const elementTagNames = await page.evaluate(({ x, y }) => {
+        return document.elementsFromPoint(x, y).map(($el) => $el.tagName)
+      }, clickPosition)
 
       expect(elementTagNames[0]).toBe('INPUT')
       expect(elementTagNames[1]).toBe('LABEL')
@@ -42,9 +58,6 @@ describe('Radios', () => {
       })
 
       describe('with conditional content', () => {
-        /** @type {ElementHandle} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
@@ -52,11 +65,7 @@ describe('Radios', () => {
         let $conditionals
 
         beforeAll(async () => {
-          await render(page, 'radios', examples['with conditional content'])
-
-          $component = /** @type {ElementHandle<HTMLElement>} */ (
-            await page.$('.nhsuk-radios')
-          )
+          await initExample('with conditional content')
 
           $inputs = await $component.$$('input.nhsuk-radios__input')
           $conditionals = await $component.$$('.nhsuk-radios__conditional')
@@ -80,7 +89,7 @@ describe('Radios', () => {
           expect($inputsWithAriaControls).toHaveLength(0)
         })
 
-        it('falls back to making all conditional content visible', async () => {
+        it('falls back to making all conditional content visible', () => {
           return Promise.all(
             $conditionals.map(async ($conditional) => {
               return expect(await isVisible($conditional)).toBe(true)
@@ -92,18 +101,11 @@ describe('Radios', () => {
 
     describe('when JavaScript is available', () => {
       describe('with conditional item checked', () => {
-        /** @type {ElementHandle<HTMLElement>} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
-          await render(page, 'radios', examples['with pre-checked value'])
-
-          $component = /** @type {ElementHandle<HTMLElement>} */ (
-            await page.$('.nhsuk-radios')
-          )
+          await initExample('with pre-checked value')
 
           $inputs = await $component.$$('input.nhsuk-radios__input')
         })
@@ -130,18 +132,11 @@ describe('Radios', () => {
       })
 
       describe('with conditional content', () => {
-        /** @type {ElementHandle<HTMLElement>} */
-        let $component
-
         /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
-          await render(page, 'radios', examples['with conditional content'])
-
-          $component = /** @type {ElementHandle<HTMLElement>} */ (
-            await page.$('.nhsuk-radios')
-          )
+          await initExample('with conditional content')
 
           $inputs = await $component.$$('input.nhsuk-radios__input')
         })
@@ -215,13 +210,9 @@ describe('Radios', () => {
       })
 
       describe('with conditional content with special characters', () => {
-        it('does not error when ID of revealed content contains special characters', async () => {
+        it('does not error when ID of revealed content contains special characters', () => {
           return expect(
-            render(
-              page,
-              'radios',
-              examples['with conditional content, special characters']
-            )
+            initExample('with conditional content, special characters')
           ).resolves.not.toThrow()
         })
       })
@@ -255,6 +246,7 @@ describe('Radios', () => {
         const $conditionalWarm = await page.$(
           `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
         )
+
         const $conditionalCool = await page.$(
           `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
         )
@@ -326,9 +318,9 @@ describe('Radios', () => {
   })
 
   describe('errors at instantiation', () => {
-    it('can throw a SupportError if appropriate', async () => {
-      await expect(
-        render(page, 'radios', examples.default, {
+    it('can throw a SupportError if appropriate', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation() {
             document.body.classList.remove('nhsuk-frontend-supported')
           }
@@ -342,9 +334,9 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when initialised twice', async () => {
-      await expect(
-        render(page, 'radios', examples.default, {
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
           async afterInitialisation($root) {
             const { Radios } = await import('nhsuk-frontend')
             new Radios($root)
@@ -356,9 +348,9 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when $root is not set', async () => {
-      await expect(
-        render(page, 'radios', examples.default, {
+    it('throws when $root is not set', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             $root.remove()
           }
@@ -371,9 +363,9 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when receiving the wrong type for $root', async () => {
-      await expect(
-        render(page, 'radios', examples.default, {
+    it('throws when receiving the wrong type for $root', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $root.outerHTML = `<svg data-module="nhsuk-radios"></svg>`
@@ -388,9 +380,9 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when the input list is empty', async () => {
-      await expect(
-        render(page, 'radios', examples.default, {
+    it('throws when the input list is empty', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root, { selector }) {
             $root.querySelectorAll(selector).forEach((item) => item.remove())
           },
@@ -407,9 +399,9 @@ describe('Radios', () => {
       })
     })
 
-    it('throws when a conditional target element is not found', async () => {
-      await expect(
-        render(page, 'radios', examples['with conditional content'], {
+    it('throws when a conditional target element is not found', () => {
+      return expect(
+        initExample('with conditional content', {
           beforeInitialisation($root) {
             $root.querySelector('.nhsuk-radios__conditional')?.remove()
           }
@@ -426,5 +418,6 @@ describe('Radios', () => {
 })
 
 /**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
  * @import { ElementHandle } from 'puppeteer'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
@@ -317,7 +317,7 @@ describe('Radios', () => {
     })
   })
 
-  describe('errors at instantiation', () => {
+  describe('Error handling', () => {
     it('can throw a SupportError if appropriate', () => {
       return expect(
         initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/radios.puppeteer.test.mjs
@@ -45,7 +45,7 @@ describe('Radios', () => {
         /** @type {ElementHandle} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         /** @type {ElementHandle[]} */
@@ -54,11 +54,11 @@ describe('Radios', () => {
         beforeAll(async () => {
           await render(page, 'radios', examples['with conditional content'])
 
-          $component = /** @type {ElementHandle} */ (
+          $component = /** @type {ElementHandle<HTMLElement>} */ (
             await page.$('.nhsuk-radios')
           )
 
-          $inputs = await $component.$$('.nhsuk-radios__input')
+          $inputs = await $component.$$('input.nhsuk-radios__input')
           $conditionals = await $component.$$('.nhsuk-radios__conditional')
         })
 
@@ -71,6 +71,7 @@ describe('Radios', () => {
           const $inputsWithAriaExpanded = await $component.$$(
             '.nhsuk-radios__input[aria-expanded]'
           )
+
           const $inputsWithAriaControls = await $component.$$(
             '.nhsuk-radios__input[aria-controls]'
           )
@@ -91,20 +92,20 @@ describe('Radios', () => {
 
     describe('when JavaScript is available', () => {
       describe('with conditional item checked', () => {
-        /** @type {ElementHandle} */
+        /** @type {ElementHandle<HTMLElement>} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
           await render(page, 'radios', examples['with pre-checked value'])
 
-          $component = /** @type {ElementHandle} */ (
+          $component = /** @type {ElementHandle<HTMLElement>} */ (
             await page.$('.nhsuk-radios')
           )
 
-          $inputs = await $component.$$('.nhsuk-radios__input')
+          $inputs = await $component.$$('input.nhsuk-radios__input')
         })
 
         it('has conditional content revealed that is associated with a checked input', async () => {
@@ -129,20 +130,20 @@ describe('Radios', () => {
       })
 
       describe('with conditional content', () => {
-        /** @type {ElementHandle} */
+        /** @type {ElementHandle<HTMLElement>} */
         let $component
 
-        /** @type {ElementHandle[]} */
+        /** @type {ElementHandle<HTMLInputElement>[]} */
         let $inputs
 
         beforeEach(async () => {
           await render(page, 'radios', examples['with conditional content'])
 
-          $component = /** @type {ElementHandle} */ (
+          $component = /** @type {ElementHandle<HTMLElement>} */ (
             await page.$('.nhsuk-radios')
           )
 
-          $inputs = await $component.$$('.nhsuk-radios__input')
+          $inputs = await $component.$$('input.nhsuk-radios__input')
         })
 
         it('indicates when conditional content is collapsed or revealed', async () => {
@@ -229,22 +230,24 @@ describe('Radios', () => {
 
   describe('with multiple groups', () => {
     describe('when JavaScript is available', () => {
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsWarm
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsCool
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsNotInForm
 
       beforeEach(async () => {
         await goToExample(page, 'multiple-radio-groups')
 
-        $inputsWarm = await page.$$('.nhsuk-radios__input[id^="warm"]')
-        $inputsCool = await page.$$('.nhsuk-radios__input[id^="cool"]')
+        $inputsWarm = await page.$$('input.nhsuk-radios__input[id^="warm"]')
+
+        $inputsCool = await page.$$('input.nhsuk-radios__input[id^="cool"]')
+
         $inputsNotInForm = await page.$$(
-          '.nhsuk-radios__input[id^="question-not-in-form"]'
+          'input.nhsuk-radios__input[id^="question-not-in-form"]'
         )
       })
 
@@ -284,19 +287,22 @@ describe('Radios', () => {
 
   describe('with multiple groups and conditional content', () => {
     describe('when JavaScript is available', () => {
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsPrimary
 
-      /** @type {ElementHandle[]} */
+      /** @type {ElementHandle<HTMLInputElement>[]} */
       let $inputsOther
 
       beforeEach(async () => {
         await goToExample(page, 'conditional-reveals')
 
         $inputsPrimary = await page.$$(
-          '.nhsuk-radios__input[id^="fave-primary"]'
+          'input.nhsuk-radios__input[id^="fave-primary"]'
         )
-        $inputsOther = await page.$$('.nhsuk-radios__input[id^="fave-other"]')
+
+        $inputsOther = await page.$$(
+          'input.nhsuk-radios__input[id^="fave-other"]'
+        )
       })
 
       it('hides conditional content in other groups', async () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/fixtures.mjs
@@ -4,10 +4,30 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  default: {
+  'default': {
     context: {
       href: '#maincontent',
       text: 'Skip to main content'
+    }
+  },
+  'without hash fragment': {
+    context: {
+      href: '/nhsuk-frontend/components/boilerplate/',
+      text: 'Skip to main content'
+    },
+    options: {
+      hidden: true,
+      throwOnError: false
+    }
+  },
+  'without link target': {
+    context: {
+      href: '#this-element-does-not-exist',
+      text: 'Skip to main content'
+    },
+    options: {
+      hidden: true,
+      throwOnError: false
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
@@ -59,7 +59,7 @@ describe('Skip link', () => {
     })
   })
 
-  describe('errors at instantiation', () => {
+  describe('Error handling', () => {
     it('can return early without errors for external href', () => {
       return expect(
         initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
@@ -22,6 +22,7 @@ describe('Skip link', () => {
   describe('Focus handling', () => {
     beforeAll(async () => {
       await initExample('default')
+
       await page.keyboard.press('Tab')
       await page.keyboard.press('Enter')
     })

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/skip-link.puppeteer.test.mjs
@@ -1,11 +1,27 @@
-import { render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import { getAttribute, render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
 
 import { examples } from './fixtures.mjs'
 
-describe('Skip Link', () => {
+describe('Skip link', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $main
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'skip-link', examples[example], browserOptions)
+
+    $main = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$('#maincontent')
+    )
+  }
+
   describe('Focus handling', () => {
     beforeAll(async () => {
-      await render(page, 'skip-link', examples.default)
+      await initExample('default')
       await page.keyboard.press('Tab')
       await page.keyboard.press('Enter')
     })
@@ -15,56 +31,38 @@ describe('Skip Link', () => {
         () => document.activeElement?.id
       )
 
-      expect(activeElementId).toBe('maincontent')
+      expect(activeElementId).toBe(await getAttribute($main, 'id'))
     })
 
     it('adds the tabindex attribute to the linked element', async () => {
-      const tabindex = await page.$eval('#maincontent', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBe('-1')
+      expect(await getAttribute($main, 'tabindex')).toBe('-1')
     })
 
     it('adds the class for removing the native focus style to the linked element', async () => {
-      const cssClass = await page.$eval('#maincontent', (el) =>
-        el.classList.contains('nhsuk-skip-link-focused-element')
+      expect(await getAttribute($main, 'class')).toContain(
+        'nhsuk-skip-link-focused-element'
       )
-
-      expect(cssClass).toBeTruthy()
     })
 
     it('removes the tabindex attribute from the linked element on blur', async () => {
-      await page.$eval(
-        '#maincontent',
-        (el) => el instanceof window.HTMLElement && el.blur()
-      )
+      await $main.evaluate(($el) => $el.blur())
 
-      const tabindex = await page.$eval('#maincontent', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBeNull()
+      expect(await getAttribute($main, 'tabindex')).toBeNull()
     })
 
     it('removes the class for removing the native focus style from the linked element on blur', async () => {
-      await page.$eval(
-        '#maincontent',
-        (el) => el instanceof window.HTMLElement && el.blur()
-      )
+      await $main.evaluate(($el) => $el.blur())
 
-      const cssClass = await page.$eval('#maincontent', (el) =>
-        el.getAttribute('class')
+      expect(await getAttribute($main, 'class')).not.toContain(
+        'nhsuk-skip-link-focused-element'
       )
-
-      expect(cssClass).not.toContain('nhsuk-skip-link-focused-element')
     })
   })
 
   describe('errors at instantiation', () => {
-    it('can return early without errors for external href', async () => {
+    it('can return early without errors for external href', () => {
       return expect(
-        render(page, 'skip-link', {
+        initExample('default', {
           context: {
             text: 'Exit this page',
             href: 'https://www.bbc.co.uk/weather'
@@ -73,9 +71,9 @@ describe('Skip Link', () => {
       ).resolves.not.toThrow()
     })
 
-    it('can return early without errors when linking to another page (without hash fragment)', async () => {
+    it('can return early without errors when linking to another page (without hash fragment)', () => {
       return expect(
-        render(page, 'skip-link', {
+        initExample('default', {
           context: {
             text: 'Exit this page',
             href: '/clear-session-data'
@@ -84,9 +82,9 @@ describe('Skip Link', () => {
       ).resolves.not.toThrow()
     })
 
-    it('can return early without errors when linking to another page (with hash fragment)', async () => {
+    it('can return early without errors when linking to another page (with hash fragment)', () => {
       return expect(
-        render(page, 'skip-link', {
+        initExample('default', {
           context: {
             text: 'Skip to main content',
             href: '/somewhere-else#main-content'
@@ -95,9 +93,9 @@ describe('Skip Link', () => {
       ).resolves.not.toThrow()
     })
 
-    it('can return early without errors when linking to the current page (with hash fragment)', async () => {
+    it('can return early without errors when linking to the current page (with hash fragment)', () => {
       return expect(
-        render(page, 'skip-link', {
+        initExample('default', {
           context: {
             text: 'Skip to main content',
             href: '#maincontent'
@@ -106,9 +104,9 @@ describe('Skip Link', () => {
       ).resolves.not.toThrow()
     })
 
-    it('can throw a SupportError if appropriate', async () => {
+    it('can throw a SupportError if appropriate', () => {
       return expect(
-        render(page, 'skip-link', examples.default, {
+        initExample('default', {
           beforeInitialisation() {
             document.body.classList.remove('nhsuk-frontend-supported')
           }
@@ -122,9 +120,9 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when initialised twice', async () => {
-      await expect(
-        render(page, 'skip-link', examples.default, {
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
           async afterInitialisation($root) {
             const { SkipLink } = await import('nhsuk-frontend')
             new SkipLink($root)
@@ -136,9 +134,9 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when $root is not set', async () => {
+    it('throws when $root is not set', () => {
       return expect(
-        render(page, 'skip-link', examples.default, {
+        initExample('default', {
           beforeInitialisation($root) {
             $root.remove()
           }
@@ -151,9 +149,9 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when receiving the wrong type for $root', async () => {
+    it('throws when receiving the wrong type for $root', () => {
       return expect(
-        render(page, 'skip-link', examples.default, {
+        initExample('default', {
           beforeInitialisation($root) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $root.outerHTML = `<svg data-module="nhsuk-skip-link"></svg>`
@@ -168,15 +166,8 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when the linked element is missing', async () => {
-      return expect(
-        render(page, 'skip-link', {
-          context: {
-            text: 'Skip to main content',
-            href: '#this-element-does-not-exist'
-          }
-        })
-      ).rejects.toMatchObject({
+    it('throws when the linked element is missing', () => {
+      return expect(initExample('without link target')).rejects.toMatchObject({
         cause: {
           name: 'ElementError',
           message:
@@ -185,21 +176,21 @@ describe('Skip Link', () => {
       })
     })
 
-    it('throws when the href does not contain a hash', async () => {
-      return expect(
-        render(page, 'skip-link', {
-          context: {
-            text: 'Skip to main content',
-            href: '/nhsuk-frontend/components/boilerplate/'
+    it('throws when the href does not contain a hash', () => {
+      return expect(initExample('without hash fragment')).rejects.toMatchObject(
+        {
+          cause: {
+            name: 'ElementError',
+            message:
+              'nhsuk-skip-link: Target link (`href="/nhsuk-frontend/components/boilerplate/"`) hash fragment not found'
           }
-        })
-      ).rejects.toMatchObject({
-        cause: {
-          name: 'ElementError',
-          message:
-            'nhsuk-skip-link: Target link (`href="/nhsuk-frontend/components/boilerplate/"`) hash fragment not found'
         }
-      })
+      )
     })
   })
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.puppeteer.test.mjs
@@ -259,7 +259,7 @@ describe('Tabs', () => {
     })
   })
 
-  describe('errors at instantiation', () => {
+  describe('Error handling', () => {
     it('can throw a SupportError if appropriate', () => {
       return expect(
         initExample('default', {

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.puppeteer.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/tabs.puppeteer.test.mjs
@@ -1,15 +1,36 @@
-import { render } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+import {
+  getAttribute,
+  isVisible,
+  render
+} from '@nhsuk/frontend-helpers/puppeteer.mjs'
 import { KnownDevices } from 'puppeteer'
 
 import { examples } from './fixtures.mjs'
+import { Tabs } from './tabs.mjs'
 
 const iPhone = KnownDevices['iPhone 6']
 
 describe('Tabs', () => {
+  /** @type {ElementHandle<HTMLElement>} */
+  let $component
+
+  /**
+   * @template {object} HandlerContext
+   * @param {keyof typeof examples} example
+   * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Puppeteer browser render options
+   */
+  async function initExample(example, browserOptions) {
+    await render(page, 'tabs', examples[example], browserOptions)
+
+    $component = /** @type {ElementHandle<HTMLElement>} */ (
+      await page.$(`[data-module="${Tabs.moduleName}"]`)
+    )
+  }
+
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
-      await render(page, 'tabs', examples.default)
+      await initExample('default')
     })
 
     afterAll(async () => {
@@ -17,212 +38,211 @@ describe('Tabs', () => {
     })
 
     it('falls back to making all tab containers visible', async () => {
-      const isContentVisible = await page.waitForSelector(
-        '.nhsuk-tabs__panel',
-        { visible: true, timeout: 1000 }
-      )
-      expect(isContentVisible).toBeTruthy()
+      const $firstPanel = await $component.$('.nhsuk-tabs__panel')
+
+      expect(await isVisible($firstPanel)).toBe(true)
     })
   })
 
   describe('when JavaScript is available', () => {
     beforeAll(async () => {
-      await render(page, 'tabs', examples.default)
+      await initExample('default')
     })
 
     it('should indicate the open state of the first tab', async () => {
-      const firstTabAriaSelected = await page.evaluate(() =>
-        document.body
-          .querySelector('.nhsuk-tabs__list-item:first-child .nhsuk-tabs__tab')
-          ?.getAttribute('aria-selected')
+      const $firstItem = await $component.$(
+        '.nhsuk-tabs__list-item:first-child'
       )
-      expect(firstTabAriaSelected).toBe('true')
+      const $firstTab = await $firstItem?.$('.nhsuk-tabs__tab')
 
-      const firstTabClasses = await page.evaluate(
-        () =>
-          document.body.querySelector('.nhsuk-tabs__list-item:first-child')
-            ?.className
+      expect(await getAttribute($firstTab, 'aria-selected')).toBe('true')
+      expect(await getAttribute($firstItem, 'class')).toContain(
+        'nhsuk-tabs__list-item--selected'
       )
-      expect(firstTabClasses).toContain('nhsuk-tabs__list-item--selected')
     })
 
     it('should display the first tab panel', async () => {
-      const tabPanelIsHidden = await page.evaluate(() =>
-        document.body
-          .querySelector('.nhsuk-tabs > .nhsuk-tabs__panel')
-          ?.classList.contains('nhsuk-tabs__panel--hidden')
+      const $firstPanel = await $component.$('.nhsuk-tabs__panel')
+
+      expect(await getAttribute($firstPanel, 'class')).not.toContain(
+        'nhsuk-tabs__panel--hidden'
       )
-      expect(tabPanelIsHidden).toBeFalsy()
     })
 
     it('should hide all the tab panels except for the first one', async () => {
-      const tabPanelIsHidden = await page.evaluate(() =>
-        document.body
-          .querySelector(
-            '.nhsuk-tabs > .nhsuk-tabs__panel ~ .nhsuk-tabs__panel'
-          )
-          ?.classList.contains('nhsuk-tabs__panel--hidden')
+      const $otherPanels = await $component.$$(
+        '.nhsuk-tabs__panel ~ .nhsuk-tabs__panel'
       )
-      expect(tabPanelIsHidden).toBeTruthy()
+
+      expect($otherPanels).toHaveLength(3)
+
+      for (const $panel of $otherPanels) {
+        expect(await getAttribute($panel, 'class')).toContain(
+          'nhsuk-tabs__panel--hidden'
+        )
+      }
     })
   })
 
   describe('when a tab is pressed', () => {
     beforeEach(async () => {
-      await render(page, 'tabs', examples.default)
+      await initExample('default')
     })
 
     it('should indicate the open state of the pressed tab', async () => {
+      const $secondListItem = await $component.$(
+        '.nhsuk-tabs__list-item:nth-child(2)'
+      )
+
+      const $secondTab = await $secondListItem?.$('.nhsuk-tabs__tab')
+
       // Click the second tab
-      await page.click('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
+      await $secondTab?.click()
 
-      const secondTabAriaSelected = await page.evaluate(() =>
-        document.body
-          .querySelector('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
-          ?.getAttribute('aria-selected')
+      expect(await getAttribute($secondTab, 'aria-selected')).toBe('true')
+      expect(await getAttribute($secondListItem, 'class')).toContain(
+        'nhsuk-tabs__list-item--selected'
       )
-      expect(secondTabAriaSelected).toBe('true')
-
-      const secondTabClasses = await page.evaluate(
-        () =>
-          document.body.querySelector('.nhsuk-tabs__list-item:nth-child(2)')
-            ?.className
-      )
-      expect(secondTabClasses).toContain('nhsuk-tabs__list-item--selected')
     })
 
     it('should display the tab panel associated with the selected tab', async () => {
-      // Click the second tab
-      await page.click('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
+      const $secondTab = await $component.$(
+        '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab'
+      )
 
-      const secondTabPanelIsHidden = await page.evaluate(() => {
-        const secondTabAriaControls = document.body
-          .querySelector('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
-          ?.getAttribute('aria-controls')
-        return document.body
-          .querySelector(`[id="${secondTabAriaControls}"]`)
-          ?.classList.contains('nhsuk-tabs__panel--hidden')
-      })
-      expect(secondTabPanelIsHidden).toBeFalsy()
+      const $secondPanel = await $component.$(
+        '.nhsuk-tabs__panel:nth-of-type(2)'
+      )
+
+      // Click the second tab
+      await $secondTab?.click()
+
+      expect(await getAttribute($secondPanel, 'id')).toBe(
+        await getAttribute($secondTab, 'aria-controls')
+      )
+
+      expect(await getAttribute($secondPanel, 'class')).not.toContain(
+        'nhsuk-tabs__panel--hidden'
+      )
     })
 
     describe('when the tab contains a DOM element', () => {
       beforeAll(async () => {
-        await render(page, 'tabs', examples.default)
+        await initExample('default')
       })
 
       it('should display the tab panel associated with the selected tab', async () => {
-        await page.evaluate(() => {
-          // Replace contents of second tab with a DOM element
-          const secondTab = document.body.querySelector(
-            '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab'
-          )
-
-          if (secondTab) {
-            secondTab.innerHTML = '<span>Past week</span>'
-          }
-        })
-
-        // Click the DOM element inside the second tab
-        await page.click(
-          '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab span'
+        const $secondTab = await $component.$(
+          '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab'
         )
 
-        const secondTabPanelIsHidden = await page.evaluate(() => {
-          const secondTabAriaControls = document.body
-            .querySelector(
-              '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab'
-            )
-            ?.getAttribute('aria-controls')
-          return document.body
-            .querySelector(`[id="${secondTabAriaControls}"]`)
-            ?.classList.contains('nhsuk-tabs__panel--hidden')
+        // Replace contents of second tab with a DOM element
+        $secondTab?.evaluate(($el) => {
+          $el.innerHTML = '<span>Past week</span>'
         })
-        expect(secondTabPanelIsHidden).toBeFalsy()
+
+        const secondPanelId = await getAttribute($secondTab, 'aria-controls')
+        const $secondPanel = await $component.$(`#${secondPanelId}`)
+
+        // Click the DOM element inside the second tab
+        await $secondTab?.$('span').then(($el) => $el?.click())
+
+        expect(await getAttribute($secondPanel, 'id')).toBe('past-week')
+        expect(await getAttribute($secondPanel, 'class')).not.toContain(
+          'nhsuk-tabs__panel--hidden'
+        )
       })
     })
   })
 
   describe('when first tab is focused and the right arrow key is pressed', () => {
     beforeEach(async () => {
-      await render(page, 'tabs', examples.default)
+      await initExample('default')
     })
 
     it('should indicate the open state of the next tab', async () => {
+      const $firstListItem = await $component.$(
+        '.nhsuk-tabs__list-item:first-child'
+      )
+
+      const $secondListItem = await $component.$(
+        '.nhsuk-tabs__list-item:nth-child(2)'
+      )
+
+      const $firstTab = await $firstListItem?.$('.nhsuk-tabs__tab')
+      const $secondTab = await $secondListItem?.$('.nhsuk-tabs__tab')
+
       // Press right arrow when focused on the first tab
-      await page.focus('.nhsuk-tabs__list-item:first-child .nhsuk-tabs__tab')
+      await $firstTab?.focus()
       await page.keyboard.press('ArrowRight')
 
-      const secondTabAriaSelected = await page.evaluate(() =>
-        document.body
-          .querySelector('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
-          ?.getAttribute('aria-selected')
+      expect(await getAttribute($secondTab, 'aria-selected')).toBe('true')
+      expect(await getAttribute($secondListItem, 'class')).toContain(
+        'nhsuk-tabs__list-item--selected'
       )
-      expect(secondTabAriaSelected).toBe('true')
-
-      const secondTabClasses = await page.evaluate(
-        () =>
-          document.body.querySelector('.nhsuk-tabs__list-item:nth-child(2)')
-            ?.className
-      )
-      expect(secondTabClasses).toContain('nhsuk-tabs__list-item--selected')
     })
 
     it('should display the tab panel associated with the selected tab', async () => {
+      const $firstTab = await $component.$(
+        '.nhsuk-tabs__list-item:first-child .nhsuk-tabs__tab'
+      )
+
+      const $secondTab = await $component.$(
+        '.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab'
+      )
+
+      const secondPanelId = await getAttribute($secondTab, 'aria-controls')
+      const $secondPanel = await $component.$(`#${secondPanelId}`)
+
       // Press right arrow
-      await page.focus('.nhsuk-tabs__list-item:first-child .nhsuk-tabs__tab')
+      await $firstTab?.focus()
       await page.keyboard.down('ArrowRight')
 
-      const secondTabPanelIsHidden = await page.evaluate(() => {
-        const secondTabAriaControls = document.body
-          .querySelector('.nhsuk-tabs__list-item:nth-child(2) .nhsuk-tabs__tab')
-          ?.getAttribute('aria-controls')
-        return document.body
-          .querySelector(`[id="${secondTabAriaControls}"]`)
-          ?.classList.contains('nhsuk-tabs__panel--hidden')
-      })
-      expect(secondTabPanelIsHidden).toBeFalsy()
+      expect(await getAttribute($secondPanel, 'id')).toBe('past-week')
+      expect(await getAttribute($secondPanel, 'class')).not.toContain(
+        'nhsuk-tabs__panel--hidden'
+      )
     })
   })
 
   describe('when a hash associated with a tab panel is passed in the URL', () => {
     it('should indicate the open state of the associated tab', async () => {
-      await render(page, 'tabs', examples.default)
+      await initExample('default')
 
       await page.evaluate(() => {
         window.location.hash = '#past-week'
       })
 
-      const currentTabAriaSelected = await page.evaluate(() =>
-        document.body
-          .querySelector('.nhsuk-tabs__tab[href="#past-week"]')
-          ?.getAttribute('aria-selected')
+      const $currentTab = await $component.$(
+        '.nhsuk-tabs__tab[href="#past-week"]'
       )
-      expect(currentTabAriaSelected).toBe('true')
+      const $currentItem = await $component.$(
+        '.nhsuk-tabs__list-item:has(.nhsuk-tabs__tab[href="#past-week"])'
+      )
 
-      const currentTabClasses = await page.evaluate(
-        () =>
-          document.body.querySelector('.nhsuk-tabs__tab[href="#past-week"]')
-            ?.parentElement?.className
-      )
-      expect(currentTabClasses).toContain('nhsuk-tabs__list-item--selected')
+      const currentPanelId = await getAttribute($currentTab, 'aria-controls')
+      const $currentPanel = await $component.$(`#${currentPanelId}`)
 
-      const currentTabPanelIsHidden = await page.evaluate(() =>
-        document
-          .getElementById('past-week')
-          ?.classList.contains('nhsuk-tabs__panel--hidden')
+      expect(await getAttribute($currentTab, 'aria-selected')).toBe('true')
+      expect(await getAttribute($currentItem, 'class')).toContain(
+        'nhsuk-tabs__list-item--selected'
       )
-      expect(currentTabPanelIsHidden).toBeFalsy()
+
+      expect(await getAttribute($currentPanel, 'id')).toBe('past-week')
+      expect(await getAttribute($currentPanel, 'class')).not.toContain(
+        'nhsuk-tabs__panel--hidden'
+      )
     })
 
     it('should only update based on hashes that are tabs', async () => {
-      await render(page, 'tabs', examples['with anchor in panel'])
+      await initExample('with anchor in panel')
 
       await page.click('[href="#anchor"]')
 
       const activeElementId = await page.evaluate(
         () => document.activeElement?.id
       )
+
       expect(activeElementId).toBe('anchor')
     })
   })
@@ -230,19 +250,19 @@ describe('Tabs', () => {
   describe('when rendered on a small device', () => {
     it('falls back to making the all tab containers visible', async () => {
       await page.emulate(iPhone)
-      await render(page, 'tabs', examples.default)
-      const isContentVisible = await page.waitForSelector(
-        '.nhsuk-tabs__panel',
-        { visible: true, timeout: 1000 }
-      )
-      expect(isContentVisible).toBeTruthy()
+
+      await initExample('default')
+
+      const $firstPanel = await $component.$('.nhsuk-tabs__panel')
+
+      expect(await isVisible($firstPanel)).toBe(true)
     })
   })
 
   describe('errors at instantiation', () => {
-    it('can throw a SupportError if appropriate', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('can throw a SupportError if appropriate', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation() {
             document.body.classList.remove('nhsuk-frontend-supported')
           }
@@ -256,9 +276,9 @@ describe('Tabs', () => {
       })
     })
 
-    it('throws when initialised twice', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('throws when initialised twice', () => {
+      return expect(
+        initExample('default', {
           async afterInitialisation($root) {
             const { Tabs } = await import('nhsuk-frontend')
             new Tabs($root)
@@ -270,9 +290,9 @@ describe('Tabs', () => {
       })
     })
 
-    it('throws when $root is not set', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('throws when $root is not set', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root) {
             $root.remove()
           }
@@ -285,9 +305,9 @@ describe('Tabs', () => {
       })
     })
 
-    it('throws when there are no tabs', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('throws when there are no tabs', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root, { selector }) {
             $root.querySelectorAll(selector).forEach((item) => item.remove())
           },
@@ -303,9 +323,9 @@ describe('Tabs', () => {
       })
     })
 
-    it('throws when the tab list is missing', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('throws when the tab list is missing', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root, { selector }) {
             $root
               .querySelector(selector)
@@ -324,9 +344,9 @@ describe('Tabs', () => {
       })
     })
 
-    it('throws when there the tab list is empty', async () => {
-      await expect(
-        render(page, 'tabs', examples.default, {
+    it('throws when there the tab list is empty', () => {
+      return expect(
+        initExample('default', {
           beforeInitialisation($root, { selector, className }) {
             $root
               .querySelectorAll(selector)
@@ -347,3 +367,8 @@ describe('Tabs', () => {
     })
   })
 })
+
+/**
+ * @import { BrowserRenderOptions } from '@nhsuk/frontend-helpers/puppeteer.mjs'
+ * @import { ElementHandle } from 'puppeteer'
+ */

--- a/shared/helpers/puppeteer.mjs
+++ b/shared/helpers/puppeteer.mjs
@@ -311,9 +311,11 @@ export function getOptions(name, example) {
 /**
  * Get property value for element
  *
- * @param {ElementHandle | null} $element - Puppeteer element handle
- * @param {string} propertyName - Property name to return value for
- * @returns {Promise<unknown>} Property value
+ * @template {Element} ElementType
+ * @template {keyof ElementType} PropertyType
+ * @param {ElementHandle<ElementType> | null | undefined} $element - Puppeteer element handle
+ * @param {PropertyType} propertyName - Property name to return value for
+ * @returns {Promise<ElementType[PropertyType]>} Property value
  */
 export async function getProperty($element, propertyName) {
   if (!$element) {
@@ -321,13 +323,13 @@ export async function getProperty($element, propertyName) {
   }
 
   const handle = await $element.getProperty(propertyName)
-  return handle.jsonValue()
+  return /** @type {ElementType[PropertyType]} */ (await handle.jsonValue())
 }
 
 /**
  * Get attribute value for element
  *
- * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @param {ElementHandle | null | undefined} $element - Puppeteer element handle
  * @param {string} attributeName - Attribute name to return value for
  * @returns {Promise<string | null>} Attribute value
  */
@@ -343,7 +345,7 @@ export function getAttribute($element, attributeName) {
  * Gets the accessible name of the given element, if it exists in the accessibility tree
  *
  * @param {Page} page - Puppeteer page object
- * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @param {ElementHandle | null | undefined} $element - Puppeteer element handle
  * @returns {Promise<string>} The element's accessible name
  * @throws {TypeError} If the element has no corresponding node in the accessibility tree
  */
@@ -373,7 +375,7 @@ export async function getAccessibleName(page, $element) {
 /**
  * Get text content for element
  *
- * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @param {ElementHandle | null | undefined} $element - Puppeteer element handle
  * @returns {Promise<string>} Text content
  */
 export async function getText($element) {
@@ -383,7 +385,7 @@ export async function getText($element) {
 /**
  * Get HTML content for element
  *
- * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @param {ElementHandle | null | undefined} $element - Puppeteer element handle
  * @returns {Promise<string>} HTML content
  */
 export async function getHtml($element) {
@@ -393,7 +395,7 @@ export async function getHtml($element) {
 /**
  * Check if element is visible
  *
- * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @param {ElementHandle | null | undefined} $element - Puppeteer element handle
  * @returns {Promise<boolean>} Element visibility
  */
 export async function isVisible($element) {

--- a/shared/helpers/puppeteer.mjs
+++ b/shared/helpers/puppeteer.mjs
@@ -338,7 +338,7 @@ export function getAttribute($element, attributeName) {
     throw new TypeError('Element is not defined')
   }
 
-  return $element.evaluate((el, name) => el.getAttribute(name), attributeName)
+  return $element.evaluate(($el, name) => $el.getAttribute(name), attributeName)
 }
 
 /**

--- a/shared/helpers/puppeteer.mjs
+++ b/shared/helpers/puppeteer.mjs
@@ -371,6 +371,26 @@ export async function getAccessibleName(page, $element) {
 }
 
 /**
+ * Get text content for element
+ *
+ * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @returns {Promise<string>} Text content
+ */
+export async function getText($element) {
+  return /** @type {string} */ (await getProperty($element, 'textContent'))
+}
+
+/**
+ * Get HTML content for element
+ *
+ * @param {ElementHandle | null} $element - Puppeteer element handle
+ * @returns {Promise<string>} HTML content
+ */
+export async function getHtml($element) {
+  return /** @type {string} */ (await getProperty($element, 'innerHTML'))
+}
+
+/**
  * Check if element is visible
  *
  * @param {ElementHandle | null} $element - Puppeteer element handle


### PR DESCRIPTION
## Description

This PR brings together some Puppeteer test improvements I've had waiting to contribute

Especially for character count where older `page.$eval()` calls were used: 

```patch
  it('shows the characters remaining if the field is pre-filled', async () => {
-   await render(page, 'character-count', examples['with default value'])
+   await initExample('with default value')
  
-   const message = await page.$eval(
-     '.nhsuk-character-count__status',
-     (el) => el.innerHTML.trim()
-   )
-   expect(message).toBe('You have 57 characters remaining')
- 
-   const srMessage = await page.$eval(
-     '.nhsuk-character-count__sr-status',
-     (el) => el.innerHTML.trim()
-   )
-   expect(srMessage).toBe('You have 57 characters remaining')  
+   expect(await getText($visibleCountMessage)).toBe('You have 57 characters remaining')
+   expect(await getText($screenReaderCountMessage)).toBe('You have 57 characters remaining')
  })
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
