### PR TITLE
[v10] Allow `nhsuk-responsive-margin()` to output negative margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Read more about [how we provide support for different browsers](/docs/contributi
 
 This was added in [pull request #1972: Add Sass mixins and utility classes for NHS.UK frontend browser support](https://github.com/nhsuk/nhsuk-frontend/pull/1972).
 
+#### Define negative margins using the Sass `nhsuk-responsive-margin()` mixin
+
+You can now pass the negative equivalent of a point from the typography scale to the `nhsuk-responsive-margin()` function to output negative margins.
+
+For example, `nhsuk-responsive-margin(3)` outputs an `8px` margin (`16px` tablet width) in all directions, and `nhsuk-responsive-margin(-3)` outputs an `-8px` margin (`-16px` tablet width).
+
+This was added in [pull request #1940: Allow `nhsuk-responsive-margin()` to output negative margins](https://github.com/nhsuk/nhsuk-frontend/pull/1940).
+
 ## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -32,7 +32,7 @@ describe('Spacing settings', () => {
   `
 
   describe('@function nhsuk-spacing', () => {
-    it('returns CSS for a property based on the given spacing point', async () => {
+    it('returns CSS for a property based on a spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -94,7 +94,7 @@ describe('Spacing settings', () => {
       )
     })
 
-    it('throws an error when passed a non-existent point', async () => {
+    it('throws an error when passed a non-existent spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -154,7 +154,7 @@ describe('Spacing settings', () => {
   })
 
   describe('@mixin nhsuk-responsive-spacing', () => {
-    it('outputs CSS for a property based on the given spacing map', async () => {
+    it('outputs CSS for a property based on a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -181,7 +181,7 @@ describe('Spacing settings', () => {
       })
     })
 
-    it('outputs CSS for a property and direction based on the spacing map', async () => {
+    it('outputs CSS for a property and direction based on a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -208,7 +208,7 @@ describe('Spacing settings', () => {
       })
     })
 
-    it('throws an exception when passed a non-existent point', async () => {
+    it('throws an exception when passed a non-existent responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -358,7 +358,7 @@ describe('Spacing settings', () => {
   })
 
   describe('@mixin nhsuk-responsive-margin', () => {
-    it('outputs simple responsive margins', async () => {
+    it('outputs simple responsive margins for a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -385,7 +385,7 @@ describe('Spacing settings', () => {
       })
     })
 
-    it('outputs extreme responsive margins', async () => {
+    it('outputs extreme responsive margins for a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -419,7 +419,7 @@ describe('Spacing settings', () => {
   })
 
   describe('@mixin nhsuk-responsive-padding', () => {
-    it('outputs simple responsive padding', async () => {
+    it('outputs simple responsive padding for a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
@@ -446,7 +446,7 @@ describe('Spacing settings', () => {
       })
     })
 
-    it('outputs extreme responsive padding', async () => {
+    it('outputs extreme responsive padding for a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -59,7 +59,7 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          top: nhsuk-spacing(-2)
+          top: nhsuk-spacing(-$app-spacing-point)
         }
       `
 
@@ -108,7 +108,7 @@ describe('Spacing settings', () => {
       })
 
       await expect(results).rejects.toThrow(
-        'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
+        'Unknown spacing point `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
       )
     })
 
@@ -126,7 +126,7 @@ describe('Spacing settings', () => {
       })
 
       await expect(results).rejects.toThrow(
-        'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
+        'Unknown spacing point `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
       )
     })
 
@@ -181,6 +181,33 @@ describe('Spacing settings', () => {
       })
     })
 
+    it('outputs CSS for a property based on a negative responsive spacing point', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          @include nhsuk-responsive-spacing(-$app-spacing-point, 'margin')
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: outdent`
+          .foo {
+            margin: -15px;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              margin: -25px;
+            }
+          }
+        `
+      })
+    })
+
     it('outputs CSS for a property and direction based on a responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
@@ -222,7 +249,25 @@ describe('Spacing settings', () => {
       })
 
       await expect(results).rejects.toThrow(
-        'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
+        'Unknown responsive spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
+      )
+    })
+
+    it('throws an error when passed a non-existent negative point', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          @include nhsuk-responsive-spacing(-999, 'margin')
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).rejects.toThrow(
+        'Unknown responsive spacing point `999`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
       )
     })
 
