### PR TITLE
[v10] Refactor character count method to reduce repeated updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ This change was introduced in [pull request #1898: Update reverse button colour 
 
 ### :wrench: **Fixes**
 
+- [#1890: Refactor character count method to reduce repeated updates](https://github.com/nhsuk/nhsuk-frontend/pull/1890)
 - [#1904: Make sure Nunjucks text-only options for card heading, label and legend are escaped](https://github.com/nhsuk/nhsuk-frontend/pull/1904)
 
 ## 10.4.2 - 25 March 2026

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -133,6 +133,29 @@ describe('Character count', () => {
         `${CharacterCount.moduleName}: Root element (\`$root\`) already initialised`
       )
     })
+
+    it('should handle deprecated methods', () => {
+      const component = new CharacterCount($root)
+
+      jest.spyOn(component, 'getCountMessage')
+      jest.spyOn(component, 'handleInput')
+      jest.spyOn(component, 'updateCount')
+      jest.spyOn(component, 'updateIfValueChanged')
+
+      expect(() => component.formattedUpdateMessage()).not.toThrow()
+      expect(() => component.handleKeyUp()).not.toThrow()
+      expect(() => component.count('')).not.toThrow()
+      expect(() => component.checkIfValueChanged()).not.toThrow()
+
+      expect(component.count('')).toBe(0)
+      expect(component.count('Existing value')).toBe(14)
+      expect(component.count('Newly updated value')).toBe(19)
+
+      expect(component.getCountMessage).toHaveBeenCalled()
+      expect(component.handleInput).toHaveBeenCalled()
+      expect(component.updateCount).toHaveBeenCalled()
+      expect(component.updateIfValueChanged).toHaveBeenCalled()
+    })
   })
 
   describe('Nunjucks configuration', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -33,6 +33,7 @@ describe('Character count', () => {
     $description = document.getElementById(`${$textarea.id}-info`)
 
     jest.spyOn($textarea, 'addEventListener')
+    jest.spyOn(window, 'addEventListener')
   }
 
   beforeEach(() => {
@@ -55,6 +56,11 @@ describe('Character count', () => {
 
       expect($textarea.addEventListener).toHaveBeenCalledWith(
         'blur',
+        expect.any(Function)
+      )
+
+      expect(window.addEventListener).toHaveBeenCalledWith(
+        'pageshow',
         expect.any(Function)
       )
     })
@@ -215,6 +221,10 @@ describe('Character count', () => {
   })
 
   describe('JavaScript configuration', () => {
+    beforeEach(() => {
+      initExample('to configure in JavaScript')
+    })
+
     describe('during initialisation', () => {
       it('overrides the default translation keys', () => {
         const component = new CharacterCount($root, {
@@ -258,6 +268,64 @@ describe('Character count', () => {
         expect(component.formatCountMessage(0, 'words')).toBe(
           'Different custom text.'
         )
+      })
+
+      it('uses existing textarea value for `maxlength` limit when initialised', () => {
+        $textarea.value = 'Existing value'
+
+        const component = new CharacterCount($root, {
+          maxlength: 100
+        })
+
+        expect(component.getCountMessage()).toBe(
+          'You have 86 characters remaining'
+        )
+      })
+
+      it('uses existing textarea value for `maxwords` limit when initialised', () => {
+        $textarea.value = 'Existing value'
+
+        const component = new CharacterCount($root, {
+          maxwords: 100
+        })
+
+        expect(component.getCountMessage()).toBe('You have 98 words remaining')
+      })
+
+      it('uses current textarea value for `maxlength` limit via back/forward navigation', () => {
+        const component = new CharacterCount($root, {
+          maxlength: 100
+        })
+
+        $textarea.value = 'Newly updated value'
+
+        // Trigger back/forward navigation
+        window.dispatchEvent(
+          new PageTransitionEvent('pageshow', {
+            persisted: true
+          })
+        )
+
+        expect(component.getCountMessage()).toBe(
+          'You have 81 characters remaining'
+        )
+      })
+
+      it('uses current textarea value for `maxwords` limit via back/forward navigation', () => {
+        const component = new CharacterCount($root, {
+          maxwords: 100
+        })
+
+        $textarea.value = 'Newly updated value'
+
+        // Trigger back/forward navigation
+        window.dispatchEvent(
+          new PageTransitionEvent('pageshow', {
+            persisted: true
+          })
+        )
+
+        expect(component.getCountMessage()).toBe('You have 97 words remaining')
       })
     })
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -44,7 +44,7 @@ describe('Character count', () => {
       initCharacterCounts()
 
       expect($textarea.addEventListener).toHaveBeenCalledWith(
-        'keyup',
+        'input',
         expect.any(Function)
       )
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.jsdom.test.mjs
@@ -213,6 +213,131 @@ describe('Character count', () => {
       })
     })
   })
+
+  describe('JavaScript configuration', () => {
+    describe('during initialisation', () => {
+      it('overrides the default translation keys', () => {
+        const component = new CharacterCount($root, {
+          maxlength: 100,
+          i18n: {
+            charactersUnderLimit: { one: 'Custom text. Count: %{count}' }
+          }
+        })
+
+        expect(component.formatCountMessage(1, 'characters')).toBe(
+          'Custom text. Count: 1'
+        )
+
+        // Other keys remain untouched
+        expect(component.formatCountMessage(10, 'characters')).toBe(
+          'You have 10 characters remaining'
+        )
+      })
+
+      it('uses specific translation keys when `maxlength` limit is reached', () => {
+        const component = new CharacterCount($root, {
+          maxlength: 100,
+          i18n: {
+            charactersAtLimit: 'Custom text.'
+          }
+        })
+
+        expect(component.formatCountMessage(0, 'characters')).toBe(
+          'Custom text.'
+        )
+      })
+
+      it('uses specific translation keys when `maxwords` limit is reached', () => {
+        const component = new CharacterCount($root, {
+          maxwords: 100,
+          i18n: {
+            wordsAtLimit: 'Different custom text.'
+          }
+        })
+
+        expect(component.formatCountMessage(0, 'words')).toBe(
+          'Different custom text.'
+        )
+      })
+    })
+
+    describe('with HTML lang attribute', () => {
+      it('overrides the locale when set on the element', () => {
+        $root.setAttribute('lang', 'de')
+
+        const component = new CharacterCount($root, {
+          maxwords: 20000
+        })
+
+        expect(component.formatCountMessage(10000, 'words')).toBe(
+          'You have 10.000 words remaining'
+        )
+      })
+
+      it('overrides the locale when set on an ancestor', () => {
+        document.body.setAttribute('lang', 'de')
+
+        const component = new CharacterCount($root, {
+          maxwords: 20000
+        })
+
+        expect(component.formatCountMessage(10000, 'words')).toBe(
+          'You have 10.000 words remaining'
+        )
+      })
+    })
+
+    describe('with HTML data attributes', () => {
+      it('overrides the default translation keys', () => {
+        $root.setAttribute(
+          'data-i18n.characters-under-limit.one',
+          'Custom text. Count: %{count}'
+        )
+
+        const component = new CharacterCount($root, {
+          maxlength: 100
+        })
+
+        expect(component.formatCountMessage(1, 'characters')).toBe(
+          'Custom text. Count: 1'
+        )
+
+        // Other keys remain untouched
+        expect(component.formatCountMessage(10, 'characters')).toBe(
+          'You have 10 characters remaining'
+        )
+      })
+
+      it('overrides the default translation keys and configuration', () => {
+        $root.setAttribute(
+          'data-i18n.characters-under-limit.one',
+          'Custom text. Count: %{count}'
+        )
+
+        const component = new CharacterCount($root, {
+          maxlength: 100,
+          i18n: {
+            charactersUnderLimit: {
+              one: 'Different custom text. Count: %{count}'
+            }
+          }
+        })
+
+        expect(component.formatCountMessage(1, 'characters')).toBe(
+          'Custom text. Count: 1'
+        )
+
+        // Other keys remain untouched
+        expect(component.formatCountMessage(-10, 'characters')).toBe(
+          'You have 10 characters too many'
+        )
+
+        expect(component.formatCountMessage(0, 'characters')).toBe(
+          'You have 0 characters remaining'
+        )
+      })
+    })
+  })
 })
 
 describe('Character count: Format count message', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -179,9 +179,11 @@ export class CharacterCount extends ConfigurableComponent {
   /**
    * Count the number of characters (or words, if `config.maxwords` is set)
    * in the given text, and update the component-wide count
+   *
+   * @param {string} [text] - Deprecated
    */
-  updateCount() {
-    const text = this.$textarea.value
+  updateCount(text) {
+    text = text ?? this.$textarea.value
 
     if (this.config.maxwords) {
       const tokens = text.match(/\S+/g) ?? [] // Matches consecutive non-whitespace chars
@@ -190,6 +192,15 @@ export class CharacterCount extends ConfigurableComponent {
     }
 
     this.length = text.length
+  }
+
+  /**
+   * @deprecated
+   * @param {string} text - The text to count the characters of
+   */
+  count(text) {
+    this.updateCount(text)
+    return this.length
   }
 
   /**
@@ -214,6 +225,13 @@ export class CharacterCount extends ConfigurableComponent {
       this.lastInputValue = this.$textarea.value
       this.updateCountMessage()
     }
+  }
+
+  /**
+   * @deprecated Use {@link CharacterCount.updateIfValueChanged} instead.
+   */
+  checkIfValueChanged() {
+    this.updateIfValueChanged()
   }
 
   /**
@@ -283,6 +301,13 @@ export class CharacterCount extends ConfigurableComponent {
   }
 
   /**
+   * @deprecated Use {@link CharacterCount.getCountMessage} instead.
+   */
+  formattedUpdateMessage() {
+    return this.getCountMessage()
+  }
+
+  /**
    * Formats the message shown to users according to what's counted
    * and how many remain
    *
@@ -338,6 +363,13 @@ export class CharacterCount extends ConfigurableComponent {
     this.updateCount()
     this.updateVisibleCountMessage()
     this.lastInputTimestamp = Date.now()
+  }
+
+  /**
+   * @deprecated Use {@link CharacterCount.handleInput} instead.
+   */
+  handleKeyUp() {
+    this.handleInput()
   }
 
   /**

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -17,6 +17,8 @@ import { I18n } from '../../i18n.mjs'
  * @augments {ConfigurableComponent<CharacterCountConfig>}
  */
 export class CharacterCount extends ConfigurableComponent {
+  count = 0
+
   /**
    * @type {number | null}
    */
@@ -135,11 +137,20 @@ export class CharacterCount extends ConfigurableComponent {
     // When the page is restored after navigating 'back' in some browsers the
     // state of form controls is not restored until *after* the DOMContentLoaded
     // event is fired, so we need to sync after the pageshow event.
-    window.addEventListener('pageshow', () => this.updateCountMessage())
+    window.addEventListener('pageshow', () => {
+      // If the current value of the textarea is the same as what's
+      // in the HTML, don't re-run when users have not edited the field yet
+      // (new page load or BF cache navigation without having edited).
+      if (this.$textarea.value !== this.$textarea.textContent) {
+        this.updateCount()
+        this.updateCountMessage()
+      }
+    })
 
     // Although we've set up handlers to sync state on the pageshow event, init
     // could be called after those events have fired, for example if they are
     // added to the page dynamically, so update now too.
+    this.updateCount()
     this.updateCountMessage()
   }
 
@@ -167,18 +178,18 @@ export class CharacterCount extends ConfigurableComponent {
 
   /**
    * Count the number of characters (or words, if `config.maxwords` is set)
-   * in the given text
-   *
-   * @param {string} text - The text to count the characters of
-   * @returns {number} the number of characters (or words) in the text
+   * in the given text, and update the component-wide count
    */
-  count(text) {
+  updateCount() {
+    const text = this.$textarea.value
+
     if (this.config.maxwords) {
       const tokens = text.match(/\S+/g) ?? [] // Matches consecutive non-whitespace chars
-      return tokens.length
+      this.count = tokens.length
+      return
     }
 
-    return text.length
+    this.count = text.length
   }
 
   /**
@@ -188,7 +199,7 @@ export class CharacterCount extends ConfigurableComponent {
    * when the user types.
    */
   bindChangeEvents() {
-    this.$textarea.addEventListener('keyup', () => this.handleKeyUp())
+    this.$textarea.addEventListener('input', () => this.handleInput())
 
     // Bind focus/blur events to start/stop polling
     this.$textarea.addEventListener('focus', () => this.handleFocus())
@@ -198,7 +209,7 @@ export class CharacterCount extends ConfigurableComponent {
   /**
    * Update count message if textarea value has changed
    */
-  checkIfValueChanged() {
+  updateIfValueChanged() {
     if (this.$textarea.value !== this.lastInputValue) {
       this.lastInputValue = this.$textarea.value
       this.updateCountMessage()
@@ -220,7 +231,7 @@ export class CharacterCount extends ConfigurableComponent {
    * Update visible count message
    */
   updateVisibleCountMessage() {
-    const remainingNumber = this.maxLength - this.count(this.$textarea.value)
+    const remainingNumber = this.maxLength - this.count
     const isError = remainingNumber < 0
 
     // If input is over the threshold, show the count message
@@ -241,7 +252,7 @@ export class CharacterCount extends ConfigurableComponent {
     this.$visibleCountMessage.classList.toggle('nhsuk-hint', !isError)
 
     // Update message
-    this.$visibleCountMessage.textContent = this.formattedUpdateMessage()
+    this.$visibleCountMessage.textContent = this.getCountMessage()
   }
 
   /**
@@ -257,7 +268,7 @@ export class CharacterCount extends ConfigurableComponent {
     }
 
     // Update message
-    this.$screenReaderCountMessage.textContent = this.formattedUpdateMessage()
+    this.$screenReaderCountMessage.textContent = this.getCountMessage()
   }
 
   /**
@@ -265,8 +276,8 @@ export class CharacterCount extends ConfigurableComponent {
    *
    * @returns {string} Status message
    */
-  formattedUpdateMessage() {
-    const remainingNumber = this.maxLength - this.count(this.$textarea.value)
+  getCountMessage() {
+    const remainingNumber = this.maxLength - this.count
     const countType = this.config.maxwords ? 'words' : 'characters'
     return this.formatCountMessage(remainingNumber, countType)
   }
@@ -309,7 +320,7 @@ export class CharacterCount extends ConfigurableComponent {
     }
 
     // Determine the remaining number of characters/words
-    const currentLength = this.count(this.$textarea.value)
+    const currentLength = this.count
     const maxLength = this.maxLength
 
     const thresholdValue = (maxLength * this.config.threshold) / 100
@@ -318,12 +329,13 @@ export class CharacterCount extends ConfigurableComponent {
   }
 
   /**
-   * Handle key up event
+   * Handle input event
    *
    * Update the visible character counter and keep track of when the last update
    * happened for each keypress
    */
-  handleKeyUp() {
+  handleInput() {
+    this.updateCount()
     this.updateVisibleCountMessage()
     this.lastInputTimestamp = Date.now()
   }
@@ -347,7 +359,7 @@ export class CharacterCount extends ConfigurableComponent {
         !this.lastInputTimestamp ||
         Date.now() - 500 >= this.lastInputTimestamp
       ) {
-        this.checkIfValueChanged()
+        this.updateIfValueChanged()
       }
     }, 1000)
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/character-count.mjs
@@ -17,7 +17,7 @@ import { I18n } from '../../i18n.mjs'
  * @augments {ConfigurableComponent<CharacterCountConfig>}
  */
 export class CharacterCount extends ConfigurableComponent {
-  count = 0
+  length = 0
 
   /**
    * @type {number | null}
@@ -185,11 +185,11 @@ export class CharacterCount extends ConfigurableComponent {
 
     if (this.config.maxwords) {
       const tokens = text.match(/\S+/g) ?? [] // Matches consecutive non-whitespace chars
-      this.count = tokens.length
+      this.length = tokens.length
       return
     }
 
-    this.count = text.length
+    this.length = text.length
   }
 
   /**
@@ -231,7 +231,7 @@ export class CharacterCount extends ConfigurableComponent {
    * Update visible count message
    */
   updateVisibleCountMessage() {
-    const remainingNumber = this.maxLength - this.count
+    const remainingNumber = this.maxLength - this.length
     const isError = remainingNumber < 0
 
     // If input is over the threshold, show the count message
@@ -277,7 +277,7 @@ export class CharacterCount extends ConfigurableComponent {
    * @returns {string} Status message
    */
   getCountMessage() {
-    const remainingNumber = this.maxLength - this.count
+    const remainingNumber = this.maxLength - this.length
     const countType = this.config.maxwords ? 'words' : 'characters'
     return this.formatCountMessage(remainingNumber, countType)
   }
@@ -320,7 +320,7 @@ export class CharacterCount extends ConfigurableComponent {
     }
 
     // Determine the remaining number of characters/words
-    const currentLength = this.count
+    const currentLength = this.length
     const maxLength = this.maxLength
 
     const thresholdValue = (maxLength * this.config.threshold) / 100


### PR DESCRIPTION
## Description

This PR uplifts https://github.com/alphagov/govuk-frontend/pull/6449 from GOV.UK Frontend v6.0.0 to improve the character count

Our JavaScript API is public by default (we publish types) so I've added 7b8cd787df2f2f66f917c11994a6f1c908666d28 and d66c040a84c35de9546e720e9b54edfb4aba251f for compatibility

Credit to @querkmachine for the original changes

Unblocks https://github.com/nhsuk/nhsuk-frontend/issues/1619

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
