### PR TITLE
[v10] Add TypeScript compiler `--force` flag

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -76,7 +76,7 @@ jobs:
 
           - description: TypeScript compiler
             name: lint-types
-            run: npm run lint:types
+            run: npm run lint:types -- --force
             cache: '**/*.tsbuildinfo'
 
     steps:


### PR DESCRIPTION
## Description

Switching from TypeScript v5 to v6 has caused issues [when restoring `*.tsbuildinfo` from cache](https://github.com/nhsuk/nhsuk-frontend/blob/v10.4.2/.github/workflows/pull-request.yml#L77-L80)

This PR adds the `--force` flag when linting using TypeScript to avoid the issue

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
