### PR TITLE
[v10] Make sure icons always use current text colour etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+Note: This release was created from the `support/10.x` branch.
+
+### :wrench: **Fixes**
+
+- [#1965: Make sure icons always use current text colour etc](https://github.com/nhsuk/nhsuk-frontend/pull/1965)
+
 ## 10.5.1 - 3 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
@@ -76,7 +76,7 @@
       fill: nhsuk-colour("green");
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: buttontext;
+        fill: ButtonText;
       }
     }
   }
@@ -90,7 +90,7 @@
       fill: $nhsuk-reverse-text-colour;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: buttontext;
+        fill: ButtonText;
       }
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
@@ -157,6 +157,13 @@ $button-shadow-size: $nhsuk-button-shadow-size;
       &::before {
         border-color: buttonborder;
       }
+
+      &:not(:focus):not(:active):hover,
+      &:not(:focus):not(:active):hover::before,
+      &:not(:focus):not(:active):hover::after {
+        border-color: Highlight;
+        color: Highlight;
+      }
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/_index.scss
@@ -151,11 +151,11 @@ $button-shadow-size: $nhsuk-button-shadow-size;
 
     // Override high-contrast link colours to match buttons
     @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      color: buttontext;
+      color: ButtonText;
 
       &,
       &::before {
-        border-color: buttonborder;
+        border-color: ButtonBorder;
       }
 
       &:not(:focus):not(:active):hover,

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/_index.scss
@@ -238,7 +238,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
       fill: $nhsuk-link-hover-colour;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: linktext;
+        fill: LinkText;
       }
     }
 
@@ -255,7 +255,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
       fill: $nhsuk-link-active-colour;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: activetext;
+        fill: ActiveText;
       }
     }
   }
@@ -563,7 +563,7 @@ $card-border-hover-colour: $nhsuk-card-border-hover-colour;
       @include nhsuk-responsive-spacing(5, "right");
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        fill: buttontext;
+        fill: ButtonText;
       }
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -327,6 +327,24 @@ $expander-icon-size: $nhsuk-expander-icon-size;
           ); // Minus icon, scalable
         }
       }
+
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        .nhsuk-details__summary-text::before {
+          background-color: ButtonText;
+        }
+
+        .nhsuk-details__summary:hover .nhsuk-details__summary-text::before {
+          background-color: LinkText;
+        }
+
+        .nhsuk-details__summary:active .nhsuk-details__summary-text::before {
+          background-color: ActiveText;
+        }
+
+        .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
+          background-color: LinkText;
+        }
+      }
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -219,6 +219,7 @@ $expander-icon-size: $nhsuk-expander-icon-size;
       }
 
       .nhsuk-details__summary:focus {
+        outline: none;
         box-shadow: none;
       }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/_index.scss
@@ -96,9 +96,20 @@
 
     text-align: left;
 
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: HighlightText;
+      background-color: Highlight;
+      forced-color-adjust: none;
+    }
+
     .nhsuk-file-upload__drop-button--empty & {
       color: $nhsuk-text-colour;
       background-color: color.scale(nhsuk-colour("grey-4"), $alpha: -50%);
+
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        color: CanvasText;
+        background-color: HighlightText;
+      }
     }
   }
 
