### PR TITLE
Add `nhsuk-u-display-none` override classes for breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,7 @@ This change was introduced in [pull request #1998: Add `compact` option for tabl
 
 - [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942)
 - [#1986: Update `nhsuk-font-monospace` font size to better match body text](https://github.com/nhsuk/nhsuk-frontend/pull/1986/changes)
+- [#1987: Add `nhsuk-u-display-none` override classes for breakpoints](https://github.com/nhsuk/nhsuk-frontend/pull/1987)
 - [#1996: Update hover colour for task list and pagination](https://github.com/nhsuk/nhsuk-frontend/pull/1996)
 - [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997)
 - [#2000: Update responsive table row margin and border width](https://github.com/nhsuk/nhsuk-frontend/pull/2000)

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_display.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_display.scss
@@ -1,3 +1,4 @@
+@use "../../core/settings" as *;
 @use "../../core/tools" as *;
 
 ////
@@ -24,15 +25,17 @@
   display: none !important;
 }
 
-.nhsuk-u-display-none-from-tablet {
-  @include nhsuk-media-query($from: tablet) {
-    display: none !important;
+@each $name, $value in $nhsuk-breakpoints {
+  @include nhsuk-media-query($until: $name) {
+    .nhsuk-u-display-none-until-#{$name} {
+      display: none !important;
+    }
   }
-}
 
-.nhsuk-u-display-none-on-mobile {
-  @include nhsuk-media-query($until: tablet) {
-    display: none !important;
+  @include nhsuk-media-query($from: $name) {
+    .nhsuk-u-display-none-from-#{$name} {
+      display: none !important;
+    }
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/core/utilities/_display.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/utilities/_display.scss
@@ -24,6 +24,18 @@
   display: none !important;
 }
 
+.nhsuk-u-display-none-from-tablet {
+  @include nhsuk-media-query($from: tablet) {
+    display: none !important;
+  }
+}
+
+.nhsuk-u-display-none-on-mobile {
+  @include nhsuk-media-query($until: tablet) {
+    display: none !important;
+  }
+}
+
 .nhsuk-u-display-none-print {
   @media print {
     display: none !important;


### PR DESCRIPTION
This PR adds new `nhsuk-u-display-none-*` override classes for breakpoints

The changes are related to https://github.com/nhsuk/nhsuk-frontend/issues/1153 and were upstreamed from NHS app frontend at [`utility/_display.scss`](https://github.com/nhsuk/nhsapp-frontend/blob/main/src/utilities/_display.scss)

### Mobile

* `nhsuk-u-display-none-until-mobile` – hide content until mobile breakpoint
* `nhsuk-u-display-none-from-mobile` – hide content from mobile breakpoint (and above)

### Tablet

* `nhsuk-u-display-none-until-tablet` – hide content until tablet breakpoint
* `nhsuk-u-display-none-from-tablet` – hide content from tablet breakpoint (and above)

### Desktop

* `nhsuk-u-display-none-until-desktop` – hide content until desktop breakpoint
* `nhsuk-u-display-none-from-desktop` – hide content from desktop breakpoint (and above)

### Large desktop

* `nhsuk-u-display-none-until-large-desktop` – hide content until large desktop breakpoint
* `nhsuk-u-display-none-from-large-desktop` – hide content from large desktop breakpoint (and above)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
