### PR TITLE
[v10] Restore action link icon colour `!important`

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
@@ -72,10 +72,12 @@
     &:not(:focus) .nhsuk-icon,
     &:not(:focus):hover .nhsuk-icon,
     &:not(:focus):active .nhsuk-icon {
-      fill: nhsuk-colour("green");
+      // stylelint-disable-next-line declaration-no-important
+      fill: nhsuk-colour("green") !important;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: buttontext;
+        // stylelint-disable-next-line declaration-no-important
+        fill: buttontext !important;
       }
     }
   }
@@ -90,10 +92,12 @@
     &:not(:focus) .nhsuk-icon,
     &:not(:focus):hover .nhsuk-icon,
     &:not(:focus):active .nhsuk-icon {
-      fill: $nhsuk-reverse-text-colour;
+      // stylelint-disable-next-line declaration-no-important
+      fill: $nhsuk-reverse-text-colour !important;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: buttontext;
+        // stylelint-disable-next-line declaration-no-important
+        fill: buttontext !important;
       }
     }
   }


### PR DESCRIPTION
## Description

This PR restores `!important` to action link icon `fill` colour styles

They were removed as unnecessary in https://github.com/nhsuk/nhsuk-frontend/commit/1a383fe60e7390612624ec374b758b0552227239 as part of https://github.com/nhsuk/nhsuk-frontend/pull/1660 but [v10.x still requires them](https://github.com/nhsuk/nhsuk-frontend/pull/1802)

No changelog entry necessary as this regression was never released

## Before
Text link `:visited` styles are automatically inherited by the icon

<img width="1210" height="410" alt="Action link with inherited (purple) icon colour" src="https://github.com/user-attachments/assets/a017715c-169e-42af-9002-85812a179649" />

## After
Text link `:visited` styles are not inherited by the icon

<img width="1210" height="410" alt="Action link with important (green) icon colour" src="https://github.com/user-attachments/assets/12ea3c1f-286c-4bb0-85a1-8ecaabeaa5bb" />

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
