### PR TITLE
[v10] Add Sass mixins and utility classes for NHS.UK frontend browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+Note: This release was created from the `support/10.x` branch.
+
+### :new: **New features**
+
+#### Show or hide content in supported browsers
+
+You can now show or hide content depending on whether NHS.UK frontend JavaScript is supported:
+
+- Add the `nhsuk-u-frontend-not-supported-hidden` class to hide content in older browsers
+- Add the `nhsuk-u-frontend-supported-hidden` class to hide content in modern browsers
+
+For example, we use this to hide conditionally revealed content for checkboxes and radios. Where our JavaScript is not supported, the revealed content is still shown.
+
+If you use Sass you can also include mixins for custom components:
+
+```scss
+.app-component {
+  @include nhsuk-frontend-supported {
+    background-color: nhsuk-colour("green");
+  }
+
+  @include nhsuk-frontend-not-supported {
+    background-color: nhsuk-colour("red");
+  }
+}
+```
+
+Read more about [how we provide support for different browsers](/docs/contributing/browser-support.md).
+
+This was added in [pull request #1972: Add Sass mixins and utility classes for NHS.UK frontend browser support](https://github.com/nhsuk/nhsuk-frontend/pull/1972).
+
 ## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/_index.scss
@@ -36,7 +36,6 @@
 
     // Hide when no textarea description is provided, during initialisation,
     // or when optionally hidden until the configured threshold is reached
-    &[hidden],
     .nhsuk-frontend-supported & {
       display: none;
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/_index.scss
@@ -36,13 +36,15 @@
 
     // Hide when no textarea description is provided, during initialisation,
     // or when optionally hidden until the configured threshold is reached
-    .nhsuk-frontend-supported & {
+    @include nhsuk-frontend-supported {
       display: none;
     }
 
     // Show when initialisation is complete (unless already hidden)
-    .nhsuk-frontend-supported [data-nhsuk-character-count-init] &:not([hidden]) {
-      display: block;
+    [data-nhsuk-character-count-init] &:not([hidden]) {
+      @include nhsuk-frontend-supported {
+        display: block;
+      }
     }
   }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -215,8 +215,10 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
     margin-left: $conditional-margin-left;
     padding-left: $conditional-padding-left;
     border-left: nhsuk-px-to-rem($nhsuk-border-width) solid nhsuk-colour("grey-3");
+  }
 
-    .nhsuk-frontend-supported &--hidden {
+  .nhsuk-checkboxes__conditional--hidden {
+    @include nhsuk-frontend-supported {
       display: none;
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
@@ -109,11 +109,6 @@
     min-width: nhsuk-px-to-rem(125px);
     margin-bottom: $nhsuk-button-shadow-size;
 
-    // Hide the button by default, JS removes this attribute
-    &[hidden] {
-      display: none;
-    }
-
     &:active,
     &:active:focus {
       top: nhsuk-spacing(3) + $nhsuk-button-shadow-size;

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/_index.scss
@@ -79,8 +79,10 @@
       box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-text-colour;
     }
 
-    .nhsuk-frontend-supported .nhsuk-code--button & {
-      padding-top: nhsuk-px-to-rem(nhsuk-spacing(9));
+    .nhsuk-code--button & {
+      @include nhsuk-frontend-supported {
+        padding-top: nhsuk-px-to-rem(nhsuk-spacing(9));
+      }
     }
 
     .nhsuk-code--reverse & {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -554,10 +554,6 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
     align-self: center;
     padding: 0 math.div($nhsuk-gutter-half, 2);
 
-    &[hidden] {
-      display: none;
-    }
-
     @include nhsuk-media-query($from: tablet) {
       padding: 0 $nhsuk-gutter-half;
     }
@@ -574,10 +570,6 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
     &,
     &:hover {
       text-decoration: none;
-    }
-
-    &[hidden] {
-      display: none;
     }
 
     &::after {
@@ -613,10 +605,6 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
 
     @include nhsuk-media-query($from: tablet) {
       margin: 0 $nhsuk-gutter-half;
-    }
-
-    &[hidden] {
-      display: none;
     }
 
     .nhsuk-header__navigation-link,

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -472,7 +472,7 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
       }
     }
 
-    .nhsuk-frontend-supported & {
+    @include nhsuk-frontend-supported {
       flex-wrap: nowrap;
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/_index.scss
@@ -23,11 +23,6 @@
   }
 
   .nhsuk-password-input__toggle {
-    // Hide the button by default, JS removes this attribute
-    &[hidden] {
-      display: none;
-    }
-
     @include nhsuk-media-query($from: mobile) {
       flex-basis: 5em;
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
@@ -218,8 +218,10 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
     margin-left: $conditional-margin-left;
     padding-left: $conditional-padding-left;
     border-left: nhsuk-px-to-rem($nhsuk-border-width) solid nhsuk-colour("grey-3");
+  }
 
-    .nhsuk-frontend-supported &--hidden {
+  .nhsuk-radios__conditional--hidden {
+    @include nhsuk-frontend-supported {
       display: none;
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
@@ -44,8 +44,7 @@
     @include nhsuk-responsive-margin(8, "bottom");
   }
 
-  // NHS.UK frontend JavaScript enabled
-  .nhsuk-frontend-supported {
+  @include nhsuk-frontend-supported {
     @include nhsuk-media-query($from: tablet) {
       .nhsuk-tabs__list {
         margin-bottom: 0;

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_hidden.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_hidden.scss
@@ -1,0 +1,15 @@
+////
+/// Hidden
+///
+/// Elements with the hidden attribute should not be shown.
+///
+/// This is the browser default, but defined here as important
+/// to override any display properties that we otherwise set.
+///
+/// @group styles
+////
+
+[hidden] {
+  // stylelint-disable-next-line declaration-no-important
+  display: none !important;
+}

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_index.scss
@@ -1,3 +1,4 @@
+@forward "hidden";
 @forward "icons";
 @forward "lists";
 @forward "section-break";

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
@@ -484,6 +484,29 @@
   @include nhsuk-print-hide;
 }
 
+/// NHS.UK frontend supported mixin
+///
+/// Applied when NHS.UK frontend JavaScript is supported
+/// For example, in modern browsers with `<script type="module">` support
+///
+/// @example scss
+///   @include nhsuk-frontend-supported; {
+///     color: red;
+///   }
+///
+
+@mixin nhsuk-frontend-supported {
+  @if & {
+    .nhsuk-frontend-supported & {
+      @content;
+    }
+  } @else {
+    .nhsuk-frontend-supported {
+      @content;
+    }
+  }
+}
+
 /// Flex mixin
 ///
 /// @example scss

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_mixins.scss
@@ -507,6 +507,29 @@
   }
 }
 
+/// NHS.UK frontend not supported mixin
+///
+/// Applied when NHS.UK frontend JavaScript is not supported
+/// For example, in older browsers without `<script type="module">` support
+///
+/// @example scss
+///   @include nhsuk-frontend-not-supported; {
+///     color: blue;
+///   }
+///
+
+@mixin nhsuk-frontend-not-supported {
+  @if & {
+    body:not(.nhsuk-frontend-supported) & {
+      @content;
+    }
+  } @else {
+    body:not(.nhsuk-frontend-supported) {
+      @content;
+    }
+  }
+}
+
 /// Flex mixin
 ///
 /// @example scss

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_index.scss
@@ -10,6 +10,7 @@
 @forward "list-border";
 @forward "reading-width";
 @forward "spacing";
+@forward "supported";
 @forward "text-align";
 @forward "typography";
 @forward "visually-hidden";

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_supported.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_supported.scss
@@ -1,0 +1,15 @@
+// stylelint-disable declaration-no-important
+
+@use "../../core/tools" as *;
+
+////
+/// NHS.UK frontend supported
+///
+/// @group utilities
+////
+
+.nhsuk-u-frontend-supported-hidden {
+  @include nhsuk-frontend-supported {
+    display: none !important;
+  }
+}

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_supported.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_supported.scss
@@ -13,3 +13,9 @@
     display: none !important;
   }
 }
+
+.nhsuk-u-frontend-not-supported-hidden {
+  @include nhsuk-frontend-not-supported {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds new Sass mixins and utility classes for NHS.UK frontend browser support.

You can now show or hide content depending on whether NHS.UK frontend JavaScript is supported:

- Add the `nhsuk-u-frontend-not-supported-hidden` class to hide content in older browsers
- Add the `nhsuk-u-frontend-supported-hidden` class to hide content in modern browsers

If you use Sass you can include mixins for custom components:

```scss
.app-component {
  @include nhsuk-frontend-supported {
    background-color: nhsuk-colour("green");
  }

  @include nhsuk-frontend-not-supported {
    background-color: nhsuk-colour("red");
  }
}
```

It also includes global `[hidden]` styles to remove duplicate versions of:

```scss
[hidden] {
  display: none;
}
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