@@ -122,6 +133,11 @@
     background-color: nhsuk-colour("white");
 
     cursor: pointer;
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: CanvasText;
+      background-color: Canvas;
+    }
 
     @include nhsuk-media-query($from: tablet) {
       padding: (nhsuk-spacing(4) + $nhsuk-border-width - $nhsuk-border-width-form-element);
@@ -233,6 +249,27 @@
       .nhsuk-button--secondary,
       .nhsuk-button--secondary-solid {
         background-color: $nhsuk-secondary-button-active-colour;
+      }
+    }
+  }
+
+  .nhsuk-file-upload__drop-button:not(:disabled),
+  .nhsuk-file-upload__drop-button--empty:not(:disabled) {
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      &:hover,
+      &:active {
+        color: CanvasText;
+        background-color: Canvas;
+
+        .nhsuk-button {
+          color: Highlight;
+          background-color: ButtonFace;
+
+          &,
+          &::before {
+            border-color: Highlight;
+          }
+        }
       }
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
@@ -118,7 +118,7 @@
       // mode so force the background color to match the system link color
       // (matching the text in the link)
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        background: buttontext;
+        background: ButtonText;
       }
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/core/elements/_links.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/elements/_links.scss
@@ -17,44 +17,10 @@
 a {
   @include nhsuk-link-style-default;
 
-  &:visited .nhsuk-icon {
-    fill: $nhsuk-link-visited-colour;
-  }
-
-  &:hover .nhsuk-icon {
-    fill: $nhsuk-link-hover-colour;
-  }
-
-  &:active .nhsuk-icon {
-    fill: $nhsuk-link-active-colour;
-  }
-
-  &:focus .nhsuk-icon {
-    fill: $nhsuk-focus-text-colour;
-  }
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    &:visited .nhsuk-icon {
-      fill: visitedtext;
-    }
-
-    &:hover .nhsuk-icon {
-      fill: linktext;
-    }
-
-    &:active .nhsuk-icon {
-      fill: activetext;
-    }
-
-    &:focus .nhsuk-icon {
-      fill: linktext;
-    }
-  }
-
   @include nhsuk-media-query($media-type: print) {
     &::after {
       content: " (Link: " attr(href) ")"; // [1]
-      color: $nhsuk-text-colour;
+      color: currentcolor;
       font-size: inherit; // [2]
     }
   }
@@ -100,10 +66,8 @@ button.nhsuk-link {
 .nhsuk-link--reverse {
   @include nhsuk-link-style-reverse;
 
-  @include nhsuk-media-query($media-type: print) {
-    &::after {
-      color: currentcolor;
-    }
+  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+    color: LinkText;
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_icons.scss
@@ -12,10 +12,17 @@
 
 .nhsuk-icon {
   display: inline-block;
+
   width: nhsuk-px-to-rem($nhsuk-icon-size);
   height: nhsuk-px-to-rem($nhsuk-icon-size);
+
   fill: currentcolor;
+
   vertical-align: middle;
+
+  // Work around SVGs not inheriting color from parent in forced color mode
+  // (https://github.com/w3c/csswg-drafts/issues/6310)
+  forced-color-adjust: auto;
 
   @include nhsuk-media-query($from: tablet) {
     width: nhsuk-px-to-rem($nhsuk-icon-size-large);

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
@@ -89,7 +89,7 @@
       border-color: $button-border-colour;
 
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-        border-color: buttonborder;
+        border-color: ButtonBorder;
       }
     }
 
@@ -114,7 +114,7 @@
     &:visited,
     &:hover,
     &:active {
-      color: buttontext;
+      color: ButtonText;
     }
 
     &,

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
@@ -108,19 +108,20 @@
     }
   }
 
-  // Override high-contrast link colours to match buttons
+  // Override high-contrast button colours back to defaults
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
     &,
     &:visited,
+    &:hover,
     &:active {
       color: buttontext;
     }
 
-    &:not(:focus):not(:active):hover,
-    &:not(:focus):not(:active):hover::before,
-    &:not(:focus):not(:active):hover::after {
-      border-color: Highlight;
-      color: Highlight;
+    &,
+    &:hover,
+    &:active,
+    &:active:focus {
+      background-color: ButtonFace;
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_buttons.scss
@@ -38,7 +38,7 @@
     color: $button-text-colour;
   }
 
-  &[href] .nhsuk-icon {
+  &[href]:not(:focus) .nhsuk-icon {
     fill: $button-text-colour;
 
     @media screen and (forced-colors: active), (-ms-high-contrast: active) {

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
@@ -28,7 +28,7 @@
   text-decoration: none;
 
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
+    color: LinkText;
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
@@ -109,16 +109,8 @@
   background-color: $nhsuk-focus-colour;
   box-shadow: 0 $nhsuk-focus-width 0 0 $nhsuk-focus-text-colour;
 
-  .nhsuk-icon {
-    fill: $nhsuk-focus-text-colour;
-  }
-
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: buttontext;
-
-    .nhsuk-icon {
-      fill: buttontext;
-    }
+    color: ButtonText;
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_focused.scss
@@ -109,8 +109,12 @@
   background-color: $nhsuk-focus-colour;
   box-shadow: 0 $nhsuk-focus-width 0 0 $nhsuk-focus-text-colour;
 
+  // When in an explicit forced-color mode, we can use the Highlight system
+  // color for the outline to better match focus states of native controls
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+    outline-color: Highlight;
     color: ButtonText;
+    background-color: ButtonFace;
   }
 }
 
@@ -126,4 +130,10 @@
   box-shadow:
     0 0 0 4px $nhsuk-focus-colour,
     0 0 0 8px $nhsuk-focus-text-colour;
+
+  // When in an explicit forced-color mode, we can use the Highlight system
+  // color for the outline to better match focus states of native controls
+  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+    outline-color: Highlight;
+  }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_links.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_links.scss
@@ -26,6 +26,10 @@
   & {
     color: $link-colour;
     text-decoration: underline;
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: LinkText;
+    }
   }
 
   @include nhsuk-link-style-visited($link-visited-colour);
@@ -46,10 +50,6 @@
 
 @mixin nhsuk-link-style-default {
   @include nhsuk-link-style;
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: LinkText;
-  }
 }
 
 /// Reverse link styles
