### PR TITLE
[v10] Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ For example, `nhsuk-responsive-margin(3)` outputs an `8px` margin (`16px` tablet
 
 This was added in [pull request #1940: Allow `nhsuk-responsive-margin()` to output negative margins](https://github.com/nhsuk/nhsuk-frontend/pull/1940).
 
+### :wrench: **Fixes**
+
+- [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).
+
 ## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -290,7 +290,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
         display: inline-block;
         position: relative;
         padding: nhsuk-spacing(1);
-        padding-left: $nhsuk-expander-icon-size + nhsuk-spacing(2);
+        padding-left: nhsuk-spacing(2, $adjustment: $nhsuk-expander-icon-size);
         cursor: pointer;
       }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -175,6 +175,30 @@ describe('Spacing settings', () => {
         })
       })
     })
+
+    describe('when an adjustment is provided', () => {
+      it('adjusts the value for the property', async () => {
+        const sass = outdent`
+          ${sassBootstrap}
+
+          .foo {
+            top: nhsuk-spacing($app-spacing-point, $adjustment: 2px);
+          }
+        `
+
+        const results = compileStringAsync(sass, {
+          loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+        })
+
+        await expect(results).resolves.toMatchObject({
+          css: outdent`
+            .foo {
+              top: 17px;
+            }
+          `
+        })
+      })
+    })
   })
 
   describe('@mixin nhsuk-responsive-spacing', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -151,6 +151,30 @@ describe('Spacing settings', () => {
         `
       })
     })
+
+    describe('when $important is set to true', () => {
+      it('marks the rule as important for the property', async () => {
+        const sass = outdent`
+          ${sassBootstrap}
+
+          .foo {
+            top: nhsuk-spacing($app-spacing-point, $important: true);
+          }
+        `
+
+        const results = compileStringAsync(sass, {
+          loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+        })
+
+        await expect(results).resolves.toMatchObject({
+          css: outdent`
+            .foo {
+              top: 15px !important;
+            }
+          `
+        })
+      })
+    })
   })
 
   describe('@mixin nhsuk-responsive-spacing', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -19,6 +19,7 @@
 /// @param {Number} $spacing-point - Point on the spacing scale
 ///  (set in `settings/_spacing.scss`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
+/// @param {Number} $adjustment [null] - Offset to adjust spacing by
 /// @return {String} Spacing measurement eg. 8px
 ///
 /// @example scss
@@ -38,7 +39,7 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@function nhsuk-spacing($spacing-point, $important: false) {
+@function nhsuk-spacing($spacing-point, $important: false, $adjustment: null) {
   @if meta.type-of($spacing-point) != "number" {
     @error "Expected a number (integer), but got a "
       + "#{meta.type-of($spacing-point)}.";
@@ -59,6 +60,14 @@
 
   @if $is-negative {
     $spacing-value: $spacing-value * -1;
+  }
+
+  @if $adjustment {
+    @if not math.compatible($spacing-value, $adjustment) {
+      $spacing-value: calc($spacing-value + $adjustment);
+    } @else {
+      $spacing-value: $spacing-value + $adjustment;
+    }
   }
 
   @if $important == true {

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -18,8 +18,8 @@
 ///
 /// @param {Number} $spacing-point - Point on the spacing scale
 ///  (set in `settings/_spacing.scss`)
-///
-/// @returns {String} Spacing measurement eg. 8px
+/// @param {Boolean} $important [false] - Whether to mark as `!important`
+/// @return {String} Spacing measurement eg. 8px
 ///
 /// @example scss
 ///   .element {
@@ -38,7 +38,7 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@function nhsuk-spacing($spacing-point) {
+@function nhsuk-spacing($spacing-point, $important: false) {
   @if meta.type-of($spacing-point) != "number" {
     @error "Expected a number (integer), but got a "
       + "#{meta.type-of($spacing-point)}.";
@@ -59,6 +59,10 @@
 
   @if $is-negative {
     $spacing-value: $spacing-value * -1;
+  }
+
+  @if $important == true {
+    $spacing-value: $spacing-value !important;
   }
 
   @return $spacing-value;

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_spacing.scss
@@ -72,12 +72,12 @@ $_spacing-directions: ("top", "right", "bottom", "left") !default;
 @mixin _nhsuk-generate-static-spacing-overrides($property) {
   @each $spacing-point in map.keys($nhsuk-spacing-points) {
     .nhsuk-u-static-#{$property}-#{$spacing-point} {
-      #{$property}: nhsuk-spacing($spacing-point) !important;
+      #{$property}: nhsuk-spacing($spacing-point, $important: true);
     }
 
     @each $direction in $_spacing-directions {
       .nhsuk-u-static-#{$property}-#{$direction}-#{$spacing-point} {
-        #{$property}-#{$direction}: nhsuk-spacing($spacing-point) !important;
+        #{$property}-#{$direction}: nhsuk-spacing($spacing-point, $important: true);
       }
     }
   }


### PR DESCRIPTION
## Description

This PRs adds missing `$adjustment` and `$important` params to `nhsuk-spacing()` for consistency with:

* `nhsuk-responsive-margin()`
* `nhsuk-responsive-padding()`
* `nhsuk-responsive-spacing()`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
