### PR TITLE
Scrollbar container with scrollbars

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
@@ -34,6 +34,19 @@
     }
   }
 
+  .nhsuk-table-container::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  .nhsuk-table-container::-webkit-scrollbar-track {
+    background: nhsuk-colour("grey-5");
+  }
+
+  .nhsuk-table-container::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background: nhsuk-colour("grey-2");
+  }
+
   .nhsuk-table,
   .nhsuk-table-responsive {
     box-sizing: border-box;

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
@@ -9,21 +9,11 @@
 /// @group components/table
 ////
 
-$nhsuk-table-overflow-colour: nhsuk-colour("grey-3");
-
 @include nhsuk-exports("nhsuk/components/table") {
   // Table container is used to ensure the table does not break the container.
   //
-  // 1. Establish an inline-size container so that children can use cqi units
-  //    to size themselves relative to the visible container width rather than
-  //    the (potentially wider) scrolling content.
-  // 2. Visual scroll indicators use background-attachment:
-  //    'local' attachment to scroll with content (hiding shadow at edges),
-  //    'scroll' attachment to stay fixed to container.
-  //    Left/right covers hide shadows when scrolled to start/end.
-  //    Left/right indicator lines show scroll availability.
-  // 3. Indicators don't show in forced-colors mode. Use borders instead
-  // 4. Margin is removed so there isn't double spacing.
+  // 1. Margin is removed so there isn't double spacing.
+  // 2. XS size not added because it matches the table header, so it'd be bad for hierarchy
 
   .nhsuk-table-container {
     box-sizing: border-box;
@@ -31,48 +21,16 @@ $nhsuk-table-overflow-colour: nhsuk-colour("grey-3");
 
     width: 100%;
 
-    container-type: inline-size; // [1]
-
     overflow-x: auto;
 
-    background: // [2]
-      // Left cover — hides left shadow when scrolled to the start
-      linear-gradient(to right, $nhsuk-body-background-colour, transparent) left center / nhsuk-spacing(2) 100% local
-        no-repeat,
-      // Right cover — hides right shadow when scrolled to the end
-      linear-gradient(to left, $nhsuk-body-background-colour, transparent) right center / nhsuk-spacing(2) 100% local
-        no-repeat,
-      // Left scroll indicator line
-      linear-gradient(to bottom, rgba($nhsuk-table-overflow-colour, 0.4), rgba($nhsuk-table-overflow-colour, 0.4)) left
-        center / nhsuk-spacing(1) 100% scroll no-repeat,
-      // Right scroll indicator line
-      linear-gradient(to bottom, rgba($nhsuk-table-overflow-colour, 0.4), rgba($nhsuk-table-overflow-colour, 0.4)) right
-        center / nhsuk-spacing(1) 100% scroll no-repeat;
-
-    &:focus-visible {
-      outline: $nhsuk-focus-width solid $nhsuk-focus-colour;
-      outline-offset: $nhsuk-focus-width;
-      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-text-colour;
-    }
-
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      background: none;
-      border-inline: $nhsuk-border-width-form-element solid $nhsuk-border-colour; // [3]
-      padding-inline: nhsuk-spacing(1);
-    }
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
 
     @include nhsuk-responsive-margin(7, "bottom");
 
     .nhsuk-table,
     .nhsuk-table-responsive {
-      margin: 0; // [4]
-    }
-
-    .nhsuk-table__caption {
-      box-sizing: border-box;
-      position: sticky;
-      left: 0;
-      max-inline-size: 100cqi;
+      margin: 0; // [1]
     }
   }
 
@@ -127,7 +85,6 @@ $nhsuk-table-overflow-colour: nhsuk-colour("grey-3");
   .nhsuk-table__caption--s {
     @include nhsuk-font-size(22);
   }
-  // size '--xs' not added because it matches the table header, so it'd be bad for hierarchy
 
   // Table panel with tab heading
   //

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/fixtures.mjs
@@ -149,6 +149,7 @@ const fixtures = {
       caption: 'Prescription prepayment certificate (PPC) charges',
       captionSize: 'm',
       firstCellIsHeader: true,
+      scrollable: true,
       head: [
         {
           text: 'Item'
@@ -1308,6 +1309,14 @@ const fixtures = {
           text: 'Nation'
         },
         {
+          text: '2017 to 2018',
+          format: 'numeric'
+        },
+        {
+          text: '2018 to 2019',
+          format: 'numeric'
+        },
+        {
           text: '2019 to 2020',
           format: 'numeric'
         },
@@ -1340,6 +1349,14 @@ const fixtures = {
         [
           {
             text: 'England'
+          },
+          {
+            text: '91.2%',
+            format: 'numeric'
+          },
+          {
+            text: '91.2%',
+            format: 'numeric'
           },
           {
             text: '91.5%',
@@ -1375,6 +1392,14 @@ const fixtures = {
             text: 'Northern Ireland'
           },
           {
+            text: '95.4%',
+            format: 'numeric'
+          },
+          {
+            text: '95.8%',
+            format: 'numeric'
+          },
+          {
             text: '95.1%',
             format: 'numeric'
           },
@@ -1408,6 +1433,14 @@ const fixtures = {
             text: 'Scotland'
           },
           {
+            text: '96.4%',
+            format: 'numeric'
+          },
+          {
+            text: '96.1%',
+            format: 'numeric'
+          },
+          {
             text: '96.2%',
             format: 'numeric'
           },
@@ -1439,6 +1472,14 @@ const fixtures = {
         [
           {
             text: 'Wales'
+          },
+          {
+            text: '95.0%',
+            format: 'numeric'
+          },
+          {
+            text: '94.9%',
+            format: 'numeric'
           },
           {
             text: '94.8%',


### PR DESCRIPTION
An alternative to #1969 - this one uses scrollbars instead of a shadow to indicate scrolling being available.

Could do both though?

<img width="731" height="599" alt="Screenshot 2026-06-16 at 12 31 17" src="https://github.com/user-attachments/assets/5009db05-0538-43ba-bb47-2b1dbd3f5829" />