### PR TITLE
[v10] Render Nunjucks icon macro into SVG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,40 @@ Or to change the icon and adjust placement:
 
 This was added in [pull request #1712: Add support for icon buttons](https://github.com/nhsuk/nhsuk-frontend/pull/1712).
 
+#### Add icons using SVGs
+
+You can also [add icons](https://service-manual.nhs.uk/design-system/styles/icons) using SVG files in the `nhsuk-frontend/dist/nhsuk/assets` directory:
+
+- `images/nhsuk-icon-arrow-down-circle.svg`
+- `images/nhsuk-icon-arrow-down.svg`
+- `images/nhsuk-icon-arrow-left-circle.svg`
+- `images/nhsuk-icon-arrow-left.svg`
+- `images/nhsuk-icon-arrow-right-circle.svg`
+- `images/nhsuk-icon-arrow-right.svg`
+- `images/nhsuk-icon-arrow-up-circle.svg`
+- `images/nhsuk-icon-arrow-up.svg`
+- `images/nhsuk-icon-chevron-down-circle.svg`
+- `images/nhsuk-icon-chevron-left-circle.svg`
+- `images/nhsuk-icon-chevron-right-circle.svg`
+- `images/nhsuk-icon-chevron-up-circle.svg`
+- `images/nhsuk-icon-cross.svg`
+- `images/nhsuk-icon-minus.svg`
+- `images/nhsuk-icon-plus.svg`
+- `images/nhsuk-icon-search.svg`
+- `images/nhsuk-icon-tick.svg`
+- `images/nhsuk-icon-user.svg`
+
+If you use Sass and you've changed the default `/assets/` public path (for example, Nunjucks `assetPath`), make sure `$nhsuk-assets-path` is configured:
+
+```scss
+  @forward "nhsuk-frontend/dist/nhsuk" with (
++   $nhsuk-assets-path: "/public/assets/",
+    $nhsuk-fonts-path: "https://assets.nhs.uk/fonts/"
+  );
+```
+
+This was added in [pull request #1915: Render Nunjucks icon macro into SVG files](https://github.com/nhsuk/nhsuk-frontend/pull/1915).
+
 ### :recycle: **Changes**
 
 #### Change border colour for details component and conditionally revealed content

--- a/packages/nhsuk-frontend/gulpfile.mjs
+++ b/packages/nhsuk-frontend/gulpfile.mjs
@@ -17,7 +17,7 @@ import types from './tsconfig.json' with { type: 'json' }
 /**
  * Utility tasks
  */
-gulp.task('assets', assets.copy)
+gulp.task('assets', gulp.series(assets.copy, assets.render))
 gulp.task('fixtures', fixtures.compile)
 gulp.task('scripts', gulp.series(scripts.compile, scripts.version))
 gulp.task('styles', gulp.series(styles.compile, styles.version))

--- a/packages/nhsuk-frontend/src/nhsuk/core/generic/_font-face.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/generic/_font-face.scss
@@ -1,6 +1,8 @@
 @use "sass:math";
 @use "../settings" as *;
 @use "../tools/exports" as *;
+@use "../tools/font-url" as *;
+@forward "../tools/font-url" show nhsuk-font-url;
 
 ////
 /// Font face
@@ -11,10 +13,6 @@
 ///
 /// @group generic
 ////
-
-@function nhsuk-font-url($filename) {
-  @return url($nhsuk-fonts-path + $filename);
-}
 
 @mixin nhsuk-font-face-frutiger {
   @at-root {

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_globals.scss
@@ -8,6 +8,28 @@
 ////
 
 // =========================================================
+// Asset paths
+// =========================================================
+
+/// Path to the assets directory, with trailing slash.
+///
+/// @type String
+
+$nhsuk-assets-path: "/assets/" !default;
+
+/// Path or URL to the images folder, with trailing slash.
+///
+/// @type String
+
+$nhsuk-images-path: "#{$nhsuk-assets-path}images/" !default;
+
+/// Path or URL to the fonts folder, with trailing slash.
+///
+/// @type String
+
+$nhsuk-fonts-path: "https://assets.nhs.uk/fonts/" !default;
+
+// =========================================================
 // Font families
 // =========================================================
 
@@ -34,12 +56,6 @@ $nhsuk-font-family: $nhsuk-font, $nhsuk-font-fallback !default;
 /// @type List
 
 $nhsuk-font-family-print: sans-serif !default;
-
-/// Path or URL to the fonts folder, with trailing slash.
-///
-/// @type String
-
-$nhsuk-fonts-path: "https://assets.nhs.uk/fonts/" !default;
 
 /// Include the default @font-face declarations
 ///

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_font-url.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_font-url.scss
@@ -1,0 +1,14 @@
+@use "../settings" as *;
+
+////
+/// @group tools
+////
+
+/// Font URL
+///
+/// @param {String} $filename - Font filename
+/// @return {String} URL for the filename, wrapped in `url()`
+
+@function nhsuk-font-url($filename) {
+  @return url($nhsuk-fonts-path + $filename);
+}

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_image-url.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_image-url.scss
@@ -1,0 +1,14 @@
+@use "../settings" as *;
+
+////
+/// @group tools
+////
+
+/// Font URL
+///
+/// @param {String} $filename - Image filename
+/// @return {String} URL for the filename, wrapped in `url()`
+
+@function nhsuk-image-url($filename) {
+  @return url($nhsuk-images-path + $filename);
+}

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_index.scss
@@ -4,7 +4,9 @@
 
 @forward "buttons";
 @forward "exports";
+@forward "font-url";
 @forward "functions";
+@forward "image-url";
 @forward "shape-arrow";
 @forward "shape-chevron";
 @forward "shape-dash";

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/font-url.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/font-url.unit.test.mjs
@@ -1,0 +1,40 @@
+import { outdent } from 'outdent'
+import { compileStringAsync } from 'sass-embedded'
+
+describe('@function font-url', () => {
+  const sassModules = outdent`
+    @use "core/tools/font-url" as *;
+  `
+
+  const sassBootstrap = outdent`
+    @use "core/settings/globals" as * with (
+      $nhsuk-fonts-path: "/path/to/fonts/"
+    );
+
+    ${sassModules}
+  `
+
+  it('by default concatenates the font path and the filename', async () => {
+    const sass = outdent`
+      ${sassBootstrap}
+
+      @font-face {
+        font-family: "whatever";
+        src: nhsuk-font-url("whatever.woff2");
+      }
+    `
+
+    const results = compileStringAsync(sass, {
+      loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining(outdent`
+        @font-face {
+          font-family: "whatever";
+          src: url("/path/to/fonts/whatever.woff2");
+        }
+      `)
+    })
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/image-url.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/image-url.unit.test.mjs
@@ -1,0 +1,38 @@
+import { outdent } from 'outdent'
+import { compileStringAsync } from 'sass-embedded'
+
+describe('@function image-url', () => {
+  const sassModules = outdent`
+    @use "core/tools/image-url" as *;
+  `
+
+  const sassBootstrap = outdent`
+    @use "core/settings/globals" as * with (
+      $nhsuk-images-path: '/path/to/images/'
+    );
+
+    ${sassModules}
+  `
+
+  it('by default concatenates the image path and the filename', async () => {
+    const sass = outdent`
+      ${sassBootstrap}
+
+      .foo {
+        background-image: nhsuk-image-url("baz.png");
+      }
+    `
+
+    const results = compileStringAsync(sass, {
+      loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining(outdent`
+        .foo {
+          background-image: url("/path/to/images/baz.png");
+        }
+      `)
+    })
+  })
+})

--- a/packages/nhsuk-frontend/src/nhsuk/lib/components.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/lib/components.mjs
@@ -69,7 +69,7 @@ export function macro(component, options) {
  *
  * @typedef {object} MacroExample
  * @property {string | undefined} [description] - Example description (optional)
- * @property {{ [param: string]: unknown }} [context] - Nunjucks context object (optional)
+ * @property {MacroRenderContext} [context] - Nunjucks context object (optional)
  * @property {string | undefined} [callBlock] - Nunjucks macro `caller()` content (optional)
  * @property {never} [prefix] - Component name prefix (not available in Nunjucks macro examples)
  * @property {MacroExampleOptions} [options] - Review app example options (optional)
@@ -137,5 +137,5 @@ export function macro(component, options) {
 
 /**
  * @import { Scenario } from 'backstopjs'
- * @import { MacroRenderOptions } from '#lib'
+ * @import { MacroRenderContext, MacroRenderOptions } from '#lib'
  */

--- a/packages/nhsuk-frontend/src/nhsuk/lib/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/lib/index.mjs
@@ -15,6 +15,7 @@ export * from './highlighter/index.mjs'
  * @typedef {import('./components.mjs').MacroOption} MacroOption
  * @typedef {import('./components.mjs').MacroParam} MacroParam
  * @typedef {import('./components.mjs').MacroScenario} MacroScenario
+ * @typedef {import('./nunjucks/index.mjs').MacroRenderContext} MacroRenderContext
  * @typedef {import('./nunjucks/index.mjs').MacroRenderOptions} MacroRenderOptions
  * @typedef {import('./nunjucks/index.mjs').TemplateRenderOptions} TemplateRenderOptions
  */

--- a/packages/nhsuk-frontend/src/nhsuk/lib/nunjucks/index.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/lib/nunjucks/index.mjs
@@ -18,6 +18,22 @@ export function renderMacro(macroName, macroPath, options) {
 }
 
 /**
+ * Render macro params
+ *
+ * @param {MacroRenderOptions['context']} [context] - Nunjucks mixed context
+ * @returns Params rendered to pass to the macro
+ */
+export function renderParams(context) {
+  const params = context ? [context].flat() : []
+
+  const paramsFormatted = params
+    .map((param) => JSON.stringify(param, undefined, 2))
+    .join(', ')
+
+  return paramsFormatted
+}
+
+/**
  * Return macro
  *
  * @param {string} macroName - The name of the macro
@@ -31,7 +47,7 @@ export function macro(macroName, macroPath, options) {
 
   // Format Nunjucks options without quoted keys
   if (options?.context && Object.keys(options.context).length) {
-    const paramsFormatted = JSON.stringify(options.context, undefined, 2)
+    const paramsFormatted = renderParams(options.context)
 
     macroCall = prettier
       .format(`${macroName}(${paramsFormatted})`, {
@@ -101,10 +117,16 @@ export function renderString(string, options) {
 export * from './environment.mjs'
 
 /**
+ * Nunjucks macro context
+ *
+ * @typedef {{ [param: string]: unknown }} MacroRenderContext
+ */
+
+/**
  * Nunjucks macro render options
  *
  * @typedef {object} MacroRenderOptions
- * @property {string | { [param: string]: unknown }} [context] - Nunjucks mixed context (optional)
+ * @property {string | MacroRenderContext | (string | MacroRenderContext)[]} [context] - Nunjucks mixed context (optional)
  * @property {string} [callBlock] - Nunjucks macro `caller()` content (optional)
  * @property {string} [prefix] - Component name prefix (optional)
  * @property {Environment} [env] - Nunjucks environment (optional)
@@ -114,7 +136,7 @@ export * from './environment.mjs'
  * Nunjucks template render options
  *
  * @typedef {object} TemplateRenderOptions
- * @property {{ [param: string]: unknown }} [context] - Nunjucks context object (optional)
+ * @property {MacroRenderContext} [context] - Nunjucks context object (optional)
  * @property {{ [block: string]: string }} [blocks] - Nunjucks blocks content in template (optional)
  * @property {Environment} [env] - Nunjucks environment (optional)
  */

--- a/packages/nhsuk-frontend/tasks/assets.mjs
+++ b/packages/nhsuk-frontend/tasks/assets.mjs
@@ -22,7 +22,7 @@ export const copy = task.name('assets:copy', () =>
 export const render = task.name('assets:render', async () => {
   for (const icon of icons.getNames()) {
     const svg = nunjucks.renderMacro('nhsukIcon', 'nhsuk/macros/icon.njk', {
-      context: icon
+      context: [icon, { attributes: { fill: '#212b32' } }]
     })
 
     // Write icon SVG to destination

--- a/packages/nhsuk-frontend/tasks/assets.mjs
+++ b/packages/nhsuk-frontend/tasks/assets.mjs
@@ -1,10 +1,13 @@
 import { join } from 'node:path'
 
 import * as config from '@nhsuk/frontend-config'
+import { files, icons } from '@nhsuk/frontend-lib'
 import { assets, task } from '@nhsuk/frontend-tasks'
 
+import { nunjucks } from '#lib'
+
 /**
- * Copy NHS.UK frontend images, icons and other assets
+ * Copy NHS.UK frontend images and other assets
  */
 export const copy = task.name('assets:copy', () =>
   assets.copy('nhsuk/assets/**', {
@@ -12,3 +15,20 @@ export const copy = task.name('assets:copy', () =>
     destPath: join(config.paths.pkg, 'dist/nhsuk/assets')
   })
 )
+
+/**
+ * Render NHS.UK frontend icons
+ */
+export const render = task.name('assets:render', async () => {
+  for (const icon of icons.getNames()) {
+    const svg = nunjucks.renderMacro('nhsukIcon', 'nhsuk/macros/icon.njk', {
+      context: icon
+    })
+
+    // Write icon SVG to destination
+    await files.write(`nhsuk-icon-${icon}.svg`, {
+      destPath: join(config.paths.pkg, 'dist/nhsuk/assets/images'),
+      output: { contents: svg }
+    })
+  }
+})

--- a/shared/lib/icons.mjs
+++ b/shared/lib/icons.mjs
@@ -1,0 +1,25 @@
+/**
+ * Get icon names
+ */
+export function getNames() {
+  return [
+    'arrow-down-circle',
+    'arrow-down',
+    'arrow-left-circle',
+    'arrow-left',
+    'arrow-right-circle',
+    'arrow-right',
+    'arrow-up-circle',
+    'arrow-up',
+    'chevron-down-circle',
+    'chevron-left-circle',
+    'chevron-right-circle',
+    'chevron-up-circle',
+    'cross',
+    'minus',
+    'plus',
+    'search',
+    'tick',
+    'user'
+  ]
+}

--- a/shared/lib/index.mjs
+++ b/shared/lib/index.mjs
@@ -3,4 +3,5 @@
  */
 export * as components from './components.mjs'
 export * as files from './files.mjs'
+export * as icons from './icons.mjs'
 export * as screenshots from './screenshots.mjs'

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -24,7 +24,7 @@ export function copy(inputPath, { srcPath, destPath, output = {}, ...rest }) {
 
     stream = stream
       .pipe(
-        changed('dist', {
+        changed(destPath, {
           transformPath() {
             return join(dir, `${name}${ext}`)
           }


### PR DESCRIPTION
## Description

This PR adds a new Gulp task to render our Nunjucks icon macro into SVG files

I've also uplifted the `govuk-image-url()` Sass function to enable:

```css
background: nhsuk-image-url("nhsuk-icon-cross.svg") no-repeat;
```

Unblocks https://github.com/nhsuk/nhsuk-frontend/pull/1660 as mentioned in https://github.com/nhsuk/nhsuk-frontend/pull/1660#discussion_r3163267520

### Icons as SVG files

* `assets/images/nhsuk-icon-arrow-down-circle.svg`
* `assets/images/nhsuk-icon-arrow-down.svg`
* `assets/images/nhsuk-icon-arrow-left-circle.svg`
* `assets/images/nhsuk-icon-arrow-left.svg`
* `assets/images/nhsuk-icon-arrow-right-circle.svg`
* `assets/images/nhsuk-icon-arrow-right.svg`
* `assets/images/nhsuk-icon-arrow-up-circle.svg`
* `assets/images/nhsuk-icon-arrow-up.svg`
* `assets/images/nhsuk-icon-chevron-down-circle.svg`
* `assets/images/nhsuk-icon-chevron-left-circle.svg`
* `assets/images/nhsuk-icon-chevron-right-circle.svg`
* `assets/images/nhsuk-icon-chevron-up-circle.svg`
* `assets/images/nhsuk-icon-cross.svg`
* `assets/images/nhsuk-icon-mask.svg`
* `assets/images/nhsuk-icon-minus.svg`
* `assets/images/nhsuk-icon-plus.svg`
* `assets/images/nhsuk-icon-search.svg`
* `assets/images/nhsuk-icon-tick.svg`
* `assets/images/nhsuk-icon-user.svg`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
