### PR TITLE
[v10] Fix missing legend `size` on inline checkboxes fixture

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
@@ -202,7 +202,9 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'Which nipple has changed?'
+          text: 'Which nipple has changed?',
+          size: 'l',
+          isPageHeading: true
         }
       },
       idPrefix: 'inline',


### PR DESCRIPTION
## Description

This PR fixes a missing `size` (and bonus `isPageHeading`) option from the inline checkboxes fixture

It fixes failing screenshot tests

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
