### PR TITLE
[v10] Prevent empty error message being rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,6 +402,7 @@ This change was introduced in [pull request #1712: Add support for icon buttons]
 - [#1904: Make sure Nunjucks text-only options for card heading, label and legend are escaped](https://github.com/nhsuk/nhsuk-frontend/pull/1904)
 - [#1925: Increase text input prefix/suffix spacing](https://github.com/nhsuk/nhsuk-frontend/pull/1925)
 - [#1934: Adjust small checkboxes and radios spacing](https://github.com/nhsuk/nhsuk-frontend/pull/1934)
+- [#1935: Prevent empty error message being rendered](https://github.com/nhsuk/nhsuk-frontend/pull/1935)
 
 ## 10.4.2 - 25 March 2026
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/template.njk
@@ -105,7 +105,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(idPrefix ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -135,7 +135,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(params.id ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -78,10 +78,6 @@
   {% set itemWidth = item.width | default(4) %}
 {% endif -%}
 
-{%- if itemHasError or (item.error != false and params.errorMessage and not anyItemHasError) %}
-  {% set itemClasses = (itemClasses + " nhsuk-input--error") | trim %}
-{% endif -%}
-
 {%- if item.classes %}
   {% set itemClasses = (itemClasses + " " + item.classes) | trim %}
 {% endif %}
@@ -96,6 +92,7 @@
       classes: "nhsuk-date-input__label" ~ (" " ~ itemLabel.classes if itemLabel.classes),
       attributes: itemLabel.attributes
     },
+    errorMessage: itemHasError or (item.error != false and params.errorMessage and not anyItemHasError),
     id: item.id if item.id else (params.id ~ "-" ~ itemName),
     name: (params.namePrefix ~ "[" ~ itemName ~ "]") if params.namePrefix else itemName,
     value: itemValue | default(params.values[itemName]),

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/template.njk
@@ -88,7 +88,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(id ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/fixtures.mjs
@@ -534,7 +534,7 @@ const fixtures = {
   'example address line 1': {
     context: {
       label: {
-        text: 'Address'
+        text: 'Address line 1'
       },
       name: 'address-line1',
       autocomplete: 'address-line1'

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/template.njk
@@ -149,7 +149,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(id ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/template.njk
@@ -97,7 +97,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(idPrefix ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/template.njk
@@ -72,7 +72,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(id ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/template.njk
@@ -47,7 +47,7 @@
     attributes: params.hint.attributes
   }) | trim | indent(2) }}
 {% endif %}
-{% if params.errorMessage %}
+{% if params.errorMessage.text or params.errorMessage.html %}
   {% set errorId = params.errorMessage.id | default(id ~ "-error") %}
   {% set describedBy = (describedBy ~ " " ~ errorId) | trim %}
   {{ errorMessage({


### PR DESCRIPTION
## Description

This PR tightens our `params.errorMessage` check to make sure text will be rendered:

```patch
- {% if params.errorMessage %}
+ {% if params.errorMessage.text or params.errorMessage.html %}
```

We only make use of this in date inputs where nested input components have red borders but no error text

This fix allows service teams to make their own nested components where error text is handled elsewhere

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
