### PR TITLE
[v10] Support multiple directions in Sass spacing mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,18 @@ Or removing `nhsuk-px-to-rem()` and using `nhsuk-spacing()` directly:
 
 This was added in [pull request #1945: Support rem units in Sass spacing functions and mixins](https://github.com/nhsuk/nhsuk-frontend/pull/1945).
 
+#### Support multiple directions in Sass spacing mixins
+
+You can now pass multiple directions into the `nhsuk-responsive-margin()` and `nhsuk-responsive-padding()` mixins.
+
+```patch
+- @include nhsuk-responsive-padding(5, "left");
+- @include nhsuk-responsive-padding(5, "right");
++ @include nhsuk-responsive-padding(5, ("left", "right"));
+```
+
+This was added in [pull request #1946: Support multiple directions in Sass spacing mixins](https://github.com/nhsuk/nhsuk-frontend/pull/1946).
+
 ### :wrench: **Fixes**
 
 - [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -70,8 +70,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
   }
 
   .nhsuk-card .nhsuk-image__caption {
-    @include nhsuk-responsive-padding(5, "left");
-    @include nhsuk-responsive-padding(5, "right");
+    @include nhsuk-responsive-padding(5, ("left", "right"));
   }
 
   .nhsuk-card__heading {
@@ -532,7 +531,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
   .nhsuk-card--primary > .nhsuk-card__content,
   // Deprecated, to be removed in v11.0
   .nhsuk-card__content--primary {
-    @include nhsuk-responsive-padding(5, "right", $adjustment: nhsuk-spacing(7), $unit: "rem");
+    @include nhsuk-responsive-padding(5, "right", $adjustment: $nhsuk-icon-size-large + nhsuk-spacing(3), $unit: "rem");
 
     @include nhsuk-media-query($from: desktop) {
       height: 100%;

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -212,18 +212,12 @@ $expander-icon-size: $nhsuk-expander-icon-size;
 
     .nhsuk-details__summary {
       display: block;
-
       width: auto;
-      padding: nhsuk-spacing(4);
-
       border: $nhsuk-expander-border-width solid $nhsuk-expander-border-colour;
       border-bottom: $nhsuk-expander-border-bottom-width solid $nhsuk-expander-border-colour;
-
       background-color: $nhsuk-card-background-colour;
 
-      @include nhsuk-media-query($from: tablet) {
-        padding: nhsuk-spacing(5);
-      }
+      @include nhsuk-responsive-padding(5);
     }
 
     .nhsuk-details__summary:hover,
@@ -240,13 +234,11 @@ $expander-icon-size: $nhsuk-expander-icon-size;
     .nhsuk-details__text {
       margin-top: 0;
       margin-left: 0;
+      padding-top: 0;
       border: $nhsuk-expander-border-width solid $nhsuk-expander-border-colour;
       border-top: 0;
 
-      @include nhsuk-responsive-padding(5, "bottom");
-      @include nhsuk-responsive-padding(5, "left");
-      @include nhsuk-responsive-padding(5, "right");
-      @include nhsuk-responsive-padding(0, "top");
+      @include nhsuk-responsive-padding(5, ("bottom", "left", "right"));
     }
 
     // Hack to support Internet Explorer 11
@@ -267,13 +259,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       border-bottom-width: $nhsuk-expander-border-bottom-width;
 
       .nhsuk-details__summary {
-        padding-bottom: nhsuk-spacing(4);
-      }
-
-      @include nhsuk-media-query($from: tablet) {
-        .nhsuk-details__summary {
-          padding-bottom: nhsuk-spacing(5);
-        }
+        @include nhsuk-responsive-padding(5, "bottom");
       }
 
       .nhsuk-details__summary::before,

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/_index.scss
@@ -14,8 +14,8 @@
 
     @include nhsuk-text-colour;
     @include nhsuk-font($size: 19);
-    @include nhsuk-responsive-padding(4);
     @include nhsuk-responsive-margin(8, "bottom");
+    @include nhsuk-responsive-padding(4);
 
     &:focus {
       border: $nhsuk-focus-width solid $nhsuk-focus-text-colour;

--- a/packages/nhsuk-frontend/src/nhsuk/components/footer/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/footer/_index.scss
@@ -18,8 +18,7 @@ $nhsuk-footer-border-colour: nhsuk-colour("grey-3");
     background-color: $nhsuk-template-background-colour;
 
     @include nhsuk-print-hide;
-    @include nhsuk-responsive-padding(5, bottom);
-    @include nhsuk-responsive-padding(5, top);
+    @include nhsuk-responsive-padding(5, ("top", "bottom"));
   }
 
   .nhsuk-footer__heading {

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
@@ -33,8 +33,7 @@
   }
 
   .nhsuk-hero__wrapper {
-    @include nhsuk-responsive-padding(8, top);
-    @include nhsuk-responsive-padding(8, bottom);
+    @include nhsuk-responsive-padding(8, ("top", "bottom"));
   }
 
   .nhsuk-hero__heading {

--- a/packages/nhsuk-frontend/src/nhsuk/components/images/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/images/_index.scss
@@ -22,8 +22,7 @@
     border-bottom: 1px solid $nhsuk-border-colour;
     background-color: $nhsuk-card-background-colour;
 
-    @include nhsuk-responsive-margin(6, "bottom");
-    @include nhsuk-responsive-margin(6, "top");
+    @include nhsuk-responsive-margin(6, ("top", "bottom"));
 
     @include nhsuk-media-query($from: desktop) {
       width: math.percentage(math.div(2, 3)); // [2]

--- a/packages/nhsuk-frontend/src/nhsuk/components/inset-text/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/inset-text/_index.scss
@@ -21,8 +21,7 @@
     @include nhsuk-reading-width; // [2]
     @include nhsuk-top-and-bottom; // [1]
 
-    @include nhsuk-responsive-margin(7, "bottom");
-    @include nhsuk-responsive-margin(7, "top");
+    @include nhsuk-responsive-margin(7, ("top", "bottom"));
     @include nhsuk-responsive-padding(4);
 
     @include nhsuk-media-query($media-type: print) {

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/_index.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "../../core/settings" as *;
 @use "../../core/tools" as *;
 @use "../../core/helpers" as *;
@@ -22,16 +23,15 @@
   }
 
   .nhsuk-notification-banner__header {
-    padding: 2px nhsuk-spacing(3) nhsuk-spacing(1);
+    padding-top: 2px;
+    padding-bottom: nhsuk-spacing(1);
 
     // Ensures the notification header appears separate to the notification body
     // text in high contrast mode
     border-bottom: 1px solid transparent;
     background-color: $nhsuk-brand-colour;
 
-    @include nhsuk-media-query($from: tablet) {
-      padding: 2px nhsuk-spacing(4) nhsuk-spacing(1);
-    }
+    @include nhsuk-responsive-padding(4, ("left", "right"));
   }
 
   .nhsuk-notification-banner__title {
@@ -45,13 +45,8 @@
   }
 
   .nhsuk-notification-banner__content {
-    $padding-tablet: nhsuk-spacing(4);
-    padding: nhsuk-spacing(3);
-
     @include nhsuk-text-colour;
-    @include nhsuk-media-query($from: tablet) {
-      padding: $padding-tablet;
-    }
+    @include nhsuk-responsive-padding(4);
 
     // Wrap content at the same place that a 2/3 grid column ends, to maintain
     // shorter line-lengths when the notification banner is full width
@@ -61,11 +56,10 @@
       box-sizing: border-box;
 
       // Calculate the internal width of a two-thirds column...
-      $two-col-width: calc($nhsuk-page-width * 2 / 3) - calc($nhsuk-gutter * 1 / 3);
+      $two-col-width: math.div($nhsuk-page-width * 2, 3) - math.div($nhsuk-gutter, 3);
 
       // ...and then factor in the left border and padding
-      $banner-exterior: ($padding-tablet + $nhsuk-border-width);
-      max-width: $two-col-width - $banner-exterior;
+      @include nhsuk-responsive-spacing(-5, "max-width", $adjustment: $two-col-width - ($nhsuk-border-width * 2));
     }
 
     > :last-child {

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/_index.scss
@@ -21,8 +21,7 @@
 
   .nhsuk-pagination {
     box-sizing: border-box;
-    @include nhsuk-responsive-margin(7, "top");
-    @include nhsuk-responsive-margin(7, "bottom");
+    @include nhsuk-responsive-margin(7, ("top", "bottom"));
   }
 
   .nhsuk-pagination__list {

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
@@ -62,13 +62,15 @@
         margin-right: nhsuk-spacing(1);
         margin-bottom: 0;
         margin-left: 0;
-        padding: nhsuk-spacing(2) nhsuk-spacing(4);
 
         float: left;
 
         background-color: nhsuk-colour("grey-4");
 
         text-align: center;
+
+        @include nhsuk-responsive-padding(2, ("top", "bottom"));
+        @include nhsuk-responsive-padding(4, ("left", "right"));
 
         &::before {
           content: none;
@@ -84,15 +86,15 @@
 
         // Compensation for border (otherwise we get a shift)
         margin-bottom: -$border-width;
-        padding-top: (nhsuk-spacing(2) * 1.5) - $border-width;
-        padding-right: nhsuk-spacing(4) - $border-width;
-        padding-bottom: (nhsuk-spacing(2) * 1.5) + $border-width;
-        padding-left: nhsuk-spacing(4) - $border-width;
 
         border: $border-width solid $nhsuk-border-colour;
         border-bottom: 0;
 
         background-color: $nhsuk-card-background-colour;
+
+        @include nhsuk-responsive-padding(2, "top", $adjustment: nhsuk-spacing(1) - $border-width);
+        @include nhsuk-responsive-padding(2, "bottom", $adjustment: nhsuk-spacing(1) + $border-width);
+        @include nhsuk-responsive-padding(4, ("left", "right"), $adjustment: - $border-width);
 
         .nhsuk-tabs__tab {
           text-decoration: none;
@@ -116,15 +118,13 @@
       }
 
       .nhsuk-tabs__panel {
+        margin-bottom: 0;
         padding: nhsuk-spacing(6) nhsuk-spacing(4);
         border: 1px solid $nhsuk-border-colour;
         border-top: 0;
         background-color: $nhsuk-card-background-colour;
-        @include nhsuk-responsive-margin(0, "bottom");
 
-        & > :last-child {
-          margin-bottom: 0;
-        }
+        @include nhsuk-top-and-bottom;
       }
 
       .nhsuk-tabs__panel--hidden {

--- a/packages/nhsuk-frontend/src/nhsuk/core/elements/_table.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/elements/_table.scss
@@ -43,9 +43,8 @@ td {
   vertical-align: top;
 
   @include nhsuk-font-size(19);
-  @include nhsuk-responsive-padding(3, "bottom");
+  @include nhsuk-responsive-padding(3, ("top", "bottom"));
   @include nhsuk-responsive-padding(4, "right");
-  @include nhsuk-responsive-padding(3, "top");
 
   &:last-child {
     padding-right: 0;

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/spacing.unit.test.mjs
@@ -336,6 +336,46 @@ describe('Spacing settings', () => {
       })
     })
 
+    it('outputs CSS for a property and multiple directions based on a responsive spacing point', async () => {
+      const sass = outdent`
+        ${sassBootstrap}
+
+        .foo {
+          @include nhsuk-responsive-spacing($app-spacing-point, 'margin', ('top', 'bottom'));
+          @include nhsuk-responsive-spacing($app-spacing-point, 'padding', ('left', 'right'), $unit: "rem");
+        }
+      `
+
+      const results = compileStringAsync(sass, {
+        loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: outdent`
+          .foo {
+            margin-top: 15px;
+            margin-bottom: 15px;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              margin-top: 25px;
+              margin-bottom: 25px;
+            }
+          }
+          .foo {
+            padding-left: 0.9375rem;
+            padding-right: 0.9375rem;
+          }
+          @media (min-width: 30em) {
+            .foo {
+              padding-left: 1.5625rem;
+              padding-right: 1.5625rem;
+            }
+          }
+        `
+      })
+    })
+
     it('throws an exception when passed a non-existent responsive spacing point', async () => {
       const sass = outdent`
         ${sassBootstrap}
@@ -511,6 +551,40 @@ describe('Spacing settings', () => {
             @media (min-width: 30em) {
               .foo {
                 margin-top: 27px;
+              }
+            }
+          `
+        })
+      })
+
+      it('adjusts the value for the property and multiple directions', async () => {
+        const sass = outdent`
+          ${sassBootstrap}
+
+          .foo {
+            @include nhsuk-responsive-spacing(
+              $app-spacing-point,
+              'margin',
+              ('top', 'bottom'),
+              $adjustment: 2px
+            )
+          }
+        `
+
+        const results = compileStringAsync(sass, {
+          loadPaths: ['packages/nhsuk-frontend/src/nhsuk']
+        })
+
+        await expect(results).resolves.toMatchObject({
+          css: outdent`
+            .foo {
+              margin-top: 17px;
+              margin-bottom: 17px;
+            }
+            @media (min-width: 30em) {
+              .foo {
+                margin-top: 27px;
+                margin-bottom: 27px;
               }
             }
           `

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_section-break.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_section-break.scss
@@ -29,8 +29,7 @@
 }
 
 %nhsuk-section-break--xl {
-  @include nhsuk-responsive-margin(8, "top");
-  @include nhsuk-responsive-margin(8, "bottom");
+  @include nhsuk-responsive-margin(8, ("top", "bottom"));
 }
 
 .nhsuk-section-break--xl {
@@ -38,8 +37,7 @@
 }
 
 %nhsuk-section-break--l {
-  @include nhsuk-responsive-margin(6, "top");
-  @include nhsuk-responsive-margin(6, "bottom");
+  @include nhsuk-responsive-margin(6, ("top", "bottom"));
 }
 
 .nhsuk-section-break--l {
@@ -47,8 +45,7 @@
 }
 
 %nhsuk-section-break--m {
-  @include nhsuk-responsive-margin(4, "top");
-  @include nhsuk-responsive-margin(4, "bottom");
+  @include nhsuk-responsive-margin(4, ("top", "bottom"));
 }
 
 .nhsuk-section-break--m {

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
@@ -310,7 +310,7 @@
 
   @include nhsuk-panel($panel-background-colour, $panel-text-colour, $panel-border-colour);
   @include nhsuk-responsive-margin(7, "top");
-  @include nhsuk-responsive-padding(5);
+  @include nhsuk-responsive-padding(5, ("bottom", "left", "right"));
 }
 
 /// Panel with label mixin, inherits panel styling
@@ -349,8 +349,7 @@
 
   margin: 0;
   margin-bottom: nhsuk-spacing(2);
-  margin-left: nhsuk-spacing(-4) - 1px; // [5]
-  padding: nhsuk-spacing(2) nhsuk-spacing(4);
+  padding: nhsuk-spacing(2);
 
   outline: 1px solid transparent; // [2]
   outline-offset: -1px;
@@ -365,10 +364,11 @@
     background: none;
   }
 
+  @include nhsuk-responsive-margin(-5, "left", $adjustment: -1px); // [5]
+  @include nhsuk-responsive-padding(5, ("left", "right"));
+
   @include nhsuk-media-query($from: tablet) {
     top: nhsuk-spacing(-3); // [6]
-    margin-left: nhsuk-spacing(-5) - 1px; // [5]
-    padding: nhsuk-spacing(2) nhsuk-spacing(5);
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
@@ -345,12 +345,12 @@
   display: inline-block; // [4]
 
   position: relative;
-  top: nhsuk-spacing(-3); // [6]
+  top: nhsuk-spacing(-2); // [6]
 
   margin: 0;
   margin-bottom: nhsuk-spacing(2);
-  margin-left: nhsuk-spacing(-5) - 1px; // [5]
-  padding: nhsuk-spacing(2) nhsuk-spacing(5);
+  margin-left: nhsuk-spacing(-4) - 1px; // [5]
+  padding: nhsuk-spacing(2) nhsuk-spacing(4);
 
   outline: 1px solid transparent; // [2]
   outline-offset: -1px;
@@ -360,15 +360,15 @@
 
   @include nhsuk-font-size(26);
 
-  @include nhsuk-media-query($until: tablet) {
-    top: nhsuk-spacing(-2); // [6]
-    margin-left: nhsuk-spacing(-4) - 1px; // [5]
-    padding: nhsuk-spacing(2) nhsuk-spacing(4);
-  }
-
   @include nhsuk-print-colour {
     top: 0;
     background: none;
+  }
+
+  @include nhsuk-media-query($from: tablet) {
+    top: nhsuk-spacing(-3); // [6]
+    margin-left: nhsuk-spacing(-5) - 1px; // [5]
+    padding: nhsuk-spacing(2) nhsuk-spacing(5);
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_spacing.scss
@@ -100,7 +100,7 @@
 /// @param {Number} $responsive-spacing-point - Point on the responsive spacing
 ///  scale, corresponds to a map of breakpoints and spacing values
 /// @param {String} $property - Property to add spacing to (e.g. 'margin')
-/// @param {String} $direction [all] - Direction to add spacing to
+/// @param {String | List} $direction [all] - Direction to add spacing to
 ///  (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
@@ -140,6 +140,17 @@
     $responsive-spacing-point: math.abs($responsive-spacing-point);
   }
 
+  @if not list.index(("string", "list"), meta.type-of($direction)) {
+    @error "Expected a string or list, but got a " + "#{meta.type-of($direction)}.";
+  }
+
+  $directions: ();
+  @if meta.type-of($direction) == "list" {
+    $directions: list.join($directions, $direction);
+  } @else {
+    $directions: ($direction);
+  }
+
   @if not map.has-key($nhsuk-spacing-responsive-scale, $responsive-spacing-point) {
     @error "Unknown responsive spacing point `#{$responsive-spacing-point}`. Make sure you are using a point from the "
       + "responsive spacing scale in `_settings/spacing.scss`.";
@@ -176,17 +187,21 @@
     & {
       // [3]
       @if not $breakpoint {
-        @if $direction == all {
-          #{$property}: $breakpoint-value;
-        } @else {
-          #{$property}-#{$direction}: $breakpoint-value;
-        }
-      } @else {
-        @include nhsuk-media-query($from: $breakpoint) {
+        @each $direction in $directions {
           @if $direction == all {
             #{$property}: $breakpoint-value;
           } @else {
             #{$property}-#{$direction}: $breakpoint-value;
+          }
+        }
+      } @else {
+        @include nhsuk-media-query($from: $breakpoint) {
+          @each $direction in $directions {
+            @if $direction == all {
+              #{$property}: $breakpoint-value;
+            } @else {
+              #{$property}-#{$direction}: $breakpoint-value;
+            }
           }
         }
       }
@@ -202,7 +217,7 @@
 ///
 /// @param {Number} $responsive-spacing-point - Point on the responsive spacing
 /// scale, corresponds to a map of breakpoints and spacing values
-/// @param {String} $direction [all] - Direction to add spacing to
+/// @param {String | List} $direction [all] - Direction(s) to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by
@@ -233,7 +248,7 @@
 ///
 /// @param {Number} $responsive-spacing-point - Point on the responsive spacing
 ///   scale, corresponds to a map of breakpoints and spacing values
-/// @param {String} $direction [all] - Direction to add spacing to
+/// @param {String | List} $direction [all] - Direction(s) to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [null] - Offset to adjust spacing by


### PR DESCRIPTION
## Description

This PR adds multiple-direction support to `nhsuk-responsive-margin()` and `nhsuk-responsive-padding()` mixins:

```patch
- @include nhsuk-responsive-padding(5, "left");
- @include nhsuk-responsive-padding(5, "right");
+ @include nhsuk-responsive-padding(5, ("left", "right"));
```

Mixin includes for multiple separate directions have been consolidated.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
