### PR TITLE
[v10] Tweak `font-size-adjust` on `nhsuk-font-monospace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,9 +252,9 @@ You can still use `nhsuk-print-colour` and `nhsuk-print-hide` but we'll remove t
 
 ### :wrench: **Fixes**
 
-- [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).
+- [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942)
 - [#1986: Update `nhsuk-font-monospace` font size to better match body text](https://github.com/nhsuk/nhsuk-frontend/pull/1986/changes)
-- [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997).
+- [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997)
 
 ## 10.5.2 - 8 June 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ You can still use `nhsuk-print-colour` and `nhsuk-print-hide` but we'll remove t
 ### :wrench: **Fixes**
 
 - [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).
+- [#1986: Update `nhsuk-font-monospace` font size to better match body text](https://github.com/nhsuk/nhsuk-frontend/pull/1986/changes)
 - [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997).
 
 ## 10.5.2 - 8 June 2026

--- a/packages/nhsuk-frontend/src/nhsuk/core/tools/_typography.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/tools/_typography.scss
@@ -118,7 +118,7 @@
   }
 
   font-family: $font-family-value;
-  font-size-adjust: 0.5;
+  font-size-adjust: 0.52;
 }
 
 /// Word break helper


### PR DESCRIPTION
## Description
Tweak `font-size-adjust` on `nhsuk-font-monospace` to better match standard body text. 

Before:
<img width="691" height="68" alt="Screenshot 2026-06-29 at 17 04 35" src="https://github.com/user-attachments/assets/21a9a71f-79e6-4a99-90fc-6ad33dc68597" />

After:
<img width="691" height="68" alt="Screenshot 2026-06-29 at 17 04 42" src="https://github.com/user-attachments/assets/953c178d-949a-40a4-827d-9abc882f8116" />


## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
