### PR TITLE
[v10] Support rem units in Sass spacing functions and mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,26 @@ For example, `nhsuk-responsive-margin(3)` outputs an `8px` margin (`16px` tablet
 
 This was added in [pull request #1940: Allow `nhsuk-responsive-margin()` to output negative margins](https://github.com/nhsuk/nhsuk-frontend/pull/1940).
 
+#### Support rem units in Sass spacing functions and mixins
+
+You can now pass `$unit: "rem"` into all Sass spacing functions and mixins.
+
+For example, to output responsive padding in rem units:
+
+```patch
+- @include nhsuk-responsive-padding(5, "right");
++ @include nhsuk-responsive-padding(5, "right", $unit: "rem");
+```
+
+Or removing `nhsuk-px-to-rem()` and using `nhsuk-spacing()` directly:
+
+```patch
+- padding: nhsuk-px-to-rem(nhsuk-spacing(1));
++ padding: nhsuk-spacing(1, $unit: "rem");
+```
+
+This was added in [pull request #1945: Support rem units in Sass spacing functions and mixins](https://github.com/nhsuk/nhsuk-frontend/pull/1945).
+
 ### :wrench: **Fixes**
 
 - [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -532,12 +532,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
   .nhsuk-card--primary > .nhsuk-card__content,
   // Deprecated, to be removed in v11.0
   .nhsuk-card__content--primary {
-    @include nhsuk-responsive-spacing(
-      5,
-      "padding",
-      $direction: "right",
-      $adjustment: nhsuk-px-to-rem(nhsuk-spacing(7))
-    );
+    @include nhsuk-responsive-padding(5, "right", $adjustment: nhsuk-spacing(7), $unit: "rem");
 
     @include nhsuk-media-query($from: desktop) {
       height: 100%;

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
@@ -81,7 +81,7 @@
 
     .nhsuk-code--button & {
       @include nhsuk-frontend-supported {
-        padding-top: nhsuk-px-to-rem(nhsuk-spacing(9));
+        padding-top: nhsuk-spacing(9, $unit: "rem");
       }
     }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -57,7 +57,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
     .nhsuk-details {
       margin-top: nhsuk-spacing(2);
       padding: nhsuk-spacing(3) 0;
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(4) - $nhsuk-border-width); // [5]
+      padding-left: nhsuk-spacing(4, $adjustment: - $nhsuk-border-width, $unit: "rem"); // [5]
       border-left: $nhsuk-border-width solid nhsuk-colour("grey-3");
     }
 
@@ -84,7 +84,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
     .nhsuk-details__summary {
       position: relative; // [2]
       width: fit-content; // [1]
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(4));
+      padding-left: nhsuk-spacing(4, $unit: "rem");
       text-decoration: none;
       cursor: pointer;
 
@@ -169,7 +169,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       margin-top: nhsuk-spacing(2);
       padding: nhsuk-spacing(3) 0;
       padding-right: 0;
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(4) - $nhsuk-border-width); // [5]
+      padding-left: nhsuk-spacing(4, $adjustment: - $nhsuk-border-width, $unit: "rem"); // [5]
       border-left: $nhsuk-border-width solid nhsuk-colour("grey-3");
 
       .nhsuk-details--reverse & {
@@ -331,7 +331,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       // replacing fixed pixel sizes with rems for text-only zooming
       @supports (clip-path: shape(from 0% 0%, line to 100% 100%)) {
         .nhsuk-details__summary-text {
-          padding-left: nhsuk-px-to-rem($nhsuk-expander-icon-size + nhsuk-spacing(2));
+          padding-left: nhsuk-spacing(2, $adjustment: $nhsuk-expander-icon-size, $unit: "rem");
         }
 
         .nhsuk-details__summary-text::before {

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
@@ -102,10 +102,10 @@
   // 16. Prevent overlap using safe area: box offset + arrow height + spacing
 
   .nhsuk-hero--image-description {
-    margin-bottom: nhsuk-px-to-rem(70px + 20px + nhsuk-spacing(3)); // [16]
+    margin-bottom: nhsuk-spacing(3, $adjustment: 70px + 20px, $unit: "rem"); // [16]
 
     @include nhsuk-media-query($from: tablet) {
-      margin-bottom: nhsuk-px-to-rem(48px + 20px + nhsuk-spacing(4)); // [16]
+      margin-bottom: nhsuk-spacing(4, $adjustment: 48px + 20px, $unit: "rem"); // [16]
     }
 
     .nhsuk-hero-content {

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
@@ -19,7 +19,7 @@
     width: 100%;
     height: nhsuk-px-to-rem(40px);
     margin-top: 0;
-    padding: nhsuk-px-to-rem(nhsuk-spacing(1));
+    padding: nhsuk-spacing(1, $unit: "rem");
     // Setting any background-color makes text invisible when changing colours
     // to dark backgrounds in Firefox (https://bugzil.la/1335476). As
     // background-color and color need to always be set together, color should
@@ -34,12 +34,12 @@
 
     // Increase left padding with prefix
     .nhsuk-input-wrapper:has(.nhsuk-input-wrapper__prefix) & {
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(1) + $nhsuk-border-width-form-element);
+      padding-left: nhsuk-spacing(1, $adjustment: $nhsuk-border-width-form-element, $unit: "rem");
     }
 
     // Increase right padding with suffix
     .nhsuk-input-wrapper:has(.nhsuk-input-wrapper__suffix) &:not([type="search"]) {
-      padding-right: nhsuk-px-to-rem(nhsuk-spacing(1) + $nhsuk-border-width-form-element);
+      padding-right: nhsuk-spacing(1, $adjustment: $nhsuk-border-width-form-element, $unit: "rem");
     }
 
     &:focus {
@@ -131,18 +131,18 @@
 
   .nhsuk-input--large {
     height: nhsuk-px-to-rem(48px);
-    padding-right: nhsuk-px-to-rem(nhsuk-spacing(2));
-    padding-left: nhsuk-px-to-rem(nhsuk-spacing(2));
+    padding-right: nhsuk-spacing(2, $unit: "rem");
+    padding-left: nhsuk-spacing(2, $unit: "rem");
     @include nhsuk-font($size: 22);
 
     // Increase left padding with prefix
     .nhsuk-input-wrapper:has(.nhsuk-input-wrapper__prefix) & {
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(2) + $nhsuk-border-width-form-element);
+      padding-left: nhsuk-spacing(2, $adjustment: $nhsuk-border-width-form-element, $unit: "rem");
     }
 
     // Increase right padding with suffix
     .nhsuk-input-wrapper:has(.nhsuk-input-wrapper__suffix) &:not([type="search"]) {
-      padding-right: nhsuk-px-to-rem(nhsuk-spacing(2) + $nhsuk-border-width-form-element);
+      padding-right: nhsuk-spacing(2, $adjustment: $nhsuk-border-width-form-element, $unit: "rem");
     }
 
     @include nhsuk-media-query($from: tablet) {
@@ -216,7 +216,7 @@
 
     min-width: nhsuk-px-to-rem(40px);
     height: nhsuk-px-to-rem(40px);
-    padding: nhsuk-px-to-rem(nhsuk-spacing(1)) nhsuk-px-to-rem(nhsuk-spacing(2));
+    padding: nhsuk-spacing(1, $unit: "rem") nhsuk-spacing(2, $unit: "rem");
 
     border: $nhsuk-border-width-form-element solid $nhsuk-input-border-colour;
 
@@ -241,8 +241,8 @@
   .nhsuk-input-wrapper--large .nhsuk-input-wrapper__suffix {
     @include nhsuk-media-query($from: mobile) {
       height: nhsuk-px-to-rem(52px);
-      padding-right: nhsuk-px-to-rem(nhsuk-spacing(3));
-      padding-left: nhsuk-px-to-rem(nhsuk-spacing(3));
+      padding-right: nhsuk-spacing(3, $unit: "rem");
+      padding-left: nhsuk-spacing(3, $unit: "rem");
       @include nhsuk-font($size: 22);
     }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/_index.scss
@@ -19,7 +19,7 @@
     min-width: 100%;
     max-width: 100%;
     height: nhsuk-px-to-rem(40px);
-    padding: nhsuk-px-to-rem(nhsuk-spacing(1));
+    padding: nhsuk-spacing(1, $unit: "rem");
 
     border: $nhsuk-border-width-form-element solid $nhsuk-input-border-colour;
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/_index.scss
@@ -16,7 +16,7 @@
     z-index: 2;
     top: nhsuk-spacing(3);
     left: nhsuk-spacing(3);
-    padding: nhsuk-px-to-rem(nhsuk-spacing(2));
+    padding: nhsuk-spacing(2, $unit: "rem");
     @include nhsuk-visually-hidden-focusable; // [1]
 
     // Respect 'display cutout' safe area (avoids notches and rounded corners)

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/_index.scss
@@ -18,7 +18,7 @@
 
     width: 100%;
     min-height: nhsuk-px-to-rem(40px);
-    padding: nhsuk-px-to-rem(nhsuk-spacing(1));
+    padding: nhsuk-spacing(1, $unit: "rem");
 
     resize: vertical;
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -37,7 +37,8 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          top: nhsuk-spacing($app-spacing-point)
+          top: nhsuk-spacing($app-spacing-point);
+          left: nhsuk-spacing($app-spacing-point, $unit: "rem");
         }
       `
 
@@ -49,6 +50,7 @@ describe('Spacing settings', () => {
         css: outdent`
           .foo {
             top: 15px;
+            left: 0.9375rem;
           }
         `
       })
@@ -59,7 +61,8 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          top: nhsuk-spacing(-$app-spacing-point)
+          top: nhsuk-spacing(-$app-spacing-point);
+          left: nhsuk-spacing(-$app-spacing-point, $unit: "rem");
         }
       `
 
@@ -71,6 +74,7 @@ describe('Spacing settings', () => {
         css: outdent`
           .foo {
             top: -15px;
+            left: -0.9375rem;
           }
         `
       })
@@ -130,12 +134,29 @@ describe('Spacing settings', () => {
       )
     })
 
+    it('throws an error when passed a non-existent unit', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          left: nhsuk-spacing($app-spacing-point, $unit: "margin");
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).rejects.toThrow('Unknown unit `margin`.')
+    })
+
     it('handles negative zero', async () => {
       const sass = outdent`
         ${sassBootstrap}
 
         .foo {
-          top: nhsuk-spacing(-0)
+          top: nhsuk-spacing(-0);
+          left: nhsuk-spacing(-0, $unit: "rem");
         }
       `
 
@@ -147,6 +168,7 @@ describe('Spacing settings', () => {
         css: outdent`
           .foo {
             top: 0;
+            left: 0rem;
           }
         `
       })
@@ -159,6 +181,7 @@ describe('Spacing settings', () => {
 
           .foo {
             top: nhsuk-spacing($app-spacing-point, $important: true);
+            left: nhsuk-spacing($app-spacing-point, $important: true, $unit: "rem");
           }
         `
 
@@ -170,6 +193,7 @@ describe('Spacing settings', () => {
           css: outdent`
             .foo {
               top: 15px !important;
+              left: 0.9375rem !important;
             }
           `
         })
@@ -183,6 +207,7 @@ describe('Spacing settings', () => {
 
           .foo {
             top: nhsuk-spacing($app-spacing-point, $adjustment: 2px);
+            left: nhsuk-spacing($app-spacing-point, $adjustment: 2px, $unit: "rem");
           }
         `
 
@@ -194,6 +219,7 @@ describe('Spacing settings', () => {
           css: outdent`
             .foo {
               top: 17px;
+              left: calc(0.9375rem + 2px);
             }
           `
         })
@@ -207,7 +233,8 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          @include nhsuk-responsive-spacing($app-spacing-point, 'margin')
+          @include nhsuk-responsive-spacing($app-spacing-point, 'margin');
+          @include nhsuk-responsive-spacing($app-spacing-point, 'padding', $unit: "rem");
         }
       `
 
@@ -225,6 +252,14 @@ describe('Spacing settings', () => {
               margin: 25px;
             }
           }
+          .foo {
+            padding: 0.9375rem;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              padding: 1.5625rem;
+            }
+          }
         `
       })
     })
@@ -234,7 +269,8 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          @include nhsuk-responsive-spacing(-$app-spacing-point, 'margin')
+          @include nhsuk-responsive-spacing(-$app-spacing-point, 'margin');
+          @include nhsuk-responsive-spacing(-$app-spacing-point, 'padding', $unit: "rem");
         }
       `
 
@@ -252,6 +288,14 @@ describe('Spacing settings', () => {
               margin: -25px;
             }
           }
+          .foo {
+            padding: -0.9375rem;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              padding: -1.5625rem;
+            }
+          }
         `
       })
     })
@@ -261,7 +305,8 @@ describe('Spacing settings', () => {
         ${sassBootstrap}
 
         .foo {
-          @include nhsuk-responsive-spacing($app-spacing-point, 'padding', 'top');
+          @include nhsuk-responsive-spacing($app-spacing-point, 'margin', 'top');
+          @include nhsuk-responsive-spacing($app-spacing-point, 'padding', 'left', $unit: "rem");
         }
       `
 
@@ -272,11 +317,19 @@ describe('Spacing settings', () => {
       await expect(results).resolves.toMatchObject({
         css: outdent`
           .foo {
-            padding-top: 15px;
+            margin-top: 15px;
           }
           @media (min-width: 30em) {
             .foo {
-              padding-top: 25px;
+              margin-top: 25px;
+            }
+          }
+          .foo {
+            padding-left: 0.9375rem;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              padding-left: 1.5625rem;
             }
           }
         `
@@ -317,6 +370,22 @@ describe('Spacing settings', () => {
       await expect(results).rejects.toThrow(
         'Unknown responsive spacing point `999`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
       )
+    })
+
+    it('throws an error when passed a non-existent unit', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          @include nhsuk-responsive-spacing($app-spacing-point, 'margin', $unit: "margin");
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).rejects.toThrow('Unknown unit `margin`.')
     })
 
     describe('when $important is set to true', () => {

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_lists.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_lists.scss
@@ -105,7 +105,7 @@ ol {
 .nhsuk-list--cross {
   position: relative;
   margin-top: 0;
-  padding-left: nhsuk-px-to-rem($nhsuk-icon-size-large + nhsuk-spacing(1)); // [3]
+  padding-left: nhsuk-spacing(1, $adjustment: $nhsuk-icon-size-large, $unit: "rem"); // [3]
   list-style: none;
 
   .nhsuk-icon {

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -1,9 +1,11 @@
 // stylelint-disable declaration-no-important
 
+@use "sass:list";
 @use "sass:map";
 @use "sass:math";
 @use "sass:meta";
 @use "../settings" as *;
+@use "functions" as *;
 @use "sass-mq" as *;
 
 ////
@@ -20,6 +22,7 @@
 ///  (set in `settings/_spacing.scss`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
+/// @param {String} $unit ["px"] - Unit to use for spacing
 /// @return {String} Spacing measurement eg. 8px
 ///
 /// @example scss
@@ -39,10 +42,14 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@function nhsuk-spacing($spacing-point, $important: false, $adjustment: null) {
+@function nhsuk-spacing($spacing-point, $important: false, $adjustment: null, $unit: "px") {
   @if meta.type-of($spacing-point) != "number" {
     @error "Expected a number (integer), but got a "
       + "#{meta.type-of($spacing-point)}.";
+  }
+
+  @if not list.index(("px", "rem"), #{$unit}) {
+    @error "Unknown unit `#{$unit}`.";
   }
 
   $is-negative: false;
@@ -60,6 +67,10 @@
 
   @if $is-negative {
     $spacing-value: $spacing-value * -1;
+  }
+
+  @if $unit == "rem" {
+    $spacing-value: nhsuk-px-to-rem($spacing-value);
   }
 
   @if $adjustment {
@@ -93,6 +104,7 @@
 ///  (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
+/// @param {String} $unit ["px"] - Unit to use for spacing
 ///
 /// @example scss
 ///   .foo {
@@ -111,10 +123,15 @@
   $property,
   $direction: "all",
   $important: false,
-  $adjustment: null
+  $adjustment: null,
+  $unit: "px"
 ) {
   @if meta.type-of($responsive-spacing-point) != "number" {
     @error "Expected a number (integer), but got a " + "#{meta.type-of($responsive-spacing-point)}.";
+  }
+
+  @if not list.index(("px", "rem"), #{$unit}) {
+    @error "Unknown unit `#{$unit}`.";
   }
 
   $is-negative: false;
@@ -138,6 +155,10 @@
   @each $breakpoint, $breakpoint-value in $scale-map {
     @if $is-negative {
       $breakpoint-value: $breakpoint-value * -1;
+    }
+
+    @if $unit == "rem" {
+      $breakpoint-value: nhsuk-px-to-rem($breakpoint-value);
     }
 
     @if $adjustment {
@@ -185,6 +206,7 @@
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
+/// @param {String} $unit ["px"] - Unit to use for spacing
 ///
 /// @example scss
 ///   .foo {
@@ -193,8 +215,14 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@mixin nhsuk-responsive-margin($responsive-spacing-point, $direction: "all", $important: false, $adjustment: null) {
-  @include nhsuk-responsive-spacing($responsive-spacing-point, "margin", $direction, $important, $adjustment);
+@mixin nhsuk-responsive-margin(
+  $responsive-spacing-point,
+  $direction: "all",
+  $important: false,
+  $adjustment: null,
+  $unit: "px"
+) {
+  @include nhsuk-responsive-spacing($responsive-spacing-point, "margin", $direction, $important, $adjustment, $unit);
 }
 
 /// Responsive padding
@@ -209,6 +237,7 @@
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
+/// @param {String} $unit ["px"] - Unit to use for spacing
 ///
 /// @example scss
 ///   .foo {
@@ -217,6 +246,12 @@
 ///
 /// @link https://github.com/alphagov/govuk-frontend Original code taken from GDS (Government Digital Service)
 
-@mixin nhsuk-responsive-padding($responsive-spacing-point, $direction: "all", $important: false, $adjustment: null) {
-  @include nhsuk-responsive-spacing($responsive-spacing-point, "padding", $direction, $important, $adjustment);
+@mixin nhsuk-responsive-padding(
+  $responsive-spacing-point,
+  $direction: "all",
+  $important: false,
+  $adjustment: null,
+  $unit: "px"
+) {
+  @include nhsuk-responsive-spacing($responsive-spacing-point, "padding", $direction, $important, $adjustment, $unit);
 }


### PR DESCRIPTION
## Description

This PR add support for `$unit: "rem"` to all Sass spacing functions and mixins to output in rem units:

```patch
- @include nhsuk-responsive-padding(5, "right");
+ @include nhsuk-responsive-padding(5, "right", $unit: "rem");
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
