### PR TITLE
[v10] Preserve conditionally revealed content margins when JavaScript is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ You can still use `nhsuk-print-colour` and `nhsuk-print-hide` but we'll remove t
 ### :wrench: **Fixes**
 
 - [#1942: Update `nhsuk-spacing()` to add missing `$adjustment` and `$important` params](https://github.com/nhsuk/nhsuk-frontend/pull/1942).
+- [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997).
 
 ## 10.5.2 - 8 June 2026
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -46,10 +46,10 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
     margin-top: 0;
   }
 
-  .nhsuk-checkboxes__item.nhsuk-u-hidden-not-supported:first-child {
+  .nhsuk-checkboxes__item.nhsuk-u-frontend-not-supported-hidden:first-child {
     @include nhsuk-frontend-not-supported {
       + .nhsuk-checkboxes__item,
-      + .nhsuk-u-hidden-not-supported + .nhsuk-checkboxes__item {
+      + .nhsuk-u-frontend-not-supported-hidden + .nhsuk-checkboxes__item {
         margin-top: 0;
       }
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -36,14 +36,24 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
     position: relative;
     flex-wrap: wrap;
     margin-top: nhsuk-spacing(2) - $nhsuk-checkboxes-offset;
-
-    .nhsuk-checkboxes__conditional:not(.nhsuk-checkboxes__conditional--hidden) + & {
-      @include nhsuk-responsive-margin(4, "top", $adjustment: - $nhsuk-checkboxes-offset);
-    }
   }
 
   .nhsuk-checkboxes__item:first-child {
     margin-top: 0;
+  }
+
+  // Add default margin to items that follow conditionally revealing content
+  .nhsuk-checkboxes__conditional + .nhsuk-checkboxes__item,
+  .nhsuk-checkboxes--small .nhsuk-checkboxes__conditional + .nhsuk-checkboxes__item {
+    @include nhsuk-responsive-margin(4, "top", $adjustment: - $nhsuk-checkboxes-offset);
+  }
+
+  // Remove margin from items that follow conditionally revealing content,
+  // but only apply when JavaScript is supported and the content is hidden
+  .nhsuk-checkboxes__conditional--hidden + .nhsuk-checkboxes__item {
+    @include nhsuk-frontend-supported {
+      margin-top: nhsuk-spacing(2) - $nhsuk-checkboxes-offset;
+    }
   }
 
   .nhsuk-checkboxes__item.nhsuk-u-frontend-not-supported-hidden:first-child {
@@ -241,6 +251,14 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
 
     .nhsuk-checkboxes__item {
       margin-top: 0;
+    }
+
+    // Remove margin from items that follow conditionally revealing content,
+    // but only apply when JavaScript is supported and the content is hidden
+    .nhsuk-checkboxes__conditional--hidden + .nhsuk-checkboxes__item {
+      @include nhsuk-frontend-supported {
+        margin-top: 0;
+      }
     }
 
     // Shift the touch target into the left margin so that the visible edge of

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -56,6 +56,8 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
     }
   }
 
+  // Remove margin from items that follow hidden "all" options or dividers,
+  // but only apply when JavaScript is **not** supported
   .nhsuk-checkboxes__item.nhsuk-u-frontend-not-supported-hidden:first-child {
     @include nhsuk-frontend-not-supported {
       + .nhsuk-checkboxes__item,

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/header.mjs
@@ -469,7 +469,7 @@ export class Header extends ConfigurableComponent {
   static moduleName = 'nhsuk-header'
 
   /**
-   * Tabs default config
+   * Header default config
    *
    * @see {@link HeaderConfig}
    * @constant
@@ -485,7 +485,7 @@ export class Header extends ConfigurableComponent {
   })
 
   /**
-   * Tabs config schema
+   * Header config schema
    *
    * @constant
    * @satisfies {Schema<HeaderConfig>}

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
@@ -41,14 +41,24 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
     position: relative;
     flex-wrap: wrap;
     margin-top: nhsuk-spacing(2) - $nhsuk-radios-offset;
-
-    .nhsuk-radios__conditional:not(.nhsuk-radios__conditional--hidden) + & {
-      @include nhsuk-responsive-margin(4, "top", $adjustment: - $nhsuk-radios-offset);
-    }
   }
 
   .nhsuk-radios__item:first-child {
     margin-top: 0;
+  }
+
+  // Add default margin to items that follow conditionally revealing content
+  .nhsuk-radios__conditional + .nhsuk-radios__item,
+  .nhsuk-radios--small .nhsuk-radios__conditional + .nhsuk-radios__item {
+    @include nhsuk-responsive-margin(4, "top", $adjustment: - $nhsuk-radios-offset);
+  }
+
+  // Remove margin from items that follow conditionally revealing content,
+  // but only apply when JavaScript is supported and the content is hidden
+  .nhsuk-radios__conditional--hidden + .nhsuk-radios__item {
+    @include nhsuk-frontend-supported {
+      margin-top: nhsuk-spacing(2) - $nhsuk-radios-offset;
+    }
   }
 
   .nhsuk-radios__input {
@@ -235,6 +245,14 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
 
     .nhsuk-radios__item {
       margin-top: 0;
+    }
+
+    // Remove margin from items that follow conditionally revealing content,
+    // but only apply when JavaScript is supported and the content is hidden
+    .nhsuk-radios__conditional--hidden + .nhsuk-radios__item {
+      @include nhsuk-frontend-supported {
+        margin-top: 0;
+      }
     }
 
     // Shift the touch target into the left margin so that the visible edge of


### PR DESCRIPTION
## Description

This PR preserves our default conditionally revealed content margins when JavaScript is not supported

Previously we'd set smaller margins assuming the content was hidden

<img width="658" alt="Checkboxes with JavaScript disabled showing tighter spacing" src="https://github.com/user-attachments/assets/37511f57-7dfd-407a-90c8-f5ee9ca464e6" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
