### PR TITLE
[v10] Remove nested errors from non-nested conditional fixtures

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
@@ -583,7 +583,7 @@ const fixtures = {
       },
       idPrefix: 'conditional',
       name: 'contact',
-      items: getItems({ invalid: true })
+      items: getItems()
     },
     variants
   },

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/fixtures.mjs
@@ -595,7 +595,7 @@ const fixtures = {
       },
       idPrefix: 'conditional',
       name: 'example',
-      items: getItems({ invalid: true })
+      items: getItems()
     },
     variants
   },


### PR DESCRIPTION
## Description

This PR removes a nested error accidentally added to non-nested conditional examples for checkboxes/radios

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
