### PR TITLE
[v10] Add support for functions in component configs

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/extract-config-by-namespace.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/reject-any-type */
 import { isObject } from '../index.mjs'
 import { normaliseString } from './normalise-string.mjs'
 
@@ -73,7 +74,7 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
  * Schema property for component config
  *
  * @typedef {object} SchemaProperty
- * @property {'string' | 'boolean' | 'number' | 'object' | 'array'} type - Property type
+ * @property {'string' | 'boolean' | 'number' | 'object' | 'array' | 'function'} type - Property type
  */
 
 /**
@@ -87,5 +88,6 @@ export function extractConfigByNamespace(schema, dataset, namespace) {
 
 /**
  * @typedef {keyof ObjectNested} NestedKey
- * @typedef {{ [key: string]: string | boolean | number | (string | number | boolean)[] | ObjectNested | undefined }} ObjectNested
+ * @typedef {string | boolean | number} NestedValue
+ * @typedef {{ [key: string]: NestedValue | NestedValue[] | ((...args: any[]) => NestedValue) | ObjectNested | undefined }} ObjectNested
  */

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-dataset.jsdom.test.mjs
@@ -22,7 +22,8 @@ describe('normaliseDataset', () => {
         'anArray1': '[]',
         'anArray2': '[true]',
         'anArray3': '[1, 2, 3, 4]',
-        'anArray4': '["goose", "gull", "gannet"]'
+        'anArray4': '["goose", "gull", "gannet"]',
+        'aFunction': '() => "albatross"'
       })
     ).toEqual({
       aNumber: 1000,
@@ -40,7 +41,8 @@ describe('normaliseDataset', () => {
       anArray1: [],
       anArray2: [true],
       anArray3: [1, 2, 3, 4],
-      anArray4: ['goose', 'gull', 'gannet']
+      anArray4: ['goose', 'gull', 'gannet'],
+      aFunction: undefined // Functions are not normalised from datasets
     })
   })
 

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
@@ -147,11 +147,11 @@ describe('normaliseString', () => {
 
     // Arrays in strings are ignored even with schema property type
     expect(normaliseString(inputArray)).toBe(inputArray)
-    expect(normaliseString(inputArray, { type: 'array' })).toBe(inputArray)
+    expect(normaliseString(inputArray, { type: 'array' })).toBeUndefined()
 
     // Objects in strings are ignored even with schema property type
     expect(normaliseString(inputObject)).toBe(inputObject)
-    expect(normaliseString(inputObject, { type: 'object' })).toBe(inputObject)
+    expect(normaliseString(inputObject, { type: 'object' })).toBeUndefined()
   })
 })
 

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.jsdom.test.mjs
@@ -143,11 +143,16 @@ describe('normaliseString', () => {
 
   it('skips unhandled property schema', () => {
     const inputArray = '["string", "array"]'
+    const inputFunction = '() => "albatross"'
     const inputObject = '{ not: "allowed" }'
 
     // Arrays in strings are ignored even with schema property type
     expect(normaliseString(inputArray)).toBe(inputArray)
     expect(normaliseString(inputArray, { type: 'array' })).toBeUndefined()
+
+    // Functions in strings are ignored even with schema property type
+    expect(normaliseString(inputFunction)).toBe(inputFunction)
+    expect(normaliseString(inputFunction, { type: 'function' })).toBeUndefined()
 
     // Objects in strings are ignored even with schema property type
     expect(normaliseString(inputObject)).toBe(inputObject)

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
@@ -14,17 +14,16 @@
  * @returns Normalised data
  */
 export function normaliseString(value, property) {
+  let outputType = property?.type
+
   if (
     !isValid(value) ||
-    (property?.type && !['string', 'number', 'boolean'].includes(property.type))
+    (outputType && !['string', 'number', 'boolean'].includes(outputType))
   ) {
     return
   }
 
   const trimmedValue = value.toString().trim()
-
-  let output
-  let outputType = property?.type
 
   // No schema type set? Determine automatically
   if (!outputType) {
@@ -38,6 +37,8 @@ export function normaliseString(value, property) {
       outputType = 'number'
     }
   }
+
+  let output
 
   switch (outputType) {
     case 'boolean':

--- a/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/common/configuration/normalise-string.mjs
@@ -14,7 +14,10 @@
  * @returns Normalised data
  */
 export function normaliseString(value, property) {
-  if (!isValid(value)) {
+  if (
+    !isValid(value) ||
+    (property?.type && !['string', 'number', 'boolean'].includes(property.type))
+  ) {
     return
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -64,10 +64,13 @@ describe('ConfigurableComponent', () => {
 
       const testComponent = document.querySelector('#test-component')
       const configComponent = new MockConfigurableComponent(testComponent, {
-        aNumber: 100
+        aNumber: 100,
+        aFunction: (name) => name
       })
 
-      expect(configComponent.config).toMatchObject({ aNumber: 100 })
+      expect(configComponent.config.aNumber).toBe(100)
+      expect(configComponent.config.aFunction).toBeInstanceOf(Function)
+      expect(configComponent.config.aFunction('albatross')).toBe('albatross')
     })
 
     it('dataset configuration over the configuration object from class initialisation', () => {
@@ -77,10 +80,13 @@ describe('ConfigurableComponent', () => {
 
       const testComponent = document.querySelector('#test-component')
       const configComponent = new MockConfigurableComponent(testComponent, {
-        aNumber: 100
+        aNumber: 100,
+        aFunction: (name) => name
       })
 
-      expect(configComponent.config).toMatchObject({ aNumber: 12 })
+      expect(configComponent.config.aNumber).toBe(12)
+      expect(configComponent.config.aFunction).toBeInstanceOf(Function)
+      expect(configComponent.config.aFunction('albatross')).toBe('albatross')
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -1,7 +1,7 @@
 import {
+  MockConfigurableComponent,
   MockConfigurableComponentNoDefaults,
-  MockConfigurableComponentNoSchema,
-  MockConfigurableComponentNumber
+  MockConfigurableComponentNoSchema
 } from '#lib/fixtures/configuration/mock-component.mjs'
 
 import { ConfigError } from './errors/index.mjs'
@@ -41,20 +41,20 @@ describe('ConfigurableComponent', () => {
       `
 
       const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponentNumber(testComponent)
+      const configComponent = new MockConfigurableComponent(testComponent)
 
-      expect(configComponent.config).toMatchObject({ example: 0 })
+      expect(configComponent.config).toMatchObject({ aNumber: 0 })
     })
 
     it('dataset of root', () => {
       document.body.innerHTML = `
-        <div id="test-component" data-example="42"></div>
+        <div id="test-component" data-a-number="42"></div>
       `
 
       const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponentNumber(testComponent)
+      const configComponent = new MockConfigurableComponent(testComponent)
 
-      expect(configComponent.config).toMatchObject({ example: 42 })
+      expect(configComponent.config).toMatchObject({ aNumber: 42 })
     })
 
     it('configuration object from class initialisation', () => {
@@ -63,26 +63,24 @@ describe('ConfigurableComponent', () => {
       `
 
       const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponentNumber(
-        testComponent,
-        { example: 100 }
-      )
+      const configComponent = new MockConfigurableComponent(testComponent, {
+        aNumber: 100
+      })
 
-      expect(configComponent.config).toMatchObject({ example: 100 })
+      expect(configComponent.config).toMatchObject({ aNumber: 100 })
     })
 
     it('dataset configuration over the configuration object from class initialisation', () => {
       document.body.innerHTML = `
-        <div id="test-component" data-example="12"></div>
+        <div id="test-component" data-a-number="12"></div>
       `
 
       const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponentNumber(
-        testComponent,
-        { example: 100 }
-      )
+      const configComponent = new MockConfigurableComponent(testComponent, {
+        aNumber: 100
+      })
 
-      expect(configComponent.config).toMatchObject({ example: 12 })
+      expect(configComponent.config).toMatchObject({ aNumber: 12 })
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/index.jsdom.test.mjs
@@ -4,7 +4,7 @@ import { names } from '#lib'
 import {
   MockComponent,
   MockComponentError,
-  MockConfigurableComponentBoolean
+  MockConfigurableComponent
 } from '#lib/fixtures/configuration/mock-component.mjs'
 
 import {
@@ -312,8 +312,8 @@ describe('NHS.UK frontend', () => {
         expect.any(MockComponent)
       ])
 
-      expect(result[0]).toHaveProperty('args', [$root1])
-      expect(result[1]).toHaveProperty('args', [$root2])
+      expect(result[0].$root).toBe($root1)
+      expect(result[1].$root).toBe($root2)
     })
 
     it('should return initialised components (with failed components omitted)', () => {
@@ -334,9 +334,9 @@ describe('NHS.UK frontend', () => {
         expect.any(MockComponentError)
       ])
 
-      expect(result[0]).toHaveProperty('args', [$root1])
-      expect(result[1]).not.toHaveProperty('args', [$root2])
-      expect(result[1]).toHaveProperty('args', [$root3])
+      expect(result[0].$root).toBe($root1)
+      expect(result[1].$root).not.toBe($root2)
+      expect(result[1].$root).toBe($root3)
     })
 
     it('should return empty array without components', () => {
@@ -432,7 +432,7 @@ describe('NHS.UK frontend', () => {
         const result = createAll(MockComponent)
 
         expect(result).toStrictEqual([expect.any(MockComponent)])
-        expect(result[0]).toHaveProperty('args', [$root])
+        expect(result[0].$root).toBe($root)
       })
     })
 
@@ -459,29 +459,27 @@ describe('NHS.UK frontend', () => {
 
         const result2 = createAll(MockComponent, undefined, $scope2)
         expect(result2).toStrictEqual([expect.any(MockComponent)])
-        expect(result2[0]).toHaveProperty('args', [$root2])
+        expect(result2[0].$root).toBe($root2)
       })
     })
 
     describe('Configurable components', () => {
       it('initialises component', () => {
         document.body.innerHTML = outdent`
-          <div data-module="${MockConfigurableComponentBoolean.moduleName}"></div>
+          <div data-module="${MockConfigurableComponent.moduleName}"></div>
         `
 
         const $root = document.querySelector(
-          `[data-module="${MockConfigurableComponentBoolean.moduleName}"]`
+          `[data-module="${MockConfigurableComponent.moduleName}"]`
         )
 
-        const result = createAll(MockConfigurableComponentBoolean, {
-          example: true
+        const result = createAll(MockConfigurableComponent, {
+          aBoolean: true
         })
 
-        expect(result).toStrictEqual([
-          expect.any(MockConfigurableComponentBoolean)
-        ])
-
-        expect(result[0]).toHaveProperty('args', [$root, { example: true }])
+        expect(result).toStrictEqual([expect.any(MockConfigurableComponent)])
+        expect(result[0].$root).toBe($root)
+        expect(result[0].config).toMatchObject({ aBoolean: true })
       })
     })
 
@@ -492,7 +490,7 @@ describe('NHS.UK frontend', () => {
             <!-- No components -->
           </div>
           <div class="app-scope-2">
-            <div data-module="${MockConfigurableComponentBoolean.moduleName}"></div>
+            <div data-module="${MockConfigurableComponent.moduleName}"></div>
           </div>
         `
 
@@ -500,28 +498,26 @@ describe('NHS.UK frontend', () => {
         const $scope2 = document.querySelector('.app-scope-2')
 
         const $root2 = $scope2?.querySelector(
-          `[data-module="${MockConfigurableComponentBoolean.moduleName}"]`
+          `[data-module="${MockConfigurableComponent.moduleName}"]`
         )
 
         const result1 = createAll(
-          MockConfigurableComponentBoolean,
-          { example: true },
+          MockConfigurableComponent,
+          { aBoolean: true },
           $scope1
         )
 
         expect(result1).toStrictEqual([])
 
         const result2 = createAll(
-          MockConfigurableComponentBoolean,
-          { example: true },
+          MockConfigurableComponent,
+          { aBoolean: true },
           $scope2
         )
 
-        expect(result2).toStrictEqual([
-          expect.any(MockConfigurableComponentBoolean)
-        ])
-
-        expect(result2[0]).toHaveProperty('args', [$root2, { example: true }])
+        expect(result2).toStrictEqual([expect.any(MockConfigurableComponent)])
+        expect(result2[0].$root).toBe($root2)
+        expect(result2[0].config).toMatchObject({ aBoolean: true })
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/lib/fixtures/configuration/mock-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/lib/fixtures/configuration/mock-component.mjs
@@ -3,14 +3,6 @@ import { ConfigurableComponent } from '../../../configurable-component.mjs'
 
 export class MockComponent extends Component {
   static moduleName = 'mock-component'
-
-  /**
-   * @param {Element | null} $root - HTML element to use for component
-   */
-  constructor($root) {
-    super($root)
-    this.args = [$root]
-  }
 }
 
 export class MockComponentError extends MockComponent {
@@ -71,70 +63,6 @@ export class MockConfigurableComponent extends ConfigurableComponent {
     anArray2: [true],
     anArray3: [1, 2, 3, 4],
     anArray4: ['goose', 'gull', 'gannet']
-  }
-}
-
-/**
- * @augments {ConfigurableComponent<MockConfigBoolean>}
- */
-export class MockConfigurableComponentBoolean extends ConfigurableComponent {
-  /**
-   * @param {Element | null} $root - HTML element to use for component
-   * @param {Partial<MockConfigBoolean>} [config] - Component config
-   */
-  constructor($root, config) {
-    super($root, config)
-    this.args = [$root, config]
-  }
-
-  static moduleName = 'mock-component'
-
-  /**
-   * @satisfies {Schema<MockConfigBoolean>}
-   */
-  static schema = {
-    properties: {
-      example: { type: 'boolean' }
-    }
-  }
-
-  /**
-   * @satisfies {MockConfigBoolean}
-   */
-  static defaults = {
-    example: false
-  }
-}
-
-/**
- * @augments {ConfigurableComponent<MockConfigNumber>}
- */
-export class MockConfigurableComponentNumber extends ConfigurableComponent {
-  /**
-   * @param {Element | null} $root - HTML element to use for component
-   * @param {Partial<MockConfigNumber>} [config] - Component config
-   */
-  constructor($root, config) {
-    super($root, config)
-    this.args = [$root, config]
-  }
-
-  static moduleName = 'mock-component'
-
-  /**
-   * @satisfies {Schema<MockConfigNumber>}
-   */
-  static schema = {
-    properties: {
-      example: { type: 'number' }
-    }
-  }
-
-  /**
-   * @satisfies {MockConfigNumber}
-   */
-  static defaults = {
-    example: 0
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/lib/fixtures/configuration/mock-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/lib/fixtures/configuration/mock-component.mjs
@@ -40,7 +40,8 @@ export class MockConfigurableComponent extends ConfigurableComponent {
       anArray1: { type: 'array' },
       anArray2: { type: 'array' },
       anArray3: { type: 'array' },
-      anArray4: { type: 'array' }
+      anArray4: { type: 'array' },
+      aFunction: { type: 'function' }
     }
   }
 
@@ -62,7 +63,8 @@ export class MockConfigurableComponent extends ConfigurableComponent {
     anArray1: [],
     anArray2: [true],
     anArray3: [1, 2, 3, 4],
-    anArray4: ['goose', 'gull', 'gannet']
+    anArray4: ['goose', 'gull', 'gannet'],
+    aFunction: (name) => name
   }
 }
 
@@ -233,6 +235,7 @@ export class MockConfigurableComponentMixed extends ConfigurableComponent {
  * @property {(string | number | boolean)[]} anArray2 - An array
  * @property {(string | number | boolean)[]} anArray3 - An array
  * @property {(string | number | boolean)[]} anArray4 - An array
+ * @property {(name: string) => string} aFunction - A function
  */
 
 /**


### PR DESCRIPTION
## Description

This PR adds a new `function` config schema type (alongside `string`, `boolean`, `object` and `array` types)

Support for `array` types was added recently in:

* https://github.com/nhsuk/nhsuk-frontend/pull/1747

### JavaScript configuration

Config function values via `initAll()` and `createAll()`, for example to configure the character count function:

```mjs
import { CharacterCount, createAll } from 'nhsuk-frontend'

createAll(CharacterCount, {
  countFunction: (string) => string.length
})
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