@@ -379,6 +424,33 @@ describe('Spacing settings', () => {
           @media (min-width: 30em) {
             .foo {
               margin: 25px;
+            }
+          }
+        `
+      })
+    })
+
+    it('outputs simple responsive margins for a negative responsive spacing point', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          @include nhsuk-responsive-margin(-$app-spacing-point)
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: outdent`
+          .foo {
+            margin: -15px;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              margin: -25px;
             }
           }
         `

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -79,7 +79,7 @@
 /// @param {String} $direction [all] - Direction to add spacing to
 ///  (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
-/// @param {Number} $adjustment [false] - Offset to adjust spacing by
+/// @param {Number} $adjustment [null] - Offset to adjust spacing by
 ///
 /// @example scss
 ///   .foo {
@@ -98,7 +98,7 @@
   $property,
   $direction: "all",
   $important: false,
-  $adjustment: false
+  $adjustment: null
 ) {
   $actual-input-type: meta.type-of($responsive-spacing-point);
   @if $actual-input-type != "number" {
@@ -163,7 +163,7 @@
 /// @param {String} $direction [all] - Direction to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
-/// @param {Number} $adjustment [false] - Offset to adjust spacing by
+/// @param {Number} $adjustment [null] - Offset to adjust spacing by
 ///
 /// @example scss
 ///   .foo {
@@ -172,7 +172,7 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@mixin nhsuk-responsive-margin($responsive-spacing-point, $direction: "all", $important: false, $adjustment: false) {
+@mixin nhsuk-responsive-margin($responsive-spacing-point, $direction: "all", $important: false, $adjustment: null) {
   @include nhsuk-responsive-spacing($responsive-spacing-point, "margin", $direction, $important, $adjustment);
 }
 
@@ -187,7 +187,7 @@
 /// @param {String} $direction [all] - Direction to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
-/// @param {Number} $adjustment [false] - Offset to adjust spacing
+/// @param {Number} $adjustment [null] - Offset to adjust spacing by
 ///
 /// @example scss
 ///   .foo {
@@ -196,6 +196,6 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@mixin nhsuk-responsive-padding($responsive-spacing-point, $direction: "all", $important: false, $adjustment: false) {
+@mixin nhsuk-responsive-padding($responsive-spacing-point, $direction: "all", $important: false, $adjustment: null) {
   @include nhsuk-responsive-spacing($responsive-spacing-point, "padding", $direction, $important, $adjustment);
 }

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -55,13 +55,13 @@
     @error "Unknown spacing variable `#{$spacing-point}`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.";
   }
 
-  $value: map.get($nhsuk-spacing-points, $spacing-point);
+  $spacing-value: map.get($nhsuk-spacing-points, $spacing-point);
 
   @if $is-negative {
-    @return $value * -1;
+    $spacing-value: $spacing-value * -1;
   }
 
-  @return $value;
+  @return $spacing-value;
 }
 
 /// Responsive spacing
@@ -105,8 +105,14 @@
     @error "Expected a number (integer), but got a " + "#{$actual-input-type}.";
   }
 
+  $is-negative: false;
+  @if $responsive-spacing-point < 0 {
+    $is-negative: true;
+    $responsive-spacing-point: math.abs($responsive-spacing-point);
+  }
+
   @if not map.has-key($nhsuk-spacing-responsive-scale, $responsive-spacing-point) {
-    @error "Unknown spacing point `#{$responsive-spacing-point}`. Make sure you are using a point from the "
+    @error "Unknown responsive spacing point `#{$responsive-spacing-point}`. Make sure you are using a point from the "
       + "responsive spacing scale in `_settings/spacing.scss`.";
   }
 
@@ -119,6 +125,10 @@
 
   // [2]
   @each $breakpoint, $breakpoint-value in $scale-map {
+    @if $is-negative {
+      $breakpoint-value: $breakpoint-value * -1;
+    }
+
     @if $adjustment {
       @if not math.compatible($breakpoint-value, $adjustment) {
         $breakpoint-value: calc($breakpoint-value + $adjustment);

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -39,10 +39,9 @@
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
 @function nhsuk-spacing($spacing-point) {
-  $actual-input-type: meta.type-of($spacing-point);
-  @if $actual-input-type != "number" {
+  @if meta.type-of($spacing-point) != "number" {
     @error "Expected a number (integer), but got a "
-      + "#{$actual-input-type}.";
+      + "#{meta.type-of($spacing-point)}.";
   }
 
   $is-negative: false;
@@ -52,7 +51,8 @@
   }
 
   @if not map.has-key($nhsuk-spacing-points, $spacing-point) {
-    @error "Unknown spacing variable `#{$spacing-point}`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.";
+    @error "Unknown spacing point `#{$spacing-point}`. Make sure you are using a point from the "
+      + "spacing scale in `_settings/spacing.scss`.";
   }
 
   $spacing-value: map.get($nhsuk-spacing-points, $spacing-point);
@@ -83,8 +83,8 @@
 ///
 /// @example scss
 ///   .foo {
-///     padding: nhsuk-spacing(5);
-///     top: nhsuk-spacing(2) !important; // if `!important` is required
+///     @include nhsuk-responsive-spacing(4, "padding");
+///     @include nhsuk-responsive-spacing(2, "top", $important: true); // if `!important` is required
 ///   }
 ///
 /// 1. Make sure that the return value from `_settings/spacing.scss` is a map.
@@ -100,9 +100,8 @@
   $important: false,
   $adjustment: null
 ) {
-  $actual-input-type: meta.type-of($responsive-spacing-point);
-  @if $actual-input-type != "number" {
-    @error "Expected a number (integer), but got a " + "#{$actual-input-type}.";
+  @if meta.type-of($responsive-spacing-point) != "number" {
+    @error "Expected a number (integer), but got a " + "#{meta.type-of($responsive-spacing-point)}.";
   }
 
   $is-negative: false;
@@ -117,10 +116,9 @@
   }
 
   $scale-map: map.get($nhsuk-spacing-responsive-scale, $responsive-spacing-point); // [1]
-  $actual-map-type: meta.type-of($scale-map);
-  @if $actual-map-type != "map" {
+  @if meta.type-of($scale-map) != "map" {
     @error "Expected a number (integer), but got a "
-      + "#{$actual-map-type}. Make sure you are using a map to set the responsive spacing in `_settings/spacing.scss`)";
+      + "#{meta.type-of($scale-map)}. Make sure you are using a map to set the responsive spacing in `_settings/spacing.scss`)";
   }
 
   // [2]


### PR DESCRIPTION
## Description

This PR adds support for negative spacing points in `nhsuk-responsive-margin()` just like `nhsuk-spacing()`

Internally (and undocumented) this means `nhsuk-responsive-spacing()` also supports negative spacing points

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
