### PR TITLE
[v10] Allow configurable components to run conditional support checks

### DIFF
--- a/packages/nhsuk-frontend-review/src/javascripts/application.mjs
+++ b/packages/nhsuk-frontend-review/src/javascripts/application.mjs
@@ -1,23 +1,40 @@
 import { initAll } from 'nhsuk-frontend'
 
+/**
+ * Review app errors
+ *
+ * @type {{ error: unknown, context: ErrorContext<CompatibleClass> }[]}
+ */
+const errors = []
+
 initAll({
   errorSummary: { disableAutoFocus: true },
   notificationBanner: { disableAutoFocus: true },
   onError(error, context) {
-    const $element = context.element
-
-    // Locate component example
-    const $example = $element?.closest('.app-wrapper')
-    const $heading = $example?.querySelector('h2')
-
-    console.error(
-      $heading
-        ? `Error in NHS.UK frontend: '${$heading.textContent}'`
-        : 'Error in NHS.UK frontend',
-      error,
-      context
-    )
-
-    throw error
+    errors.push({ error, context })
   }
 })
+
+for (const { error, context } of errors) {
+  const $element = context.element
+
+  // Locate component example
+  const $example = $element?.closest('.app-wrapper')
+  const $heading = $example?.querySelector('h2')
+
+  console.error(
+    $heading
+      ? `Error in NHS.UK frontend: '${$heading.textContent}'`
+      : 'Error in NHS.UK frontend',
+    error,
+    context
+  )
+}
+
+if (errors.length > 0) {
+  throw new Error('Errors in NHS.UK frontend review app')
+}
+
+/**
+ * @import { CompatibleClass, ErrorContext } from 'nhsuk-frontend'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
@@ -1,4 +1,5 @@
-import { Component } from './component.mjs'
+import { MockComponent } from '#lib/fixtures/configuration/mock-component.mjs'
+
 import { SupportError } from './errors/index.mjs'
 
 describe('Component', () => {
@@ -8,35 +9,36 @@ describe('Component', () => {
   })
 
   describe('checkSupport()', () => {
-    describe('default implementation', () => {
-      class ServiceComponent extends Component {
-        static moduleName = 'app-service-component'
-      }
+    let /** @type {HTMLElement} */ $root
 
