### PR TITLE
[v10] Make sure Nunjucks text-only options for card heading, label and legend are escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ The button's active state text now has a contrast ratio of 7:1 to help meet the 
 
 This change was introduced in [pull request #1898: Update reverse button colour to light blue](https://github.com/nhsuk/nhsuk-frontend/pull/1898).
 
+### :wrench: **Fixes**
+
+- [#1904: Make sure Nunjucks text-only options for card heading, label and legend are escaped](https://github.com/nhsuk/nhsuk-frontend/pull/1904)
+
 ## 10.4.2 - 25 March 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
@@ -119,7 +119,7 @@
   <h{{ headingLevel }} class="{{ classNamesHeading }}" {%- if params.headingId %} id="{{ params.headingId }}"{% endif %}>
   {% if params.href and not "nhsuk-card--feature" in classNames %}
     <a class="nhsuk-card__link" href="{{ params.href }}">
-      {{- params.heading | safe -}}
+      {{- params.heading -}}
     </a>
   {% elif params.headingVisuallyHiddenText %}
     <span role="text">

--- a/packages/nhsuk-frontend/src/nhsuk/components/label/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/label/template.njk
@@ -39,7 +39,7 @@
 {% if caller or params.html %}
   {{ caller() if caller else params.html | safe | trim | indent(2) }}
 {% elif params.text %}
-  {{ params.text | safe | trim | indent(2) }}
+  {{ params.text | trim | indent(2) }}
 {% endif %}
 </label>
 {% endset -%}

--- a/packages/nhsuk-frontend/src/nhsuk/components/legend/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/legend/template.njk
@@ -25,7 +25,7 @@
 {% if caller or params.html %}
   {{ caller() if caller else params.html | safe | trim | indent(2) }}
 {% elif params.text %}
-  {{ params.text | safe | trim | indent(2) }}
+  {{ params.text | trim | indent(2) }}
 {% endif %}
 {% endset -%}
 


### PR DESCRIPTION
## Description

This PR includes fixes to always apply auto escaping to the following options:

* Card component `params.heading` option
* Label component `params.text` option
* Legend component `params.text` option

Thanks to @duncanjbrown for reporting

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