@@ -288,6 +288,10 @@
   // stylelint-disable-next-line selector-class-pattern
   &:not(:focus):not(.\:focus):hover {
     color: rgba($override-colour, 0.99);
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: LinkText;
+    }
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_links.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_links.scss
@@ -48,7 +48,7 @@
   @include nhsuk-link-style;
 
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
+    color: LinkText;
   }
 }
 
@@ -70,16 +70,8 @@
 @mixin nhsuk-link-style-reverse {
   @include nhsuk-link-style-text($override-colour: $nhsuk-reverse-text-colour);
 
-  &:not(:focus) .nhsuk-icon {
-    fill: $nhsuk-reverse-text-colour;
-  }
-
   @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: linktext;
-
-    &:not(:focus) .nhsuk-icon {
-      fill: currentcolor;
-    }
+    color: LinkText;
   }
 }
 
@@ -107,6 +99,10 @@
 @mixin nhsuk-link-style-visited($link-visited-colour: $nhsuk-link-visited-colour) {
   &:visited {
     color: $link-visited-colour;
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: VisitedText;
+    }
   }
 }
 
@@ -122,6 +118,10 @@
   &:hover {
     color: $link-hover-colour;
     text-decoration: none;
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: LinkText;
+    }
   }
 }
 
@@ -152,6 +152,10 @@
 @mixin nhsuk-link-style-active($link-active-colour: $nhsuk-link-active-colour) {
   &:active {
     color: $link-active-colour;
+
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      color: ActiveText;
+    }
   }
 }
 
@@ -229,10 +233,6 @@
     $link-hover-colour: $nhsuk-link-hover-colour,
     $link-active-colour: $nhsuk-link-active-colour
   );
-
-  &:visited .nhsuk-icon {
-    fill: currentcolor;
-  }
 }
 
 /// Remove underline from links


### PR DESCRIPTION
## Description

This PR fixes the header account icon `:visited` color by preserving `fill: currentcolor`

Originally suggested by @paulrobertlloyd in https://github.com/nhsuk/nhsuk-frontend/pull/1521#discussion_r2276452831

<img width="1025" height="285" alt="Header with account link visited icon colour" src="https://github.com/user-attachments/assets/1bdca55f-9b8a-4463-a5f7-2bc35b13a081" />

<br>
<br>

It also adds a few extra defaults like `background-color: ButtonFace;` in high contrast mode

This is needed by Firefox to prevent a low contrast colour choice for button `:hover` states etc

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry

---

Copied from https://github.com/nhsuk/nhsuk-frontend/pull/1521#discussion_r2276452831 as GitHub comment linking seems broken:

<br>

> Sadly not, think it's lots of things (potentially)
> 
> It was this [specification change](https://github.com/w3c/csswg-drafts/issues/5419) and issues with SVGs in https://github.com/w3c/csswg-drafts/issues/6310 and a comment here:
> 
> * https://github.com/alphagov/govuk-frontend/issues/2272#issuecomment-876577113
> 
> Looks like the `:visited` colour was related but not necessarily fixed
> 
> Could give a couple of solutions a try from this article:
> 
> **CurrentColor SVG in forced colors modes**
> https://melanie-richards.com/blog/currentcolor-svg-hcm/
> 
> 1. `fill: LinkText`
> 2. `forced-color-adjust: preserve-parent-color`
> 
> Otherwise might be best keeping our existing mixin "clobber the icon colour" approach for now, but I'm very aware lots of components aren't supporting forced colours well enough currently