### PR TITLE
Fix clean task `Error: ENOTEMPTY: directory not empty, rmdir`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "install:playwright": "playwright install chromium --with-deps --only-shell",
     "install:puppeteer": "puppeteer browsers install",
-    "preclean": "del-cli dist",
+    "preclean": "del-cli dist/*",
     "clean": "npm run clean --if-present --workspaces",
     "postclean": "tsc --build --clean",
     "build": "npm run build --if-present --workspaces",

--- a/packages/nhsuk-frontend-review/package.json
+++ b/packages/nhsuk-frontend-review/package.json
@@ -4,7 +4,7 @@
   "description": "NHS.UK frontend review app",
   "license": "MIT",
   "scripts": {
-    "clean": "del-cli dist",
+    "clean": "del-cli dist/*",
     "postclean": "tsc --build --clean",
     "build": "gulp build --color",
     "serve": "gulp serve --color",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -53,7 +53,7 @@
     "!**/*.test.*"
   ],
   "scripts": {
-    "clean": "del-cli dist",
+    "clean": "del-cli dist/nhsuk/*",
     "postclean": "tsc --build --clean",
     "build": "gulp build --color",
     "watch": "gulp watch --color",

--- a/shared/lib/components.mjs
+++ b/shared/lib/components.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { paths } from '@nhsuk/frontend-config'
 
@@ -76,12 +76,12 @@ export async function loadAll() {
  * Get component names
  */
 export function getNames() {
-  const listing = files.getDirectories('nhsuk/components', {
+  const listing = files.getListing('nhsuk/components/*/template.njk', {
     cwd: join(paths.pkg, 'src')
   })
 
   // Use directory names only
-  return listing.map((directoryPath) => basename(directoryPath)).sort()
+  return listing.map((directoryPath) => basename(dirname(directoryPath))).sort()
 }
 
 /**


### PR DESCRIPTION
## Description

This PR is a workaround to an issue with [Node.js `fsPromises.rm()`](https://nodejs.org/docs/latest-v24.x/api/fs.html#fspromisesrmpath-options) where deleting large directories such as `packages/nhsuk-frontend/dist` throws `ENOTEMPTY` or other errors [when the file system is busy](https://github.com/nodejs/node/issues/54561#issuecomment-2449076853)

```console
[Error: ENOTEMPTY: directory not empty, rmdir '/path/to/nhsuk-frontend/packages/nhsuk-frontend/dist'] {
  errno: -66,
  code: 'ENOTEMPTY',
  syscall: 'rmdir',
  path: '/path/to/nhsuk-frontend/packages/nhsuk-frontend/dist'
}
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
