### PR TITLE
[v10] Move details component link appearance to summary text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK frontend Changelog
 
-## Unreleased
+## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note: This release was created from the `support/10.x` branch.
 
 ### :wrench: **Fixes**
 
+- [#1964: Move details component link appearance to summary text](https://github.com/nhsuk/nhsuk-frontend/pull/1964)
 - [#1965: Make sure icons always use current text colour etc](https://github.com/nhsuk/nhsuk-frontend/pull/1965)
 
 ## 10.5.1 - 3 June 2026

--- a/package-lock.json
+++ b/package-lock.json
@@ -24371,7 +24371,7 @@
       }
     },
     "packages/nhsuk-frontend": {
-      "version": "10.5.1",
+      "version": "10.5.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",

--- a/packages/nhsuk-frontend/package.json
+++ b/packages/nhsuk-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-frontend",
-  "version": "10.5.1",
+  "version": "10.5.2",
   "description": "NHS.UK frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "homepage": "https://nhsuk.github.io/nhsuk-frontend/",
   "bugs": {

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -85,15 +85,10 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       position: relative; // [2]
       width: fit-content; // [1]
       padding-left: nhsuk-px-to-rem(nhsuk-spacing(4));
+      text-decoration: none;
       cursor: pointer;
-      @include nhsuk-link-style-default;
 
-      &:hover,
-      &:focus {
-        .nhsuk-details__summary-text {
-          text-decoration: none;
-        }
-      }
+      @include nhsuk-link-style-focus;
 
       &::-webkit-details-marker {
         display: none; // [4]
@@ -115,16 +110,53 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       .nhsuk-details[open] > &::before {
         @include nhsuk-shape-arrow($direction: down, $base: 14px);
       }
+    }
 
-      .nhsuk-details--reverse &:not(:focus),
-      .nhsuk-details--reverse &:not(:focus):hover {
-        color: $nhsuk-reverse-text-colour;
-      }
+    // Style the arrow and summary text to look like a link...
+    .nhsuk-details__summary::before,
+    .nhsuk-details__summary-text {
+      color: $nhsuk-link-colour;
     }
 
     // ...but only underline the text, not the arrow
     .nhsuk-details__summary-text {
       text-decoration: underline; // [3]
+    }
+
+    .nhsuk-details__summary:hover,
+    .nhsuk-details__summary:focus {
+      & .nhsuk-details__summary-text {
+        text-decoration: none;
+      }
+    }
+
+    .nhsuk-details__summary:hover {
+      &::before,
+      & .nhsuk-details__summary-text {
+        color: $nhsuk-link-hover-colour;
+      }
+    }
+
+    .nhsuk-details__summary:active {
+      &::before,
+      & .nhsuk-details__summary-text {
+        color: $nhsuk-link-active-colour;
+      }
+    }
+
+    .nhsuk-details__summary:focus {
+      &::before,
+      & .nhsuk-details__summary-text {
+        color: $nhsuk-focus-text-colour;
+      }
+    }
+
+    .nhsuk-details--reverse .nhsuk-details__summary:not(:focus),
+    .nhsuk-details--reverse .nhsuk-details__summary:not(:focus):hover {
+      &::before,
+      & .nhsuk-details__summary-text {
+        color: $nhsuk-reverse-text-colour;
+      }
     }
 
     .nhsuk-details__text {
@@ -136,6 +168,32 @@ $expander-icon-size: $nhsuk-expander-icon-size;
 
       .nhsuk-details--reverse & {
         border-left-color: $nhsuk-reverse-border-colour;
+      }
+    }
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      .nhsuk-details__summary,
+      .nhsuk-details__summary:hover {
+        &::before,
+        & .nhsuk-details__summary-text {
+          color: LinkText;
+        }
+      }
+
+      .nhsuk-details__summary:active {
+        &::before,
+        & .nhsuk-details__summary-text {
+          color: ActiveText;
+        }
+      }
+
+      .nhsuk-details__summary:focus,
+      .nhsuk-details--reverse .nhsuk-details__summary:not(:focus),
+      .nhsuk-details--reverse .nhsuk-details__summary:not(:focus):hover {
+        &::before,
+        & .nhsuk-details__summary-text {
+          color: LinkText;
+        }
       }
     }
   }