+    beforeEach(() => {
+      $root = document.createElement('div')
+      $root.setAttribute('data-module', MockComponent.moduleName)
+
+      document.body.appendChild($root)
+    })
+
+    describe('default implementation', () => {
       it('Makes initialisation throw if NHS.UK frontend is not supported', () => {
         document.body.classList.remove('nhsuk-frontend-supported')
-        expect(() => new ServiceComponent(document.body)).toThrow(SupportError)
+        expect(() => new MockComponent($root)).toThrow(SupportError)
       })
 
       it('Allows initialisation if NHS.UK frontend is supported', () => {
-        expect(() => new ServiceComponent(document.body)).not.toThrow()
+        expect(() => new MockComponent($root)).not.toThrow()
       })
     })
 
     describe('when overriden', () => {
       it('Allows child classes to define their own condition for support', () => {
-        class ServiceComponent extends Component {
-          static moduleName = 'app-service-component'
-
+        class ServiceComponent extends MockComponent {
           static checkSupport() {
             throw new Error('Custom error')
           }
         }
 
         // Use the message rather than the class as `SupportError` extends `Error`
-        expect(() => new ServiceComponent(document.body)).toThrow(
-          'Custom error'
-        )
+        expect(() => new ServiceComponent($root)).toThrow('Custom error')
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.jsdom.test.mjs
@@ -30,15 +30,48 @@ describe('Component', () => {
     })
 
     describe('when overriden', () => {
-      it('Allows child classes to define their own condition for support', () => {
+      let /** @type {HTMLElement} */ $root1
+      let /** @type {HTMLElement} */ $root2
+
+      beforeEach(() => {
+        $root1 = $root
+        $root2 = document.createElement('div')
+
+        document.body.appendChild($root2)
+      })
+
+      it('Allows child classes to define support checks', () => {
         class ServiceComponent extends MockComponent {
           static checkSupport() {
-            throw new Error('Custom error')
+            throw new Error('Error thrown from support check')
           }
         }
 
-        // Use the message rather than the class as `SupportError` extends `Error`
-        expect(() => new ServiceComponent($root)).toThrow('Custom error')
+        expect(() => new ServiceComponent($root)).toThrow(
+          'Error thrown from support check'
+        )
+      })
+
+      it('Allows child classes to define conditional $root support checks', () => {
+        class ServiceComponent extends MockComponent {
+          /**
+           * @param {HTMLElement} [$root]
+           */
+          static checkSupport($root) {
+            if ($root?.dataset.throw === 'true') {
+              throw new Error('Error thrown from $root support check')
+            }
+          }
+        }
+
+        $root1.dataset.throw = 'false'
+        $root2.dataset.throw = 'true'
+
+        expect(() => new ServiceComponent($root1)).not.toThrow()
+
+        expect(() => new ServiceComponent($root2)).toThrow(
+          'Error thrown from $root support check'
+        )
       })
     })
   })

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -13,7 +13,7 @@ const _self =
  * Centralises the behaviours shared by our components
  *
  * @abstract
- * @template {Element} [RootElementType=HTMLElement]
+ * @template {HTMLElement} [RootElementType=HTMLElement]
  */
 export class Component {
   /**
@@ -47,7 +47,7 @@ export class Component {
 
     this.$root = /** @type {RootElementType} */ ($root)
 
-    childConstructor.checkSupport()
+    childConstructor.checkSupport(this.$root)
     this.setInitialised()
   }
 
@@ -83,9 +83,11 @@ export class Component {
   /**
    * Validate whether component is supported
    *
+   * @template {HTMLElement} [RootElementType=HTMLElement]
+   * @param {RootElementType} [_$root] - HTML element to use for component
    * @throws {SupportError} when component is not supported
    */
-  static checkSupport() {
+  static checkSupport(_$root) {
     if (!isSupported()) {
       throw new SupportError()
     }

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -47,8 +47,10 @@ export class Component {
 
     this.$root = /** @type {RootElementType} */ ($root)
 
-    childConstructor.checkSupport(this.$root)
-    this.setInitialised()
+    if (!('defaults' in childConstructor)) {
+      childConstructor.checkSupport(this.$root)
+      this.setInitialised()
+    }
   }
 
   /**
@@ -83,11 +85,13 @@ export class Component {
   /**
    * Validate whether component is supported
    *
+   * @template {Partial<Record<keyof ConfigurationType, unknown>>} [ConfigurationType=ObjectNested]
    * @template {HTMLElement} [RootElementType=HTMLElement]
    * @param {RootElementType} [_$root] - HTML element to use for component
+   * @param {ConfigurationType} [_config] - Config specified by configurable components only
    * @throws {SupportError} when component is not supported
    */
-  static checkSupport(_$root) {
+  static checkSupport(_$root, _config) {
     if (!isSupported()) {
       throw new SupportError()
     }

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -48,6 +48,16 @@ export class Component {
     this.$root = /** @type {RootElementType} */ ($root)
 
     childConstructor.checkSupport()
+    this.setInitialised()
+  }
+
+  /**
+   * Set component as initialised
+   */
+  setInitialised() {
+    const childConstructor = /** @type {ComponentConstructor} */ (
+      this.constructor
+    )
 
     this.checkInitialised()
 

--- a/packages/nhsuk-frontend/src/nhsuk/component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/component.mjs
@@ -81,9 +81,9 @@ export class Component {
   }
 
   /**
-   * Validates whether components are supported
+   * Validate whether component is supported
    *
-   * @throws {SupportError} when the components are not supported
+   * @throws {SupportError} when component is not supported
    */
   static checkSupport() {
     if (!isSupported()) {

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/code.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/code.jsdom.test.mjs
@@ -135,6 +135,7 @@ describe('Code', () => {
     })
 
     it('should not throw with missing $button element', () => {
+      $root.classList.remove('nhsuk-code--button')
       $button.remove()
 
       expect(() => new Code($root)).not.toThrow()

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/code.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/code.mjs
@@ -207,7 +207,7 @@ export class Code extends ConfigurableComponent {
   static moduleName = 'nhsuk-code'
 
   /**
-   * Validates whether components are supported
+   * Validate whether components are supported
    */
   static checkSupport() {
     ConfigurableComponent.checkSupport()

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/code.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/code.mjs
@@ -57,8 +57,9 @@ export class Code extends ConfigurableComponent {
 
     this.$content = $content
 
-    const $button = this.$root.querySelector('.nhsuk-js-code-button')
-    if ($button) {
+    // Check for copy button support
+    if (this.$root.classList.contains(`${Code.moduleName}--button`)) {
+      const $button = this.$root.querySelector('.nhsuk-js-code-button')
       if (!($button instanceof HTMLButtonElement)) {
         throw new ElementError({
           component: Code,
@@ -207,12 +208,23 @@ export class Code extends ConfigurableComponent {
   static moduleName = 'nhsuk-code'
 
   /**
-   * Validate whether components are supported
+   * Validate whether component is supported
+   *
+   * @param {HTMLElement} [$root] - HTML element to use for component
+   * @param {Partial<CodeConfig>} [config] - Code config
    */
-  static checkSupport() {
-    ConfigurableComponent.checkSupport()
+  static checkSupport($root, config) {
+    ConfigurableComponent.checkSupport($root, config)
 
+    // Check for copy button support
+    if (!$root?.classList.contains(`${Code.moduleName}--button`)) {
+      return
+    }
+
+    // Check for clipboard support
     if (!('clipboard' in navigator)) {
+      $root.classList.remove(`${Code.moduleName}--button`)
+
       throw new SupportError(
         formatErrorMessage(Code, 'Support for "navigator.clipboard" required')
       )

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -7,16 +7,21 @@ import {
 import { ConfigError } from './errors/index.mjs'
 
 describe('ConfigurableComponent', () => {
+  let /** @type {HTMLElement} */ $root
+
   beforeEach(() => {
     document.documentElement.innerHTML = ''
     document.body.classList.add('nhsuk-frontend-supported')
+
+    $root = document.createElement('div')
+    $root.setAttribute('data-module', MockConfigurableComponent.moduleName)
+
+    document.body.appendChild($root)
   })
 
   describe('throws error', () => {
     it('if no schema defined', () => {
-      expect(
-        () => new MockConfigurableComponentNoSchema(document.body)
-      ).toThrow(
+      expect(() => new MockConfigurableComponentNoSchema($root)).toThrow(
         new ConfigError(
           'mock-component: Config passed as parameter into constructor but no schema defined'
         )
@@ -24,9 +29,7 @@ describe('ConfigurableComponent', () => {
     })
 
     it('if no defaults defined', () => {
-      expect(
-        () => new MockConfigurableComponentNoDefaults(document.body)
-      ).toThrow(
+      expect(() => new MockConfigurableComponentNoDefaults($root)).toThrow(
         new ConfigError(
           'mock-component: Config passed as parameter into constructor but no defaults defined'
         )
@@ -36,57 +39,41 @@ describe('ConfigurableComponent', () => {
 
   describe('set configuration on initialisation to', () => {
     it('defaults if no configuration provided', () => {
-      document.body.innerHTML = `
-        <div id="test-component"></div>
-      `
+      const component = new MockConfigurableComponent($root)
 
-      const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponent(testComponent)
-
-      expect(configComponent.config).toMatchObject({ aNumber: 0 })
+      expect(component.config).toMatchObject({ aNumber: 0 })
     })
 
     it('dataset of root', () => {
-      document.body.innerHTML = `
-        <div id="test-component" data-a-number="42"></div>
-      `
+      $root.setAttribute('data-a-number', '42')
 
-      const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponent(testComponent)
+      const component = new MockConfigurableComponent($root)
 
-      expect(configComponent.config).toMatchObject({ aNumber: 42 })
+      expect(component.config).toMatchObject({ aNumber: 42 })
     })
 
     it('configuration object from class initialisation', () => {
-      document.body.innerHTML = `
-        <div id="test-component"></div>
-      `
-
-      const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponent(testComponent, {
+      const component = new MockConfigurableComponent($root, {
         aNumber: 100,
         aFunction: (name) => name
       })
 
-      expect(configComponent.config.aNumber).toBe(100)
-      expect(configComponent.config.aFunction).toBeInstanceOf(Function)
-      expect(configComponent.config.aFunction('albatross')).toBe('albatross')
+      expect(component.config.aNumber).toBe(100)
+      expect(component.config.aFunction).toBeInstanceOf(Function)
+      expect(component.config.aFunction('albatross')).toBe('albatross')
     })
 
     it('dataset configuration over the configuration object from class initialisation', () => {
-      document.body.innerHTML = `
-        <div id="test-component" data-a-number="12"></div>
-      `
+      $root.setAttribute('data-a-number', '12')
 
-      const testComponent = document.querySelector('#test-component')
-      const configComponent = new MockConfigurableComponent(testComponent, {
+      const component = new MockConfigurableComponent($root, {
         aNumber: 100,
         aFunction: (name) => name
       })
 
-      expect(configComponent.config.aNumber).toBe(12)
-      expect(configComponent.config.aFunction).toBeInstanceOf(Function)
-      expect(configComponent.config.aFunction('albatross')).toBe('albatross')
+      expect(component.config.aNumber).toBe(12)
+      expect(component.config.aFunction).toBeInstanceOf(Function)
+      expect(component.config.aFunction('albatross')).toBe('albatross')
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -4,6 +4,7 @@ import {
   MockConfigurableComponentNoSchema
 } from '#lib/fixtures/configuration/mock-component.mjs'
 
+import { SupportError } from './errors/index.mjs'
 import { ConfigError } from './errors/index.mjs'
 
 describe('ConfigurableComponent', () => {
@@ -74,6 +75,65 @@ describe('ConfigurableComponent', () => {
       expect(component.config.aNumber).toBe(12)
       expect(component.config.aFunction).toBeInstanceOf(Function)
       expect(component.config.aFunction('albatross')).toBe('albatross')
+    })
+  })
+
+  describe('checkSupport()', () => {
+    describe('default implementation', () => {
+      it('Makes initialisation throw if NHS.UK frontend is not supported', () => {
+        document.body.classList.remove('nhsuk-frontend-supported')
+        expect(() => new MockConfigurableComponent($root)).toThrow(SupportError)
+      })
+
+      it('Allows initialisation if NHS.UK frontend is supported', () => {
+        expect(() => new MockConfigurableComponent($root)).not.toThrow()
+      })
+    })
+
+    describe('when overriden', () => {
+      let /** @type {HTMLElement} */ $root1
+      let /** @type {HTMLElement} */ $root2
+
+      beforeEach(() => {
+        $root1 = $root
+        $root2 = document.createElement('div')
+
+        document.body.appendChild($root2)
+      })
+
+      it('Allows child classes to define support checks', () => {
+        class ServiceComponent extends MockConfigurableComponent {
+          static checkSupport() {
+            throw new Error('Error thrown from support check')
+          }
+        }
+
+        expect(() => new ServiceComponent($root)).toThrow(
+          'Error thrown from support check'
+        )
+      })
+
+      it('Allows child classes to define conditional $root support checks', () => {
+        class ServiceComponent extends MockConfigurableComponent {
+          /**
+           * @param {HTMLElement} [$root]
+           */
+          static checkSupport($root) {
+            if ($root?.dataset.throw === 'true') {
+              throw new Error('Error thrown from $root support check')
+            }
+          }
+        }
+
+        $root1.dataset.throw = 'false'
+        $root2.dataset.throw = 'true'
+
+        expect(() => new ServiceComponent($root1)).not.toThrow()
+
+        expect(() => new ServiceComponent($root2)).toThrow(
+          'Error thrown from $root support check'
+        )
+      })
     })
   })
 })

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.jsdom.test.mjs
@@ -134,6 +134,30 @@ describe('ConfigurableComponent', () => {
           'Error thrown from $root support check'
         )
       })
+
+      it('Allows child classes to define conditional config support checks', () => {
+        class ServiceComponent extends MockConfigurableComponent {
+          /**
+           * @param {HTMLElement} [$root]
+           * @param {Partial<MockConfig>} [config]
+           */
+          static checkSupport($root, config) {
+            if (config?.aBoolean) {
+              throw new Error('Error thrown from config support check')
+            }
+          }
+        }
+
+        expect(() => new ServiceComponent($root1)).not.toThrow()
+
+        expect(() => new ServiceComponent($root2, { aBoolean: true })).toThrow(
+          'Error thrown from config support check'
+        )
+      })
     })
   })
 })
+
+/**
+ * @import { MockConfig } from '#lib/fixtures/configuration/mock-component.mjs'
+ */

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -80,6 +80,9 @@ export class ConfigurableComponent extends Component {
     if (errors[0]) {
       throw new ConfigError(formatErrorMessage(childConstructor, errors[0]))
     }
+
+    childConstructor.checkSupport(this.$root, this.config)
+    this.setInitialised()
   }
 
   /**
@@ -95,6 +98,15 @@ export class ConfigurableComponent extends Component {
    */
   configOverride(_datasetConfig) {
     return {}
+  }
+
+  /**
+   * Validate whether component is supported
+   *
+   * @type {typeof Component.checkSupport}
+   */
+  static checkSupport(_$root, _config) {
+    Component.checkSupport(_$root, _config)
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -93,7 +93,7 @@ export class ConfigurableComponent extends Component {
    * @param {Partial<ConfigurationType>} _datasetConfig - Config specified by dataset
    * @returns {Partial<ConfigurationType>} Config to override by dataset
    */
-  configOverride(_datasetConfig = {}) {
+  configOverride(_datasetConfig) {
     return {}
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -25,7 +25,7 @@ export class ConfigurableComponent extends Component {
    * Constructs a new component, validating that NHS.UK frontend is supported
    *
    * @param {Element | null} $root - HTML element to use for component
-   * @param {Partial<ConfigurationType>} [config] - HTML element to use for component
+   * @param {Partial<ConfigurationType>} [config] - Component config
    */
   constructor($root, config) {
     super($root)

--- a/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/configurable-component.mjs
@@ -80,6 +80,9 @@ export class ConfigurableComponent extends Component {
     if (errors[0]) {
       throw new ConfigError(formatErrorMessage(childConstructor, errors[0]))
     }
+
+    childConstructor.checkSupport(this.$root, this.config)
+    this.setInitialised()
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds component conditional support checks

E.g. Code component can omit `navigator.clipboard` errors when the copy button is disabled

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