@@ -225,19 +283,10 @@ $expander-icon-size: $nhsuk-expander-icon-size;
 
       .nhsuk-details__summary-text {
         display: inline-block;
-
         position: relative;
-
         padding: nhsuk-spacing(1);
         padding-left: $nhsuk-expander-icon-size + nhsuk-spacing(2);
-
-        color: $nhsuk-link-colour;
-
         cursor: pointer;
-      }
-
-      .nhsuk-details__summary:hover .nhsuk-details__summary-text {
-        color: $nhsuk-link-hover-colour;
       }
 
       .nhsuk-details__summary:focus .nhsuk-details__summary-text {
@@ -260,7 +309,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
           "M13.5 1a12.5 12.5 0 1 1 0 25 12.5 12.5 0 0 1 0-25Zm0 6c-.8 0-1.5.7-1.5 1.5V12H8.5c-.8 0-1.4.6-1.5 1.4v.1c0 .8.7 1.5 1.5 1.5H12v3.5c0 .8.6 1.4 1.4 1.5h.1c.8 0 1.5-.7 1.5-1.5V15h3.5c.8 0 1.4-.6 1.5-1.4v-.1c0-.8-.7-1.5-1.5-1.5H15V8.5c0-.8-.6-1.4-1.4-1.5Z"
         ); // Plus icon
 
-        background-color: currentcolor;
+        background-color: ButtonText;
       }
 
       &[open] {
@@ -282,8 +331,10 @@ $expander-icon-size: $nhsuk-expander-icon-size;
 
         .nhsuk-details__summary-text::before {
           top: calc(50% - nhsuk-px-to-rem(math.div($nhsuk-expander-icon-size, 2)));
+
           width: nhsuk-px-to-rem($nhsuk-expander-icon-size);
           height: nhsuk-px-to-rem($nhsuk-expander-icon-size);
+
           clip-path: shape(
             from 50% 3.7%,
             arc by 0% 92.6% of 46.3% 46.3% large cw,
@@ -311,6 +362,10 @@ $expander-icon-size: $nhsuk-expander-icon-size;
             curve by -5.19% -5.56% with 0% -2.96% / -2.22% -5.19%,
             close
           ); // Plus icon, scalable
+
+          background-color: currentcolor;
+
+          forced-color-adjust: none;
         }
 
         &[open] .nhsuk-details__summary-text::before {
@@ -330,20 +385,8 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       }
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        .nhsuk-details__summary-text::before {
+        .nhsuk-details__summary:not(:focus):not(:hover):not(:active) .nhsuk-details__summary-text::before {
           background-color: ButtonText;
-        }
-
-        .nhsuk-details__summary:hover .nhsuk-details__summary-text::before {
-          background-color: LinkText;
-        }
-
-        .nhsuk-details__summary:active .nhsuk-details__summary-text::before {
-          background-color: ActiveText;
-        }
-
-        .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
-          background-color: LinkText;
         }
       }
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -89,6 +89,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       cursor: pointer;
 
       @include nhsuk-link-style-focus;
+      @include nhsuk-top-and-bottom;
 
       &::-webkit-details-marker {
         display: none; // [4]
@@ -121,6 +122,11 @@ $expander-icon-size: $nhsuk-expander-icon-size;
     // ...but only underline the text, not the arrow
     .nhsuk-details__summary-text {
       text-decoration: underline; // [3]
+      @include nhsuk-responsive-margin(3, "bottom");
+    }
+
+    .nhsuk-details__summary-text:only-child {
+      margin-bottom: 0;
     }
 
     .nhsuk-details__summary:hover,


### PR DESCRIPTION
## Description

This PR moves the link appearance for the details component to the summary text element

This fixes an issue for service teams that extend summary content to include additional children

## Before

Lifted from GOV.UK Frontend, we add our link styles to `.nhsuk-details__summary`

<img width="785" height="365" alt="Expander with extra summary content before" src="https://github.com/user-attachments/assets/53e72634-3ffb-441e-af47-0a484a922917" />

## After

Moving our link styles to only the arrow and `.nhsuk-details__summary-text`

<img width="785" height="360" alt="Expander with extra summary content after" src="https://github.com/user-attachments/assets/50b49dfa-7e63-4ab7-9b0b-2fbb18b7cace" />

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
