### PR TITLE
[v10] Use double quotes in fixtures to match Nunjucks

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -29,6 +29,12 @@ module.exports = {
         printWidth: 120,
         singleQuote: false
       }
+    },
+    {
+      files: 'fixtures.mjs',
+      options: {
+        singleQuote: false
+      }
     }
   ]
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
@@ -1,4 +1,4 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
 /**
  * Nunjucks macro option variants
@@ -10,12 +10,12 @@ export const variants = [
     // Regular variant
   },
   {
-    description: 'reverse',
+    description: "reverse",
     context: {
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   }
 ]
@@ -26,29 +26,29 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'Find your nearest A&E',
-      href: '#'
+      text: "Find your nearest A&E",
+      href: "#"
     },
     variants,
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-action-link'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-action-link"
     }
   },
-  'as a button': {
+  "as a button": {
     context: {
-      text: 'Find your nearest A&E',
-      element: 'button'
+      text: "Find your nearest A&E",
+      element: "button"
     },
     variants,
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-action-link'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-action-link"
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
       html: outdent`
         Start session<br>
@@ -56,7 +56,7 @@ const fixtures = {
       `
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     callBlock: outdent`
       Start session<br>
       <span class="nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>

--- a/packages/nhsuk-frontend/src/nhsuk/components/back-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/back-link/fixtures.mjs
@@ -8,12 +8,12 @@ export const variants = [
     // Regular variant
   },
   {
-    description: 'reverse',
+    description: "reverse",
     context: {
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   }
 ]
@@ -24,40 +24,40 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'Back',
-      href: '#'
+      text: "Back",
+      href: "#"
     },
     variants,
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-back-link'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-back-link"
     }
   },
-  'as a button': {
+  "as a button": {
     context: {
-      text: 'Back',
-      element: 'button'
+      text: "Back",
+      element: "button"
     },
     variants,
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-back-link'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-back-link"
     }
   },
-  'with text escaping': {
+  "with text escaping": {
     context: {
-      text: 'What to expect at A&E'
+      text: "What to expect at A&E"
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      html: 'What to expect at A&amp;E'
+      html: "What to expect at A&amp;E"
     }
   },
-  'with HTML via call block': {
-    callBlock: 'What to expect at A&amp;E'
+  "with HTML via call block": {
+    callBlock: "What to expect at A&amp;E"
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/fixtures.mjs
@@ -4,107 +4,107 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'Home'
+          href: "#",
+          text: "Home"
         },
         {
-          href: '#',
-          text: 'NHS services'
+          href: "#",
+          text: "NHS services"
         },
         {
-          href: '#',
-          text: 'Hospitals'
+          href: "#",
+          text: "Hospitals"
         }
       ]
     },
     screenshot: true
   },
-  'reverse': {
+  "reverse": {
     context: {
-      variant: 'reverse',
+      variant: "reverse",
       items: [
         {
-          href: '#',
-          text: 'Home'
+          href: "#",
+          text: "Home"
         },
         {
-          href: '#',
-          text: 'NHS services'
+          href: "#",
+          text: "NHS services"
         },
         {
-          href: '#',
-          text: 'Hospitals'
+          href: "#",
+          text: "Hospitals"
         }
       ]
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     },
     screenshot: true
   },
-  'with back link as a button': {
+  "with back link as a button": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'Home'
+          href: "#",
+          text: "Home"
         },
         {
-          href: '#',
-          text: 'Search results'
+          href: "#",
+          text: "Search results"
         }
       ],
       backLink: {
-        element: 'button'
+        element: "button"
       }
     }
   },
-  'with back link custom text': {
+  "with back link custom text": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'Home'
+          href: "#",
+          text: "Home"
         },
         {
-          href: '#',
-          text: 'Advanced search'
+          href: "#",
+          text: "Advanced search"
         }
       ],
       backLink: {
-        text: 'Search results',
-        href: '#'
+        text: "Search results",
+        href: "#"
       }
     }
   },
-  'attributes': {
+  "attributes": {
     context: {
-      id: 'with-attributes',
+      id: "with-attributes",
       items: [
         {
-          href: '#',
-          text: 'Home',
-          attributes: { lang: 'en' }
+          href: "#",
+          text: "Home",
+          attributes: { lang: "en" }
         },
         {
-          href: '#',
-          text: 'NHS services',
-          attributes: { lang: 'en' }
+          href: "#",
+          text: "NHS services",
+          attributes: { lang: "en" }
         },
         {
-          href: '#',
-          text: 'Hospitals',
-          classes: 'example-class-one example-class-two',
-          attributes: { lang: 'en' }
+          href: "#",
+          text: "Hospitals",
+          classes: "example-class-one example-class-two",
+          attributes: { lang: "en" }
         }
       ],
       backLink: {
-        id: 'back-link-with-attributes',
-        attributes: { lang: 'en' }
+        id: "back-link-with-attributes",
+        attributes: { lang: "en" }
       }
     },
     options: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/button/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/button/fixtures.mjs
@@ -4,666 +4,666 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'Save and continue'
+      text: "Save and continue"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'default, small': {
+  "default, small": {
     context: {
-      text: 'Save and continue',
+      text: "Save and continue",
       small: true
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
-      text: 'Disabled button',
+      text: "Disabled button",
       disabled: true
     },
     screenshot: true
   },
-  'disabled, small': {
+  "disabled, small": {
     context: {
-      text: 'Disabled button',
+      text: "Disabled button",
       disabled: true,
       small: true
     }
   },
-  'as a link': {
+  "as a link": {
     context: {
-      text: 'Link button',
-      href: '#'
+      text: "Link button",
+      href: "#"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'as a link, small': {
+  "as a link, small": {
     context: {
-      text: 'Link button',
+      text: "Link button",
       small: true,
-      href: '#'
+      href: "#"
     }
   },
-  'with icon at start': {
+  "with icon at start": {
     context: {
-      text: 'Previous',
+      text: "Previous",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     }
   },
-  'with icon at start, small': {
+  "with icon at start, small": {
     context: {
-      text: 'Previous',
+      text: "Previous",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     }
   },
-  'with icon at end': {
+  "with icon at end": {
     context: {
-      text: 'Next',
+      text: "Next",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     }
   },
-  'with icon at end, small': {
+  "with icon at end, small": {
     context: {
-      text: 'Next',
+      text: "Next",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     }
   },
-  'with double click prevented': {
+  "with double click prevented": {
     context: {
-      text: 'Save and continue',
+      text: "Save and continue",
       preventDoubleClick: true
     }
   },
-  'with double click not prevented': {
+  "with double click not prevented": {
     context: {
-      text: 'Save and continue',
+      text: "Save and continue",
       preventDoubleClick: false
     }
   },
-  'login': {
+  "login": {
     context: {
-      text: 'Continue',
-      variant: 'login'
+      text: "Continue",
+      variant: "login"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'login, small': {
+  "login, small": {
     context: {
-      text: 'Continue',
-      variant: 'login',
+      text: "Continue",
+      variant: "login",
       small: true
     }
   },
-  'login disabled': {
+  "login disabled": {
     context: {
-      text: 'Continue',
-      variant: 'login',
+      text: "Continue",
+      variant: "login",
       disabled: true
     },
     screenshot: true
   },
-  'login disabled, small': {
+  "login disabled, small": {
     context: {
-      text: 'Continue',
-      variant: 'login',
+      text: "Continue",
+      variant: "login",
       disabled: true,
       small: true
     }
   },
-  'login as a link': {
+  "login as a link": {
     context: {
-      text: 'Continue',
-      variant: 'login',
-      href: '#'
+      text: "Continue",
+      variant: "login",
+      href: "#"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'login as a link, small': {
+  "login as a link, small": {
     context: {
-      text: 'Continue',
-      variant: 'login',
+      text: "Continue",
+      variant: "login",
       small: true,
-      href: '#'
+      href: "#"
     }
   },
-  'login with icon at start': {
+  "login with icon at start": {
     context: {
-      text: 'Previous',
-      variant: 'login',
+      text: "Previous",
+      variant: "login",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     }
   },
-  'login with icon at start, small': {
+  "login with icon at start, small": {
     context: {
-      text: 'Previous',
-      variant: 'login',
+      text: "Previous",
+      variant: "login",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     }
   },
-  'login with icon at end': {
+  "login with icon at end": {
     context: {
-      text: 'Next',
-      variant: 'login',
+      text: "Next",
+      variant: "login",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     }
   },
-  'login with icon at end, small': {
+  "login with icon at end, small": {
     context: {
-      text: 'Next',
-      variant: 'login',
+      text: "Next",
+      variant: "login",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     }
   },
-  'reverse': {
+  "reverse": {
     context: {
-      text: 'Log out',
-      variant: 'reverse'
+      text: "Log out",
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'reverse, small': {
+  "reverse, small": {
     context: {
-      text: 'Log out',
-      variant: 'reverse',
+      text: "Log out",
+      variant: "reverse",
       small: true
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse disabled': {
+  "reverse disabled": {
     context: {
-      text: 'Log out',
-      variant: 'reverse',
+      text: "Log out",
+      variant: "reverse",
       disabled: true
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     },
     screenshot: true
   },
-  'reverse disabled, small': {
+  "reverse disabled, small": {
     context: {
-      text: 'Log out',
-      variant: 'reverse',
+      text: "Log out",
+      variant: "reverse",
       disabled: true,
       small: true
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse as a link': {
+  "reverse as a link": {
     context: {
-      text: 'Log out',
-      variant: 'reverse',
-      href: '#'
+      text: "Log out",
+      variant: "reverse",
+      href: "#"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'reverse as a link, small': {
+  "reverse as a link, small": {
     context: {
-      text: 'Log out',
-      variant: 'reverse',
+      text: "Log out",
+      variant: "reverse",
       small: true,
-      href: '#'
+      href: "#"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse with icon at start': {
+  "reverse with icon at start": {
     context: {
-      text: 'Previous',
-      variant: 'reverse',
+      text: "Previous",
+      variant: "reverse",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse with icon at start, small': {
+  "reverse with icon at start, small": {
     context: {
-      text: 'Previous',
-      variant: 'reverse',
+      text: "Previous",
+      variant: "reverse",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse with icon at end': {
+  "reverse with icon at end": {
     context: {
-      text: 'Next',
-      variant: 'reverse',
+      text: "Next",
+      variant: "reverse",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'reverse with icon at end, small': {
+  "reverse with icon at end, small": {
     context: {
-      text: 'Next',
-      variant: 'reverse',
+      text: "Next",
+      variant: "reverse",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'secondary': {
+  "secondary": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary'
+      text: "Find my location",
+      variant: "secondary"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'secondary, small': {
+  "secondary, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary',
+      text: "Find my location",
+      variant: "secondary",
       small: true
     }
   },
-  'secondary disabled': {
+  "secondary disabled": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary',
+      text: "Find my location",
+      variant: "secondary",
       disabled: true
     },
     screenshot: true
   },
-  'secondary disabled, small': {
+  "secondary disabled, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary',
+      text: "Find my location",
+      variant: "secondary",
       disabled: true,
       small: true
     }
   },
-  'secondary as a link': {
+  "secondary as a link": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary',
-      href: '#'
+      text: "Find my location",
+      variant: "secondary",
+      href: "#"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'secondary as a link, small': {
+  "secondary as a link, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary',
+      text: "Find my location",
+      variant: "secondary",
       small: true,
-      href: '#'
+      href: "#"
     }
   },
-  'secondary with icon at start': {
+  "secondary with icon at start": {
     context: {
-      text: 'Previous',
-      variant: 'secondary',
+      text: "Previous",
+      variant: "secondary",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     }
   },
-  'secondary with icon at start, small': {
+  "secondary with icon at start, small": {
     context: {
-      text: 'Previous',
-      variant: 'secondary',
+      text: "Previous",
+      variant: "secondary",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     }
   },
-  'secondary with icon at end': {
+  "secondary with icon at end": {
     context: {
-      text: 'Next',
-      variant: 'secondary',
+      text: "Next",
+      variant: "secondary",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     }
   },
-  'secondary with icon at end, small': {
+  "secondary with icon at end, small": {
     context: {
-      text: 'Next',
-      variant: 'secondary',
+      text: "Next",
+      variant: "secondary",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     }
   },
-  'secondary, solid background': {
+  "secondary, solid background": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid'
+      text: "Find my location",
+      variant: "secondary-solid"
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'secondary, solid background, small': {
+  "secondary, solid background, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid',
+      text: "Find my location",
+      variant: "secondary-solid",
       small: true
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background disabled': {
+  "secondary, solid background disabled": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid',
+      text: "Find my location",
+      variant: "secondary-solid",
       disabled: true
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     },
     screenshot: true
   },
-  'secondary, solid background disabled, small': {
+  "secondary, solid background disabled, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid',
+      text: "Find my location",
+      variant: "secondary-solid",
       disabled: true,
       small: true
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background as a link': {
+  "secondary, solid background as a link": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid',
-      href: '#'
+      text: "Find my location",
+      variant: "secondary-solid",
+      href: "#"
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'secondary, solid background as a link, small': {
+  "secondary, solid background as a link, small": {
     context: {
-      text: 'Find my location',
-      variant: 'secondary-solid',
+      text: "Find my location",
+      variant: "secondary-solid",
       small: true,
-      href: '#'
+      href: "#"
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background with icon at start': {
+  "secondary, solid background with icon at start": {
     context: {
-      text: 'Previous',
-      variant: 'secondary-solid',
+      text: "Previous",
+      variant: "secondary-solid",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background with icon at start, small': {
+  "secondary, solid background with icon at start, small": {
     context: {
-      text: 'Previous',
-      variant: 'secondary-solid',
+      text: "Previous",
+      variant: "secondary-solid",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background with icon at end': {
+  "secondary, solid background with icon at end": {
     context: {
-      text: 'Next',
-      variant: 'secondary-solid',
+      text: "Next",
+      variant: "secondary-solid",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'secondary, solid background with icon at end, small': {
+  "secondary, solid background with icon at end, small": {
     context: {
-      text: 'Next',
-      variant: 'secondary-solid',
+      text: "Next",
+      variant: "secondary-solid",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     },
     options: {
-      layout: 'background-grey'
+      layout: "background-grey"
     }
   },
-  'warning': {
+  "warning": {
     context: {
-      text: 'Yes, delete this vaccine',
-      variant: 'warning'
+      text: "Yes, delete this vaccine",
+      variant: "warning"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'warning, small': {
+  "warning, small": {
     context: {
-      text: 'Yes, delete this vaccine',
+      text: "Yes, delete this vaccine",
       small: true,
-      variant: 'warning'
+      variant: "warning"
     }
   },
-  'warning disabled': {
+  "warning disabled": {
     context: {
-      text: 'Yes, delete this vaccine',
-      variant: 'warning',
+      text: "Yes, delete this vaccine",
+      variant: "warning",
       disabled: true
     },
     screenshot: true
   },
-  'warning disabled, small': {
+  "warning disabled, small": {
     context: {
-      text: 'Yes, delete this vaccine',
-      variant: 'warning',
+      text: "Yes, delete this vaccine",
+      variant: "warning",
       small: true,
       disabled: true
     }
   },
-  'warning as a link': {
+  "warning as a link": {
     context: {
-      text: 'Yes, delete this vaccine',
-      variant: 'warning',
-      href: '#'
+      text: "Yes, delete this vaccine",
+      variant: "warning",
+      href: "#"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-button'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-button"
     }
   },
-  'warning as a link, small': {
+  "warning as a link, small": {
     context: {
-      text: 'Yes, delete this vaccine',
+      text: "Yes, delete this vaccine",
       small: true,
-      variant: 'warning',
-      href: '#'
+      variant: "warning",
+      href: "#"
     }
   },
-  'warning with icon at start': {
+  "warning with icon at start": {
     context: {
-      text: 'Previous',
-      variant: 'warning',
+      text: "Previous",
+      variant: "warning",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       }
     }
   },
-  'warning with icon at start, small': {
+  "warning with icon at start, small": {
     context: {
-      text: 'Previous',
-      variant: 'warning',
+      text: "Previous",
+      variant: "warning",
       icon: {
-        name: 'arrow-left',
-        placement: 'start'
+        name: "arrow-left",
+        placement: "start"
       },
       small: true
     }
   },
-  'warning with icon at end': {
+  "warning with icon at end": {
     context: {
-      text: 'Next',
-      variant: 'warning',
+      text: "Next",
+      variant: "warning",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       }
     }
   },
-  'warning with icon at end, small': {
+  "warning with icon at end, small": {
     context: {
-      text: 'Next',
-      variant: 'warning',
+      text: "Next",
+      variant: "warning",
       icon: {
-        name: 'arrow-right',
-        placement: 'end'
+        name: "arrow-right",
+        placement: "end"
       },
       small: true
     }
   },
-  'example reverse search button, small': {
+  "example reverse search button, small": {
     context: {
-      text: 'Search',
-      variant: 'reverse',
+      text: "Search",
+      variant: "reverse",
       small: true
     },
     options: {
       hidden: true
     }
   },
-  'example reverse save button, small': {
+  "example reverse save button, small": {
     context: {
-      text: 'Save',
-      variant: 'reverse',
+      text: "Save",
+      variant: "reverse",
       small: true
     },
     options: {
       hidden: true
     }
   },
-  'example secondary search button, small': {
+  "example secondary search button, small": {
     context: {
-      text: 'Search',
-      variant: 'secondary',
+      text: "Search",
+      variant: "secondary",
       small: true
     },
     options: {
       hidden: true
     }
   },
-  'example secondary save button, small': {
+  "example secondary save button, small": {
     context: {
-      text: 'Save',
-      variant: 'secondary',
+      text: "Save",
+      variant: "secondary",
       small: true
     },
     options: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/fixtures.mjs
@@ -1,9 +1,9 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as imageExamples } from '../images/fixtures.mjs'
-import { examples as summaryListExamples } from '../summary-list/fixtures.mjs'
+import { examples as imageExamples } from "../images/fixtures.mjs"
+import { examples as summaryListExamples } from "../summary-list/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -11,7 +11,7 @@ import { examples as summaryListExamples } from '../summary-list/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       heading: "If you need help now, but it's not an emergency",
       headingLevel: 3
@@ -20,10 +20,10 @@ const fixtures = {
       <p class="nhsuk-card__description">Go to <a href="#">NHS 111 online</a> or <a href="#">call 111</a>.</p>
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'heading': {
+  "heading": {
     context: {
       heading: "If you need help now, but it's not an emergency",
       headingLevel: 3
@@ -33,50 +33,50 @@ const fixtures = {
     `,
     variants: [
       {
-        description: 'basic with size S',
+        description: "basic with size S",
         context: {
-          headingSize: 's'
+          headingSize: "s"
         }
       },
       {
-        description: 'basic with size M',
+        description: "basic with size M",
         context: {
-          headingSize: 'm'
+          headingSize: "m"
         }
       },
       {
-        description: 'basic with size L',
+        description: "basic with size L",
         context: {
-          headingSize: 'l'
+          headingSize: "l"
         }
       },
       {
-        description: 'basic with size XL',
+        description: "basic with size XL",
         context: {
-          headingSize: 'xl'
+          headingSize: "xl"
         }
       }
     ]
   },
-  'basic without heading': {
+  "basic without heading": {
     context: {
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     }
   },
-  'basic with heading link': {
+  "basic with heading link": {
     context: {
-      href: '#',
-      heading: 'Introduction to care and support',
-      headingSize: 'm',
+      href: "#",
+      heading: "Introduction to care and support",
+      headingSize: "m",
       headingLevel: 3,
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     }
   },
-  'basic with custom HTML': {
+  "basic with custom HTML": {
     context: {
-      heading: 'Help from NHS 111',
+      heading: "Help from NHS 111",
       headingLevel: 3
     },
     callBlock: outdent`
@@ -85,189 +85,189 @@ const fixtures = {
       <p class="nhsuk-body">For a life-threatening emergency call 999.</p>
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'basic with summary list': {
+  "basic with summary list": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet']
+      viewports: ["mobile", "tablet"]
     }
   },
-  'basic with summary lists': {
+  "basic with summary lists": {
     context: {
-      heading: 'Regional Managers',
+      heading: "Regional Managers",
       headingLevel: 3
     },
     callBlock: outdent`
       <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis"]
       )}
 
       <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Sarah Philips (no border)']
+        "summary-list",
+        summaryListExamples["example person: Sarah Philips (no border)"]
       )}
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet']
+      viewports: ["mobile", "tablet"]
     }
   },
-  'basic with summary list and button': {
+  "basic with summary list and button": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis"]
       )}
 
-      ${components.render('button', {
+      ${components.render("button", {
         context: {
-          text: 'Add role',
-          variant: 'secondary'
+          text: "Add role",
+          variant: "secondary"
         }
       })}
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet']
+      viewports: ["mobile", "tablet"]
     }
   },
-  'basic with summary list and action': {
+  "basic with summary list and action": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            text: 'Delete',
-            href: '#/delete'
+            text: "Delete",
+            href: "#/delete"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and action as a button': {
+  "basic with summary list and action as a button": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            element: 'button',
-            text: 'Delete'
+            element: "button",
+            text: "Delete"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and actions': {
+  "basic with summary list and actions": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            text: 'Delete',
-            href: '#/delete'
+            text: "Delete",
+            href: "#/delete"
           },
           {
-            text: 'Withdraw',
-            href: '#/withdraw'
+            text: "Withdraw",
+            href: "#/withdraw"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and actions as buttons': {
+  "basic with summary list and actions as buttons": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            element: 'button',
-            text: 'Delete'
+            element: "button",
+            text: "Delete"
           },
           {
-            element: 'button',
-            text: 'Withdraw'
+            element: "button",
+            text: "Withdraw"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and actions, without heading': {
+  "basic with summary list and actions, without heading": {
     context: {
       actions: {
         items: [
           {
-            text: 'Delete',
-            visuallyHiddenText: '(Karen Francis)',
-            href: '#/delete'
+            text: "Delete",
+            visuallyHiddenText: "(Karen Francis)",
+            href: "#/delete"
           },
           {
-            text: 'Withdraw',
-            visuallyHiddenText: '(Karen Francis)',
-            href: '#/withdraw'
+            text: "Withdraw",
+            visuallyHiddenText: "(Karen Francis)",
+            href: "#/withdraw"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and actions (empty items)': {
+  "basic with summary list and actions (empty items)": {
     context: {
-      heading: 'Regional Manager',
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            text: 'Delete',
-            href: '#/delete'
+            text: "Delete",
+            href: "#/delete"
           },
           false
         ]
@@ -275,46 +275,46 @@ const fixtures = {
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'basic with summary list and heading link': {
+  "basic with summary list and heading link": {
     context: {
-      href: '#',
-      heading: 'Regional Manager',
+      href: "#",
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'secondary without heading': {
+  "secondary without heading": {
     context: {
-      variant: 'secondary',
+      variant: "secondary",
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     }
   },
-  'secondary with heading link': {
+  "secondary with heading link": {
     context: {
-      href: '#',
-      variant: 'secondary',
-      heading: 'Introduction to care and support',
-      headingSize: 'm',
+      href: "#",
+      variant: "secondary",
+      heading: "Introduction to care and support",
+      headingSize: "m",
       headingLevel: 3,
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     }
   },
-  'secondary with custom HTML': {
+  "secondary with custom HTML": {
     context: {
-      variant: 'secondary',
-      heading: 'Help from NHS 111',
+      variant: "secondary",
+      heading: "Help from NHS 111",
       headingLevel: 3
     },
     callBlock: outdent`
@@ -323,119 +323,119 @@ const fixtures = {
       <p class="nhsuk-body">For a life-threatening emergency call 999.</p>
     `
   },
-  'secondary with summary list': {
+  "secondary with summary list": {
     context: {
-      variant: 'secondary',
-      heading: 'Regional Manager',
+      variant: "secondary",
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'secondary with summary lists': {
+  "secondary with summary lists": {
     context: {
-      variant: 'secondary',
-      heading: 'Regional Managers',
+      variant: "secondary",
+      heading: "Regional Managers",
       headingLevel: 3
     },
     callBlock: outdent`
       <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">East</h4>
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis"]
       )}
 
       <h4 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">West</h4>
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Sarah Philips (no border)']
+        "summary-list",
+        summaryListExamples["example person: Sarah Philips (no border)"]
       )}
     `
   },
-  'secondary with summary list and button': {
+  "secondary with summary list and button": {
     context: {
-      variant: 'secondary',
-      heading: 'Regional Manager',
+      variant: "secondary",
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis"]
       )}
 
-      ${components.render('button', {
+      ${components.render("button", {
         context: {
-          text: 'Add role',
-          variant: 'secondary'
+          text: "Add role",
+          variant: "secondary"
         }
       })}
     `
   },
-  'secondary with summary list and actions': {
+  "secondary with summary list and actions": {
     context: {
-      variant: 'secondary',
-      heading: 'Regional Manager',
+      variant: "secondary",
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            text: 'Delete',
-            href: '#/delete'
+            text: "Delete",
+            href: "#/delete"
           },
           {
-            text: 'Withdraw',
-            href: '#/withdraw'
+            text: "Withdraw",
+            href: "#/withdraw"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'secondary with summary list and actions, without heading': {
+  "secondary with summary list and actions, without heading": {
     context: {
-      variant: 'secondary',
+      variant: "secondary",
       actions: {
         items: [
           {
-            text: 'Delete',
-            visuallyHiddenText: '(Karen Francis)',
-            href: '#/delete'
+            text: "Delete",
+            visuallyHiddenText: "(Karen Francis)",
+            href: "#/delete"
           },
           {
-            text: 'Withdraw',
-            visuallyHiddenText: '(Karen Francis)',
-            href: '#/withdraw'
+            text: "Withdraw",
+            visuallyHiddenText: "(Karen Francis)",
+            href: "#/withdraw"
           }
         ]
       }
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'secondary with summary list and actions (empty items)': {
+  "secondary with summary list and actions (empty items)": {
     context: {
-      variant: 'secondary',
-      heading: 'Regional Manager',
+      variant: "secondary",
+      heading: "Regional Manager",
       headingLevel: 3,
       actions: {
         items: [
           {
-            text: 'Delete',
-            href: '#/delete'
+            text: "Delete",
+            href: "#/delete"
           },
           false
         ]
@@ -443,30 +443,30 @@ const fixtures = {
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'secondary with summary list and heading link': {
+  "secondary with summary list and heading link": {
     context: {
-      href: '#',
-      variant: 'secondary',
-      heading: 'Regional Manager',
+      href: "#",
+      variant: "secondary",
+      heading: "Regional Manager",
       headingLevel: 3
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'non-urgent (blue)': {
+  "non-urgent (blue)": {
     context: {
-      heading: 'Speak to a GP if:',
+      heading: "Speak to a GP if:",
       headingLevel: 3,
-      variant: 'non-urgent'
+      variant: "non-urgent"
     },
     callBlock: outdent`
       <ul>
@@ -478,14 +478,14 @@ const fixtures = {
       <p>Tell the receptionist you think it's chickenpox before going in. They may recommend a special appointment time if other patients are at risk.</p>
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'urgent (red)': {
+  "urgent (red)": {
     context: {
-      heading: 'Ask for an urgent GP appointment if:',
+      heading: "Ask for an urgent GP appointment if:",
       headingLevel: 3,
-      variant: 'urgent'
+      variant: "urgent"
     },
     callBlock: outdent`
       <ul>
@@ -497,14 +497,14 @@ const fixtures = {
       <p>In these situations, your GP can prescribe medicine to prevent complications. You need to take it within 24 hours of the spots coming out.</p>
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'emergency (red and black)': {
+  "emergency (red and black)": {
     context: {
-      heading: 'Call 999 if you have sudden chest pain that:',
+      heading: "Call 999 if you have sudden chest pain that:",
       headingLevel: 3,
-      variant: 'emergency'
+      variant: "emergency"
     },
     callBlock: outdent`
       <ul>
@@ -515,14 +515,14 @@ const fixtures = {
       <p>You could be having a heart attack. Call 999 immediately as you need immediate treatment in hospital.</p>
     `,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'emergency (red and black) with action link': {
+  "emergency (red and black) with action link": {
     context: {
-      heading: 'Call 999 or go to A&E now if:',
+      heading: "Call 999 or go to A&E now if:",
       headingLevel: 3,
-      variant: 'emergency'
+      variant: "emergency"
     },
     callBlock: outdent`
       <ul>
@@ -530,99 +530,99 @@ const fixtures = {
         <li>you have severe difficulty breathing – you're gasping, choking or not able to get words out</li>
       </ul>
 
-      ${components.render('action-link', {
+      ${components.render("action-link", {
         context: {
-          text: 'Find your nearest A&E',
-          variant: 'reverse',
-          href: '#'
+          text: "Find your nearest A&E",
+          variant: "reverse",
+          href: "#"
         }
       })}
     `
   },
-  'primary (with chevron)': {
+  "primary (with chevron)": {
     context: {
-      href: '#',
-      variant: 'primary',
+      href: "#",
+      variant: "primary",
       clickable: true,
-      heading: 'Breast screening',
-      headingSize: 'm'
+      heading: "Breast screening",
+      headingSize: "m"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'primary (with chevron and description)': {
+  "primary (with chevron and description)": {
     context: {
-      href: '#',
-      variant: 'primary',
+      href: "#",
+      variant: "primary",
       clickable: true,
-      heading: 'Introduction to care and support',
-      headingSize: 'm',
+      heading: "Introduction to care and support",
+      headingSize: "m",
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'clickable': {
+  "clickable": {
     context: {
-      href: '#',
+      href: "#",
       clickable: true,
-      heading: 'Introduction to care and support',
-      headingSize: 'm',
+      heading: "Introduction to care and support",
+      headingSize: "m",
       description:
-        'A quick guide for people who have care and support needs and their carers'
+        "A quick guide for people who have care and support needs and their carers"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'secondary': {
+  "secondary": {
     context: {
-      href: '#',
+      href: "#",
       clickable: true,
-      variant: 'secondary',
-      heading: 'Urgent and emergency care services',
-      headingSize: 'm',
+      variant: "secondary",
+      heading: "Urgent and emergency care services",
+      headingSize: "m",
       description:
-        'Services the NHS provides if you need urgent or emergency medical help'
+        "Services the NHS provides if you need urgent or emergency medical help"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'secondary non-clickable with custom description': {
+  "secondary non-clickable with custom description": {
     context: {
-      href: '#',
-      variant: 'secondary',
-      heading: 'Why we are reinvesting in the NHS Prototype kit',
-      headingClasses: 'nhsuk-u-font-size-22 nhsuk-u-margin-bottom-2',
+      href: "#",
+      variant: "secondary",
+      heading: "Why we are reinvesting in the NHS Prototype kit",
+      headingClasses: "nhsuk-u-font-size-22 nhsuk-u-margin-bottom-2",
       descriptionHtml: outdent`
         <p class="nhsuk-body-s nhsuk-u-margin-bottom-2">21 July 2025</p>
         <p class="nhsuk-card__description">Frankie and Mike explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it.</p>
       `
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'feature': {
+  "feature": {
     context: {
-      variant: 'feature',
-      heading: 'Feature card heading',
-      description: 'Feature card description.'
+      variant: "feature",
+      heading: "Feature card heading",
+      description: "Feature card description."
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'feature with A to Z content': {
+  "feature with A to Z content": {
     context: {
-      variant: 'feature',
-      heading: 'A',
-      headingId: 'a',
-      headingSize: 'm',
+      variant: "feature",
+      heading: "A",
+      headingId: "a",
+      headingSize: "m",
       descriptionHtml: outdent`
         <ul class="nhsuk-list nhsuk-list--border">
           <li><a href="#/conditions/abdominal-aortic-aneurysm/">AAA, see Abdominal aortic aneurysm</a></li>
@@ -632,70 +632,70 @@ const fixtures = {
       `
     }
   },
-  'feature with summary list': {
+  "feature with summary list": {
     context: {
-      variant: 'feature',
-      heading: 'Feature card heading'
+      variant: "feature",
+      heading: "Feature card heading"
     },
     callBlock: outdent`
       ${components.render(
-        'summary-list',
-        summaryListExamples['example person: Karen Francis (no border)']
+        "summary-list",
+        summaryListExamples["example person: Karen Francis (no border)"]
       )}
     `
   },
-  'feature with nested card and summary list': {
+  "feature with nested card and summary list": {
     context: {
-      variant: 'feature',
-      heading: 'Flu: Follow-up requested'
+      variant: "feature",
+      heading: "Flu: Follow-up requested"
     },
     callBlock: outdent`
       <p>Sarah Philips (Mum) would like to speak to a member of the team about other options for their child's vaccination.</p>
-      ${components.render('button', {
+      ${components.render("button", {
         context: {
-          text: 'Record a new consent response',
-          variant: 'secondary',
-          href: '#'
+          text: "Record a new consent response",
+          variant: "secondary",
+          href: "#"
         }
       })}
 
       <h3 class="nhsuk-heading-s">Consent responses</h3>
 
-      ${components.render('summary-list', {
+      ${components.render("summary-list", {
         context: {
           card: {
-            href: '#',
+            href: "#",
             clickable: true,
-            heading: 'Sarah Philips (Mum)',
+            heading: "Sarah Philips (Mum)",
             headingLevel: 4
           },
           rows: [
             {
               key: {
-                text: 'Email address'
+                text: "Email address"
               },
               value: {
-                text: 'sarah.philips@example.com'
+                text: "sarah.philips@example.com"
               }
             },
             {
               key: {
-                text: 'Date'
+                text: "Date"
               },
               value: {
-                text: '25 August 2025 at 4:04 pm'
+                text: "25 August 2025 at 4:04 pm"
               }
             },
             {
               border: false,
               key: {
-                text: 'Response'
+                text: "Response"
               },
               value: {
-                html: components.render('tag', {
+                html: components.render("tag", {
                   context: {
-                    text: 'Follow up requested',
-                    colour: 'orange'
+                    text: "Follow up requested",
+                    colour: "orange"
                   }
                 })
               }
@@ -705,92 +705,92 @@ const fixtures = {
       })}
     `
   },
-  'warning': {
+  "warning": {
     context: {
-      variant: 'warning',
-      heading: 'School, nursery or work',
+      variant: "warning",
+      heading: "School, nursery or work",
       description:
-        'Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.'
+        "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
     }
   },
-  'warning with actions': {
+  "warning with actions": {
     context: {
-      variant: 'warning',
-      heading: 'School, nursery or work',
+      variant: "warning",
+      heading: "School, nursery or work",
       description:
-        'Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.',
+        "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.",
       actions: {
         items: [
           {
-            text: 'Dismiss',
-            href: '#/dismiss'
+            text: "Dismiss",
+            href: "#/dismiss"
           }
         ]
       }
     }
   },
-  'with image': {
+  "with image": {
     context: {
       image: {
-        src: 'https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg'
+        src: "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg"
       },
-      href: '#',
+      href: "#",
       clickable: true,
-      heading: 'Exercise',
-      headingSize: 'm',
+      heading: "Exercise",
+      headingSize: "m",
       description:
-        'Programmes, workouts and tips to get you moving and improve your fitness and wellbeing'
+        "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with image and caption': {
+  "with image and caption": {
     context: {
       image: {
-        html: components.render('images', imageExamples['default'])
+        html: components.render("images", imageExamples["default"])
       },
-      href: '#',
+      href: "#",
       clickable: true,
-      heading: 'Exercise',
-      headingSize: 'm',
+      heading: "Exercise",
+      headingSize: "m",
       description:
-        'Programmes, workouts and tips to get you moving and improve your fitness and wellbeing'
+        "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
     }
   },
-  'with image and custom HTML': {
+  "with image and custom HTML": {
     context: {
       image: {
-        src: 'https://service-manual.nhs.uk/assets/blog-prototype-kit.png'
+        src: "https://service-manual.nhs.uk/assets/blog-prototype-kit.png"
       },
-      href: 'https://digital.nhs.uk/blog/design-matters/2025/why-we-are-reinvesting-in-the-nhs-prototype-kit',
+      href: "https://digital.nhs.uk/blog/design-matters/2025/why-we-are-reinvesting-in-the-nhs-prototype-kit",
       clickable: true,
-      heading: 'Why we are reinvesting in the NHS prototype kit',
-      headingSize: 'm',
+      heading: "Why we are reinvesting in the NHS prototype kit",
+      headingSize: "m",
       headingHtml: outdent`
         <p class="nhsuk-body-s nhsuk-u-secondary-text-colour nhsuk-u-margin-bottom-0"><span class="nhsuk-u-visually-hidden">Published on: </span>21 July 2025</p>
         <p class="nhsuk-body-s nhsuk-u-font-weight-bold">NHS England Design Matters blog</p>
       `,
       description:
-        'Frankie Roberto and Mike Gallagher explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it.'
+        "Frankie Roberto and Mike Gallagher explain why we revived the NHS prototype kit, the benefits of prototyping in code and how digital teams in the NHS can get started using it."
     },
     options: {
-      width: 'one-half'
+      width: "one-half"
     }
   },
-  'top task': {
+  "top task": {
     context: {
-      href: '#',
+      href: "#",
       clickable: true,
-      heading: 'Order a repeat prescription',
-      headingSize: 'xs',
+      heading: "Order a repeat prescription",
+      headingSize: "xs",
       headingLevel: 3
     },
     options: {
-      width: 'one-third'
+      width: "one-third"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/character-count/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/character-count/fixtures.mjs
@@ -4,186 +4,186 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      name: 'example',
+      name: "example",
       maxlength: 200
     },
     screenshot: {
-      states: ['focus'],
-      selector: '.nhsuk-textarea'
+      states: ["focus"],
+      selector: ".nhsuk-textarea"
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      name: 'example',
+      name: "example",
       maxlength: 200,
       disabled: true
     },
     screenshot: true
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       maxlength: 200
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Job description must be 350 characters or less'
+        text: "Job description must be 350 characters or less"
       },
-      id: 'with-error-message',
-      name: 'example',
+      id: "with-error-message",
+      name: "example",
       maxlength: 350,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
       errorMessage: {
-        text: 'Job description must be 350 characters or less'
+        text: "Job description must be 350 characters or less"
       },
-      id: 'with-error-message',
-      name: 'example',
+      id: "with-error-message",
+      name: "example",
       maxlength: 350,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
     },
     screenshot: {
-      states: ['focus'],
-      selector: '.nhsuk-textarea'
+      states: ["focus"],
+      selector: ".nhsuk-textarea"
     }
   },
-  'with value': {
+  "with value": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-value',
-      name: 'example',
+      id: "with-value",
+      name: "example",
       maxlength: 350,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
     }
   },
-  'with custom rows': {
+  "with custom rows": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'custom-rows',
-      name: 'example',
+      id: "custom-rows",
+      name: "example",
       maxlength: 350,
       rows: 15
     }
   },
-  'label': {
+  "label": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'custom-size',
-      name: 'example',
+      id: "custom-size",
+      name: "example",
       maxlength: 200
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           label: {
-            size: 's'
+            size: "s"
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           label: {
-            size: 'm'
+            size: "m"
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           label: {
-            size: 'l'
+            size: "l"
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           label: {
-            size: 'xl'
+            size: "xl"
           }
         }
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Tell us more about what happened'
+        text: "Tell us more about what happened"
       },
-      id: 'without-heading',
-      name: 'example',
+      id: "without-heading",
+      name: "example",
       maxlength: 150
     }
   },
-  'with maxlength attribute': {
+  "with maxlength attribute": {
     context: {
       label: {
-        text: 'Enter a job description'
+        text: "Enter a job description"
       },
-      id: 'maxlength-attribute',
-      name: 'example',
+      id: "maxlength-attribute",
+      name: "example",
       maxlength: 11,
       attributes: {
         maxlength: 11
@@ -193,89 +193,89 @@ const fixtures = {
       hidden: true
     }
   },
-  'with maxwords': {
+  "with maxwords": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-word-count',
-      name: 'example',
+      id: "with-word-count",
+      name: "example",
       maxwords: 150
     }
   },
   "with count type 'length'": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-length-count-type',
-      name: 'example',
-      countType: 'length',
+      id: "with-length-count-type",
+      name: "example",
+      countType: "length",
       maxlength: 200
     }
   },
   "with count type 'characters'": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-characters-count-type',
-      name: 'example',
-      countType: 'characters',
+      id: "with-characters-count-type",
+      name: "example",
+      countType: "characters",
       maxlength: 200
     }
   },
   "with count type 'characters' and error message": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Job description must be 200 characters or less'
+        text: "Job description must be 200 characters or less"
       },
-      id: 'with-characters-count-type-error-message',
-      name: 'example',
-      countType: 'characters',
+      id: "with-characters-count-type-error-message",
+      name: "example",
+      countType: "characters",
       maxlength: 350,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
     }
   },
   "with count type 'characters' and value": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-characters-count-type-value',
-      name: 'example',
-      countType: 'characters',
+      id: "with-characters-count-type-value",
+      name: "example",
+      countType: "characters",
       maxlength: 350,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
     }
   },
   "with count type 'characters' and threshold": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-characters-count-type-threshold',
-      name: 'example',
-      countType: 'characters',
+      id: "with-characters-count-type-threshold",
+      name: "example",
+      countType: "characters",
       value:
-        'Type another letter into this field after this message to see the threshold feature',
+        "Type another letter into this field after this message to see the threshold feature",
       maxlength: 112,
       threshold: 75
     }
@@ -283,49 +283,49 @@ const fixtures = {
   "with count type 'words'": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-words-count-type',
-      name: 'example',
-      countType: 'words',
+      id: "with-words-count-type",
+      name: "example",
+      countType: "words",
       maxlength: 50
     },
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
   "with count type 'words' and error message": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Job description must be 40 words or less'
+        text: "Job description must be 40 words or less"
       },
-      id: 'with-words-count-type-error-message',
-      name: 'example',
-      countType: 'words',
+      id: "with-words-count-type-error-message",
+      name: "example",
+      countType: "words",
       maxlength: 51,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format."
     }
   },
   "with count type 'words' and threshold": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-words-count-type-threshold',
-      name: 'example',
-      countType: 'words',
+      id: "with-words-count-type-threshold",
+      name: "example",
+      countType: "words",
       value:
-        'Type another word into this field after this message to see the threshold feature',
+        "Type another word into this field after this message to see the threshold feature",
       maxlength: 51,
       threshold: 30
     }
@@ -333,47 +333,47 @@ const fixtures = {
   "with count type 'words' and value": {
     context: {
       label: {
-        text: 'Enter a job description',
-        size: 'l',
+        text: "Enter a job description",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-words-count-type-value',
-      name: 'example',
-      countType: 'words',
+      id: "with-words-count-type-value",
+      name: "example",
+      countType: "words",
       maxlength: 51,
       value:
-        '👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels.'
+        "👩🏻‍🚀 A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels."
     }
   },
-  'with threshold': {
+  "with threshold": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-threshold',
-      name: 'example',
+      id: "with-threshold",
+      name: "example",
       value:
-        'Type another letter into this field after this message to see the threshold feature',
+        "Type another letter into this field after this message to see the threshold feature",
       maxlength: 112,
       threshold: 75
     },
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'with neither maxlength nor maxwords set': {
+  "with neither maxlength nor maxwords set": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      textareaDescriptionText: 'No more than %{count} characters',
-      id: 'no-maximum-description',
-      name: 'example',
-      value: 'This textarea has no maximum character or word count.',
+      textareaDescriptionText: "No more than %{count} characters",
+      id: "no-maximum-description",
+      name: "example",
+      value: "This textarea has no maximum character or word count.",
       rows: 8
     },
     options: {
@@ -381,16 +381,16 @@ const fixtures = {
       throwOnError: false
     }
   },
-  'with neither maxlength, maxwords nor textarea description set': {
+  "with neither maxlength, maxwords nor textarea description set": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'no-maximum',
-      name: 'example',
-      value: 'This textarea has no maximum character or word count.',
+      id: "no-maximum",
+      name: "example",
+      value: "This textarea has no maximum character or word count.",
       rows: 8
     },
     options: {
@@ -398,46 +398,46 @@ const fixtures = {
       throwOnError: false
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
       label: {
-        text: 'Allwch chi roi mwy o fanylion?',
-        size: 'l',
+        text: "Allwch chi roi mwy o fanylion?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Peidiwch â chynnwys gwybodaeth bersonol, fel eich enw, dyddiad geni na rhif y GIG'
+        text: "Peidiwch â chynnwys gwybodaeth bersonol, fel eich enw, dyddiad geni na rhif y GIG"
       },
-      id: 'with-translations',
-      name: 'example',
+      id: "with-translations",
+      name: "example",
       maxlength: 200,
-      textareaDescriptionText: 'Gallwch ddefnyddio hyd at %{count} nod',
+      textareaDescriptionText: "Gallwch ddefnyddio hyd at %{count} nod",
       charactersUnderLimitText: {
-        one: 'Mae gennych %{count} nod ar ôl',
-        two: 'Mae gennych %{count} nod ar ôl',
-        few: 'Mae gennych %{count} nod ar ôl',
-        many: 'Mae gennych %{count} nod ar ôl',
-        other: 'Mae gennych %{count} nod ar ôl'
+        one: "Mae gennych %{count} nod ar ôl",
+        two: "Mae gennych %{count} nod ar ôl",
+        few: "Mae gennych %{count} nod ar ôl",
+        many: "Mae gennych %{count} nod ar ôl",
+        other: "Mae gennych %{count} nod ar ôl"
       },
-      charactersAtLimitText: 'Mae gennych 0 nod ar ôl',
+      charactersAtLimitText: "Mae gennych 0 nod ar ôl",
       charactersOverLimitText: {
-        one: 'Mae gennych %{count} nod yn ormod',
-        two: 'Mae gennych %{count} nod yn ormod',
-        few: 'Mae gennych %{count} nod yn ormod',
-        many: 'Mae gennych %{count} nod yn ormod',
-        other: 'Mae gennych chi %{count} nod yn ormod'
+        one: "Mae gennych %{count} nod yn ormod",
+        two: "Mae gennych %{count} nod yn ormod",
+        few: "Mae gennych %{count} nod yn ormod",
+        many: "Mae gennych %{count} nod yn ormod",
+        other: "Mae gennych chi %{count} nod yn ormod"
       }
     }
   },
-  'to configure in JavaScript': {
+  "to configure in JavaScript": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'to-configure-in-javascript',
-      name: 'example'
+      id: "to-configure-in-javascript",
+      name: "example"
     },
     options: {
       hidden: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/fixtures.mjs
@@ -1,8 +1,8 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as inputExamples } from '../input/fixtures.mjs'
+import { examples as inputExamples } from "../input/fixtures.mjs"
 
 /**
  * Nunjucks macro option variants
@@ -14,12 +14,12 @@ export const variants = [
     // Regular variant
   },
   {
-    description: 'small',
+    description: "small",
     context: {
       small: true,
       fieldset: {
         legend: {
-          size: 'm'
+          size: "m"
         }
       }
     }
@@ -32,366 +32,366 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      name: 'example',
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'disabled',
-      name: 'example',
+      idPrefix: "disabled",
+      name: "example",
       disabled: true,
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: true
   },
-  'disabled input': {
+  "disabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'disabled-input',
-      name: 'example',
+      idPrefix: "disabled-input",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message',
+          value: "text",
+          text: "Text message",
           disabled: true
         }
       ]
     },
     variants
   },
-  'disabled with enabled input': {
+  "disabled with enabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'disabled-enabled-input',
-      name: 'example',
+      idPrefix: "disabled-enabled-input",
+      name: "example",
       disabled: true,
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message',
+          value: "text",
+          text: "Text message",
           disabled: false
         }
       ]
     },
     variants
   },
-  'with hint': {
+  "with hint": {
     context: {
       fieldset: {
         legend: {
-          text: 'What medical conditions do you have?',
-          size: 'l',
+          text: "What medical conditions do you have?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 or more'
+        text: "Select 1 or more"
       },
-      idPrefix: 'with-hint',
-      name: 'example',
+      idPrefix: "with-hint",
+      name: "example",
       items: [
         {
-          value: 'alzheimers',
+          value: "alzheimers",
           text: "Alzheimer's disease or dementia"
         },
         {
-          value: 'asthma',
-          text: 'Asthma'
+          value: "asthma",
+          text: "Asthma"
         },
         {
-          value: 'cancer',
-          text: 'Cancer'
+          value: "cancer",
+          text: "Cancer"
         },
         {
-          value: 'diabetes',
-          text: 'Diabetes'
+          value: "diabetes",
+          text: "Diabetes"
         }
       ]
     },
     variants
   },
-  'inline': {
+  "inline": {
     context: {
       fieldset: {
         legend: {
-          text: 'Which nipple has changed?',
-          size: 'l',
+          text: "Which nipple has changed?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'inline',
-      name: 'example',
+      idPrefix: "inline",
+      name: "example",
       inline: true,
       items: [
         {
-          value: 'right',
-          text: 'Right nipple'
+          value: "right",
+          text: "Right nipple"
         },
         {
-          value: 'left',
-          text: 'Left nipple'
+          value: "left",
+          text: "Left nipple"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with pre-checked values': {
+  "with pre-checked values": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'conditional',
-      name: 'contact',
-      values: ['email', 'text'],
+      idPrefix: "conditional",
+      name: "contact",
+      values: ["email", "text"],
       items: getItems()
     },
     variants
   },
-  'with hints on items': {
+  "with hints on items": {
     context: {
       fieldset: {
         legend: {
-          text: 'What medical conditions do you have?',
-          size: 'l',
+          text: "What medical conditions do you have?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 or more'
+        text: "Select 1 or more"
       },
-      idPrefix: 'with-hint-item',
-      name: 'example',
+      idPrefix: "with-hint-item",
+      name: "example",
       items: [
         {
-          value: 'alzheimers',
+          value: "alzheimers",
           text: "Alzheimer's disease or dementia"
         },
         {
-          value: 'asthma',
-          text: 'Asthma'
+          value: "asthma",
+          text: "Asthma"
         },
         {
-          value: 'cancer',
-          text: 'Cancer'
+          value: "cancer",
+          text: "Cancer"
         },
         {
-          value: 'diabetes',
-          text: 'Diabetes',
+          value: "diabetes",
+          text: "Diabetes",
           hint: {
-            text: 'including type 1, type 2, and gestational diabetes'
+            text: "including type 1, type 2, and gestational diabetes"
           }
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without fieldset': {
+  "without fieldset": {
     context: {
       fieldset: null,
-      idPrefix: 'without-fieldset',
-      name: 'colours',
+      idPrefix: "without-fieldset",
+      name: "colours",
       items: [
         {
-          value: 'red',
-          text: 'Red'
+          value: "red",
+          text: "Red"
         },
         {
-          value: 'green',
-          text: 'Green'
+          value: "green",
+          text: "Green"
         },
         {
-          value: 'blue',
-          text: 'Blue'
+          value: "blue",
+          text: "Blue"
         }
       ]
     },
     variants
   },
-  'with error message': {
+  "with error message": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       errorMessage: {
-        text: 'Select how you want to be contacted'
+        text: "Select how you want to be contacted"
       },
-      idPrefix: 'with-error-message',
-      name: 'example',
+      idPrefix: "with-error-message",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text message',
-          text: 'Text message'
+          value: "text message",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: {
-      states: ['focus'],
-      selector: '#with-error-message',
-      viewports: ['mobile', 'tablet', 'desktop']
+      states: ["focus"],
+      selector: "#with-error-message",
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
       errorMessage: {
-        text: 'Select how you want to be contacted'
+        text: "Select how you want to be contacted"
       },
-      idPrefix: 'with-hint-error',
-      name: 'example',
+      idPrefix: "with-hint-error",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text message',
-          text: 'Text message'
+          value: "text message",
+          text: "Text message"
         }
       ]
     },
     variants
   },
-  'with long text': {
+  "with long text": {
     context: {
       fieldset: {
         legend: {
-          text: 'Venenatis Condimentum',
-          size: 'l',
+          text: "Venenatis Condimentum",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'with-long-text',
-      name: 'example',
+      idPrefix: "with-long-text",
+      name: "example",
       items: [
         {
-          value: 'nullam',
+          value: "nullam",
           text: outdent`
             Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
             quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
@@ -400,7 +400,7 @@ const fixtures = {
           `
         },
         {
-          value: 'aenean',
+          value: "aenean",
           text: outdent`
             Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
             vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
@@ -412,7 +412,7 @@ const fixtures = {
           `
         },
         {
-          value: 'fusce',
+          value: "fusce",
           text: outdent`
             Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
             nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
@@ -426,139 +426,139 @@ const fixtures = {
     },
     variants
   },
-  'legend': {
+  "legend": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l'
+          text: "How do you want to be contacted about this?",
+          size: "l"
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'custom-size',
-      name: 'example',
+      idPrefix: "custom-size",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text message',
-          text: 'Text message'
+          value: "text message",
+          text: "Text message"
         }
       ]
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           fieldset: {
             legend: {
-              size: 's'
+              size: "s"
             }
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           fieldset: {
             legend: {
-              size: 'm'
+              size: "m"
             }
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           fieldset: {
             legend: {
-              size: 'l'
+              size: "l"
             }
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           fieldset: {
             legend: {
-              size: 'xl'
+              size: "xl"
             }
           }
         }
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
+          text: "How do you want to be contacted about this?",
           isPageHeading: false
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'without-heading',
-      name: 'example',
+      idPrefix: "without-heading",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text message',
-          text: 'Text message'
+          value: "text message",
+          text: "Text message"
         }
       ]
     },
     variants
   },
-  'with conditional content': {
+  "with conditional content": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'conditional',
-      name: 'contact',
+      idPrefix: "conditional",
+      name: "contact",
       items: getItems()
     },
     variants
   },
-  'with conditional content, special characters': {
+  "with conditional content, special characters": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'user.profile[contact-prefs]',
-      name: 'contact',
+      idPrefix: "user.profile[contact-prefs]",
+      name: "contact",
       items: getItems()
     },
     options: {
@@ -566,107 +566,107 @@ const fixtures = {
     },
     variants
   },
-  'with conditional content, error message': {
+  "with conditional content, error message": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
       errorMessage: {
-        text: 'Select how you like to be contacted'
+        text: "Select how you like to be contacted"
       },
-      idPrefix: 'conditional',
-      name: 'contact',
+      idPrefix: "conditional",
+      name: "contact",
       items: getItems()
     },
     variants
   },
-  'with conditional content, error message (nested)': {
+  "with conditional content, error message (nested)": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select all options that are relevant to you'
+        text: "Select all options that are relevant to you"
       },
-      idPrefix: 'conditional',
-      name: 'example',
-      values: ['phone'],
+      idPrefix: "conditional",
+      name: "example",
+      values: ["phone"],
       items: getItems({ invalid: true })
     },
     variants,
     screenshot: {
-      states: ['focus'],
-      selector: '#conditional-2',
-      viewports: ['mobile', 'tablet', 'desktop']
+      states: ["focus"],
+      selector: "#conditional-2",
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
   'with "all" option': {
     context: {
       fieldset: {
         legend: {
-          text: 'Which vaccines would you like to include?',
-          size: 'l',
+          text: "Which vaccines would you like to include?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'all',
-      name: 'example',
+      idPrefix: "all",
+      name: "example",
       items: [
         {
-          value: 'all',
-          text: 'All 9 vaccines',
-          behaviour: 'inclusive'
+          value: "all",
+          text: "All 9 vaccines",
+          behaviour: "inclusive"
         },
         {
-          divider: 'or',
-          behaviour: 'inclusive'
+          divider: "or",
+          behaviour: "inclusive"
         },
         {
-          value: '4in1',
-          text: '4-in-1 pre-school booster'
+          value: "4in1",
+          text: "4-in-1 pre-school booster"
         },
         {
-          value: '6in1',
-          text: '6-in-1'
+          value: "6in1",
+          text: "6-in-1"
         },
         {
-          value: 'hpv',
-          text: 'HPV'
+          value: "hpv",
+          text: "HPV"
         },
         {
-          value: 'menb',
-          text: 'MenB'
+          value: "menb",
+          text: "MenB"
         },
         {
-          value: 'menacwy',
-          text: 'MenACWY'
+          value: "menacwy",
+          text: "MenACWY"
         },
         {
-          value: 'mmrv',
-          text: 'MMRV'
+          value: "mmrv",
+          text: "MMRV"
         },
         {
-          value: 'rotavirus',
-          text: 'Rotavirus'
+          value: "rotavirus",
+          text: "Rotavirus"
         },
         {
-          value: 'pneumococcal',
-          text: 'Pneumococcal'
+          value: "pneumococcal",
+          text: "Pneumococcal"
         },
         {
-          value: 'tdipv',
-          text: 'Td/IPV'
+          value: "tdipv",
+          text: "Td/IPV"
         }
       ]
     },
@@ -676,68 +676,68 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'Which vaccines would you like to include?',
-          size: 'l',
+          text: "Which vaccines would you like to include?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'all',
-      name: 'example',
+      idPrefix: "all",
+      name: "example",
       items: [
         {
-          value: 'all',
-          text: 'All 9 vaccines',
-          behaviour: 'inclusive',
-          behaviourGroup: 'vaccines-included'
+          value: "all",
+          text: "All 9 vaccines",
+          behaviour: "inclusive",
+          behaviourGroup: "vaccines-included"
         },
         {
-          divider: 'or',
-          behaviour: 'inclusive'
+          divider: "or",
+          behaviour: "inclusive"
         },
         {
-          value: '4in1',
-          text: '4-in-1 pre-school booster',
-          behaviourGroup: 'vaccines-included'
+          value: "4in1",
+          text: "4-in-1 pre-school booster",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: '6in1',
-          text: '6-in-1',
-          behaviourGroup: 'vaccines-included'
+          value: "6in1",
+          text: "6-in-1",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'hpv',
-          text: 'HPV',
-          behaviourGroup: 'vaccines-included'
+          value: "hpv",
+          text: "HPV",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'menb',
-          text: 'MenB',
-          behaviourGroup: 'vaccines-included'
+          value: "menb",
+          text: "MenB",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'menacwy',
-          text: 'MenACWY',
-          behaviourGroup: 'vaccines-included'
+          value: "menacwy",
+          text: "MenACWY",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'mmrv',
-          text: 'MMRV',
-          behaviourGroup: 'vaccines-included'
+          value: "mmrv",
+          text: "MMRV",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'rotavirus',
-          text: 'Rotavirus',
-          behaviourGroup: 'vaccines-included'
+          value: "rotavirus",
+          text: "Rotavirus",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'pneumococcal',
-          text: 'Pneumococcal',
-          behaviourGroup: 'vaccines-included'
+          value: "pneumococcal",
+          text: "Pneumococcal",
+          behaviourGroup: "vaccines-included"
         },
         {
-          value: 'tdipv',
-          text: 'Td/IPV',
-          behaviourGroup: 'vaccines-included'
+          value: "tdipv",
+          text: "Td/IPV",
+          behaviourGroup: "vaccines-included"
         }
       ]
     },
@@ -749,77 +749,77 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'Which vaccines would you like to include?',
-          size: 'l',
+          text: "Which vaccines would you like to include?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'all',
+      idPrefix: "all",
       items: [
         {
-          name: 'vaccines-all',
-          value: 'all',
-          text: 'All 9 vaccines',
-          behaviour: 'inclusive',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-all",
+          value: "all",
+          text: "All 9 vaccines",
+          behaviour: "inclusive",
+          behaviourGroup: "vaccines-included"
         },
         {
-          divider: 'or',
-          behaviour: 'inclusive'
+          divider: "or",
+          behaviour: "inclusive"
         },
         {
-          name: 'vaccines-4in1',
-          value: '4in1',
-          text: '4-in-1 pre-school booster',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-4in1",
+          value: "4in1",
+          text: "4-in-1 pre-school booster",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-6in1',
-          value: '6in1',
-          text: '6-in-1',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-6in1",
+          value: "6in1",
+          text: "6-in-1",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-hpv',
-          value: 'hpv',
-          text: 'HPV',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-hpv",
+          value: "hpv",
+          text: "HPV",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-menb',
-          value: 'menb',
-          text: 'MenB',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-menb",
+          value: "menb",
+          text: "MenB",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-menacwy',
-          value: 'menacwy',
-          text: 'MenACWY',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-menacwy",
+          value: "menacwy",
+          text: "MenACWY",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-mmrv',
-          value: 'mmrv',
-          text: 'MMRV',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-mmrv",
+          value: "mmrv",
+          text: "MMRV",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-rotavirus',
-          value: 'rotavirus',
-          text: 'Rotavirus',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-rotavirus",
+          value: "rotavirus",
+          text: "Rotavirus",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-pneumococcal',
-          value: 'pneumococcal',
-          text: 'Pneumococcal',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-pneumococcal",
+          value: "pneumococcal",
+          text: "Pneumococcal",
+          behaviourGroup: "vaccines-included"
         },
         {
-          name: 'vaccines-tdipv',
-          value: 'tdipv',
-          text: 'Td/IPV',
-          behaviourGroup: 'vaccines-included'
+          name: "vaccines-tdipv",
+          value: "tdipv",
+          text: "Td/IPV",
+          behaviourGroup: "vaccines-included"
         }
       ]
     },
@@ -831,33 +831,33 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'none',
-      name: 'example',
+      idPrefix: "none",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         },
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          value: 'none',
-          text: 'I do not want to be contacted',
-          behaviour: 'exclusive'
+          value: "none",
+          text: "I do not want to be contacted",
+          behaviour: "exclusive"
         }
       ]
     },
@@ -867,32 +867,32 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'none',
-      name: 'example',
+      idPrefix: "none",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         },
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          value: 'none',
-          text: 'I do not want to be contacted',
+          value: "none",
+          text: "I do not want to be contacted",
           exclusive: true
         }
       ]
@@ -902,21 +902,21 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'none',
-      name: 'example',
+      idPrefix: "none",
+      name: "example",
       items: getItems().concat([
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          value: 'none',
-          text: 'I do not want to be contacted',
-          behaviour: 'exclusive'
+          value: "none",
+          text: "I do not want to be contacted",
+          behaviour: "exclusive"
         }
       ])
     },
@@ -926,37 +926,37 @@ const fixtures = {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'none',
-      name: 'example',
+      idPrefix: "none",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email',
-          exclusiveGroup: 'communication-preferences'
+          value: "email",
+          text: "Email",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          value: 'phone',
-          text: 'Phone',
-          exclusiveGroup: 'communication-preferences'
+          value: "phone",
+          text: "Phone",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          value: 'text',
-          text: 'Text message',
-          exclusiveGroup: 'communication-preferences'
+          value: "text",
+          text: "Text message",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          value: 'none',
-          text: 'I do not want to be contacted',
-          behaviour: 'exclusive',
-          exclusiveGroup: 'communication-preferences'
+          value: "none",
+          text: "I do not want to be contacted",
+          behaviour: "exclusive",
+          exclusiveGroup: "communication-preferences"
         }
       ]
     },
@@ -964,48 +964,48 @@ const fixtures = {
       hidden: true
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
   'with "none" option (named group, unique)': {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'none',
-      name: 'example',
+      idPrefix: "none",
+      name: "example",
       items: [
         {
-          name: 'preference-email',
-          value: 'yes',
-          text: 'Email',
-          exclusiveGroup: 'communication-preferences'
+          name: "preference-email",
+          value: "yes",
+          text: "Email",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          name: 'preference-phone',
-          value: 'yes',
-          text: 'Phone',
-          exclusiveGroup: 'communication-preferences'
+          name: "preference-phone",
+          value: "yes",
+          text: "Phone",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          name: 'preference-text',
-          value: 'yes',
-          text: 'Text message',
-          exclusiveGroup: 'communication-preferences'
+          name: "preference-text",
+          value: "yes",
+          text: "Text message",
+          exclusiveGroup: "communication-preferences"
         },
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          name: 'preference-none',
-          value: 'yes',
-          text: 'I do not want to be contacted',
-          behaviour: 'exclusive',
-          exclusiveGroup: 'communication-preferences'
+          name: "preference-none",
+          value: "yes",
+          text: "I do not want to be contacted",
+          behaviour: "exclusive",
+          exclusiveGroup: "communication-preferences"
         }
       ]
     },
@@ -1022,35 +1022,35 @@ const fixtures = {
  * @returns {object[]}
  */
 function getItems(options = {}) {
-  let input1 = inputExamples['example email address']
-  let input2 = inputExamples['example phone number']
-  let input3 = inputExamples['example mobile phone number']
+  let input1 = inputExamples["example email address"]
+  let input2 = inputExamples["example phone number"]
+  let input3 = inputExamples["example mobile phone number"]
 
   // Include error message example (optional)
   if (options.invalid) {
-    input2 = inputExamples['example phone number with error message']
+    input2 = inputExamples["example phone number with error message"]
   }
 
   return [
     {
-      value: 'email',
-      text: 'Email',
+      value: "email",
+      text: "Email",
       conditional: {
-        html: components.render('input', input1)
+        html: components.render("input", input1)
       }
     },
     {
-      value: 'phone',
-      text: 'Phone',
+      value: "phone",
+      text: "Phone",
       conditional: {
-        html: components.render('input', input2)
+        html: components.render("input", input2)
       }
     },
     {
-      value: 'text',
-      text: 'Text message',
+      value: "text",
+      text: "Text message",
       conditional: {
-        html: components.render('input', input3)
+        html: components.render("input", input3)
       }
     }
   ]

--- a/packages/nhsuk-frontend/src/nhsuk/components/code/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/code/fixtures.mjs
@@ -4,99 +4,99 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'This is a plain text code block'
+      text: "This is a plain text code block"
     }
   },
-  'button': {
+  "button": {
     context: {
-      text: 'This is a plain text code block',
+      text: "This is a plain text code block",
       button: true
     },
     variants: [
       {
-        description: 'with primary',
+        description: "with primary",
         context: {
-          copyButtonClassList: ['nhsuk-button--small']
+          copyButtonClassList: ["nhsuk-button--small"]
         }
       },
       {
-        description: 'with secondary'
+        description: "with secondary"
       },
       {
-        description: 'with secondary, solid background',
+        description: "with secondary, solid background",
         context: {
-          background: 'body',
+          background: "body",
           copyButtonClassList: [
-            'nhsuk-button--secondary-solid',
-            'nhsuk-button--small'
+            "nhsuk-button--secondary-solid",
+            "nhsuk-button--small"
           ]
         },
         options: {
-          layout: 'background-white'
+          layout: "background-white"
         }
       }
     ]
   },
-  'with button double click prevented': {
+  "with button double click prevented": {
     context: {
-      text: 'This is a plain text code block',
+      text: "This is a plain text code block",
       button: {
         preventDoubleClick: true
       }
     }
   },
-  'with button double click not prevented': {
+  "with button double click not prevented": {
     context: {
-      text: 'This is a plain text code block',
+      text: "This is a plain text code block",
       button: {
         preventDoubleClick: false
       }
     }
   },
-  'without border': {
+  "without border": {
     context: {
-      text: 'This is a plain text code block',
+      text: "This is a plain text code block",
       border: false
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
-  'with custom HTML': {
+  "with custom HTML": {
     context: {
-      html: '<p>This is an HTML code block.</p>'
+      html: "<p>This is an HTML code block.</p>"
     }
   },
-  'with custom HTML and button': {
+  "with custom HTML and button": {
     context: {
-      html: '<p>This is an HTML code block.</p>',
+      html: "<p>This is an HTML code block.</p>",
       button: true
     }
   },
-  'with custom HTML (escaped) and button': {
+  "with custom HTML (escaped) and button": {
     context: {
       button: true
     },
-    callBlock: '&lt;p&gt;This is a code block.&lt;/p&gt;'
+    callBlock: "&lt;p&gt;This is a code block.&lt;/p&gt;"
   },
-  'with scroll overflow': {
+  "with scroll overflow": {
     context: {
       text: "Supercalifragilisticexpialidocious! Even though the sound of it is something quite atrocious, if you say it loud enough, you'll always sound precocious!"
     }
   },
-  'with scroll overflow and button': {
+  "with scroll overflow and button": {
     context: {
       text: "Supercalifragilisticexpialidocious! Even though the sound of it is something quite atrocious, if you say it loud enough, you'll always sound precocious!",
       button: true
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
-      html: '<p>Bloc cod HTML yw hwn.</p>',
+      html: "<p>Bloc cod HTML yw hwn.</p>",
       button: true,
-      copyButtonText: 'Copïo cod',
+      copyButtonText: "Copïo cod",
       copiedButtonText: "Cod wedi'i gopïo",
       copiedAnnouncementText: "Cod wedi'i gopïo i'r clipfwrdd"
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/contents-list/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/contents-list/fixtures.mjs
@@ -4,79 +4,79 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'What is AMD?',
+          href: "#",
+          text: "What is AMD?",
           current: true
         },
         {
-          href: '#',
-          text: 'Symptoms'
+          href: "#",
+          text: "Symptoms"
         },
         {
-          href: '#',
-          text: 'Getting diagnosed'
+          href: "#",
+          text: "Getting diagnosed"
         },
         {
-          href: '#',
-          text: 'Treatments'
+          href: "#",
+          text: "Treatments"
         },
         {
-          href: '#',
-          text: 'Living with AMD'
+          href: "#",
+          text: "Living with AMD"
         }
       ]
     },
     screenshot: true
   },
-  'with empty items': {
+  "with empty items": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'What is AMD?',
+          href: "#",
+          text: "What is AMD?",
           current: true
         },
         {
-          href: '#',
-          text: 'Symptoms'
+          href: "#",
+          text: "Symptoms"
         },
         false,
         {
-          href: '#',
-          text: 'Treatments'
+          href: "#",
+          text: "Treatments"
         },
         false
       ]
     }
   },
-  'with nested lists': {
+  "with nested lists": {
     context: {
       items: [
         {
-          href: '#',
-          text: 'Chapter 1'
+          href: "#",
+          text: "Chapter 1"
         },
         {
-          href: '#',
-          text: 'Chapter 2',
+          href: "#",
+          text: "Chapter 2",
           items: [
             {
-              href: '#',
-              text: 'Section 2.1'
+              href: "#",
+              text: "Section 2.1"
             },
             {
-              href: '#',
-              text: 'Section 2.2'
+              href: "#",
+              text: "Section 2.2"
             }
           ]
         },
         {
-          href: '#',
-          text: 'Chapter 3'
+          href: "#",
+          text: "Chapter 3"
         }
       ]
     },

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/fixtures.mjs
@@ -4,544 +4,544 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example'
+      id: "example"
     },
     screenshot: true
   },
-  'disabled': {
+  "disabled": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       disabled: true
     },
     screenshot: true
   },
-  'disabled with enabled input': {
+  "disabled with enabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       disabled: true,
       year: {
         disabled: false
       }
     }
   },
-  'disabled input': {
+  "disabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       year: {
         disabled: true
       }
     }
   },
-  'disabled input (using items)': {
+  "disabled input (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2
         },
         {
-          name: 'month',
+          name: "month",
           width: 2
         },
         {
-          name: 'year',
+          name: "year",
           width: 4,
           disabled: true
         }
       ]
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
       fieldset: {
         legend: {
-          text: 'Beth yw eich dyddiad geni?',
-          size: 'l',
+          text: "Beth yw eich dyddiad geni?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Er enghraifft, 31 3 1980'
+        text: "Er enghraifft, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       day: {
         label: {
-          text: 'Dydd'
+          text: "Dydd"
         }
       },
       month: {
         label: {
-          text: 'Mis'
+          text: "Mis"
         }
       },
       year: {
         label: {
-          text: 'Blwyddyn'
+          text: "Blwyddyn"
         }
       }
     }
   },
-  'with values': {
+  "with values": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       values: {
-        day: '5',
-        month: '8',
-        year: '2024'
+        day: "5",
+        month: "8",
+        year: "2024"
       }
     }
   },
-  'day and month': {
+  "day and month": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your birthday?',
-          size: 'l',
+          text: "What is your birthday?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 5 12'
+        text: "For example, 5 12"
       },
-      id: 'example',
+      id: "example",
       year: false
     }
   },
-  'day and month (using items)': {
+  "day and month (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your birthday?',
-          size: 'l',
+          text: "What is your birthday?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 5 12'
+        text: "For example, 5 12"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2
         },
         {
-          name: 'month',
+          name: "month",
           width: 2
         }
       ]
     }
   },
-  'day and month (with empty item)': {
+  "day and month (with empty item)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your birthday?',
-          size: 'l',
+          text: "What is your birthday?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 5 12'
+        text: "For example, 5 12"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2
         },
         {
-          name: 'month',
+          name: "month",
           width: 2
         },
         false
       ]
     }
   },
-  'month and year': {
+  "month and year": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       day: false
     }
   },
-  'month and year (using items)': {
+  "month and year (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'month',
+          name: "month",
           width: 2
         },
         {
-          name: 'year',
+          name: "year",
           width: 4
         }
       ]
     }
   },
-  'month and year (with empty item)': {
+  "month and year (with empty item)": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       items: [
         false,
         {
-          name: 'month',
+          name: "month",
           width: 2
         },
         {
-          name: 'year',
+          name: "year",
           width: 4
         }
       ]
     }
   },
-  'month and year with fields': {
+  "month and year with fields": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       day: false,
       month: {
-        value: '11'
+        value: "11"
       },
       year: {
-        value: '2023'
+        value: "2023"
       }
     }
   },
-  'month and year with fields overriding values': {
+  "month and year with fields overriding values": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       day: false,
       month: {
-        value: '11'
+        value: "11"
       },
       year: {
-        value: '2023'
+        value: "2023"
       },
       values: {
-        month: '8',
-        year: '2024'
+        month: "8",
+        year: "2024"
       }
     }
   },
-  'month and year with values': {
+  "month and year with values": {
     context: {
       fieldset: {
         legend: {
-          text: 'When did you start your job?',
-          size: 'l',
+          text: "When did you start your job?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 11 2023'
+        text: "For example, 11 2023"
       },
-      id: 'example',
+      id: "example",
       day: false,
       values: {
-        month: '8',
-        year: '2024'
+        month: "8",
+        year: "2024"
       }
     }
   },
-  'legend': {
+  "legend": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'custom-size'
+      id: "custom-size"
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           fieldset: {
             legend: {
-              size: 's'
+              size: "s"
             }
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           fieldset: {
             legend: {
-              size: 'm'
+              size: "m"
             }
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           fieldset: {
             legend: {
-              size: 'l'
+              size: "l"
             }
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           fieldset: {
             legend: {
-              size: 'xl'
+              size: "xl"
             }
           }
         }
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?'
+          text: "What is your date of birth?"
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example'
+      id: "example"
     }
   },
-  'with autocomplete values': {
+  "with autocomplete values": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       day: {
-        autocomplete: 'bday-day'
+        autocomplete: "bday-day"
       },
       month: {
-        autocomplete: 'bday-month'
+        autocomplete: "bday-month"
       },
       year: {
-        autocomplete: 'bday-year'
+        autocomplete: "bday-year"
       }
     }
   },
-  'with autocomplete values (using items)': {
+  "with autocomplete values (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2,
-          autocomplete: 'bday-day'
+          autocomplete: "bday-day"
         },
         {
-          name: 'month',
+          name: "month",
           width: 2,
-          autocomplete: 'bday-month'
+          autocomplete: "bday-month"
         },
         {
-          name: 'year',
+          name: "year",
           width: 4,
-          autocomplete: 'bday-year'
+          autocomplete: "bday-year"
         }
       ]
     }
   },
-  'with custom name prefix': {
+  "with custom name prefix": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
-      id: 'example',
-      namePrefix: 'example'
+      id: "example",
+      namePrefix: "example"
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       errorMessage: {
-        text: 'Enter your date of birth'
+        text: "Enter your date of birth"
       },
-      id: 'example'
+      id: "example"
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Enter your date of birth'
+        text: "Enter your date of birth"
       },
-      id: 'example'
+      id: "example"
     },
     screenshot: true
   },
-  'with errors only': {
+  "with errors only": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
-      id: 'example',
+      id: "example",
       day: {
         error: true
       },
@@ -553,215 +553,215 @@ const fixtures = {
       }
     }
   },
-  'with errors only (using items)': {
+  "with errors only (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2,
           error: true
         },
         {
-          name: 'month',
+          name: "month",
           width: 2,
           error: true
         },
         {
-          name: 'year',
+          name: "year",
           width: 4,
           error: true
         }
       ]
     }
   },
-  'with error on day input': {
+  "with error on day input": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a day'
+        text: "Date of birth must include a day"
       },
-      id: 'example',
+      id: "example",
       day: {
         error: true
       },
       month: {
-        value: '3'
+        value: "3"
       },
       year: {
-        value: '1980'
+        value: "1980"
       }
     }
   },
-  'with error on day input (using items)': {
+  "with error on day input (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a day'
+        text: "Date of birth must include a day"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2,
           error: true
         },
         {
-          name: 'month',
-          value: '3',
+          name: "month",
+          value: "3",
           width: 2
         },
         {
-          name: 'year',
-          value: '1980',
+          name: "year",
+          value: "1980",
           width: 4
         }
       ]
     }
   },
-  'with error on month input': {
+  "with error on month input": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a month'
+        text: "Date of birth must include a month"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2,
-          value: '31'
+          value: "31"
         },
         {
-          name: 'month',
+          name: "month",
           width: 2,
           error: true
         },
         {
-          name: 'year',
+          name: "year",
           width: 4,
-          value: '1980'
+          value: "1980"
         }
       ]
     }
   },
-  'with error on month input (using items)': {
+  "with error on month input (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a month'
+        text: "Date of birth must include a month"
       },
-      id: 'example',
+      id: "example",
       day: {
-        value: '31'
+        value: "31"
       },
       month: {
         error: true
       },
       year: {
-        value: '1980'
+        value: "1980"
       }
     }
   },
-  'with error on year input': {
+  "with error on year input": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a year'
+        text: "Date of birth must include a year"
       },
-      id: 'example',
+      id: "example",
       day: {
-        value: '31'
+        value: "31"
       },
       month: {
-        value: '3'
+        value: "3"
       },
       year: {
         error: true
       }
     }
   },
-  'with error on year input (using items)': {
+  "with error on year input (using items)": {
     context: {
       fieldset: {
         legend: {
-          text: 'What is your date of birth?',
-          size: 'l',
+          text: "What is your date of birth?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'For example, 31 3 1980'
+        text: "For example, 31 3 1980"
       },
       errorMessage: {
-        text: 'Date of birth must include a year'
+        text: "Date of birth must include a year"
       },
-      id: 'example',
+      id: "example",
       items: [
         {
-          name: 'day',
+          name: "day",
           width: 2,
-          value: '31'
+          value: "31"
         },
         {
-          name: 'month',
+          name: "month",
           width: 2,
-          value: '3'
+          value: "3"
         },
         {
-          name: 'year',
+          name: "year",
           width: 4,
           error: true
         }

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/fixtures.mjs
@@ -1,8 +1,8 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as tablesExamples } from '../tables/fixtures.mjs'
+import { examples as tablesExamples } from "../tables/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -10,9 +10,9 @@ import { examples as tablesExamples } from '../tables/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      summaryText: 'How to find your NHS number'
+      summaryText: "How to find your NHS number"
     },
     callBlock: outdent`
       <p>An NHS number is a 10 digit number, like <span class="nhsuk-u-nowrap">999 123 4567</span>.</p>
@@ -26,13 +26,13 @@ const fixtures = {
       <p>Ask your GP surgery for help if you cannot find your NHS number.</p>
     `,
     screenshot: {
-      states: ['click'],
-      selector: '.nhsuk-details__summary'
+      states: ["click"],
+      selector: ".nhsuk-details__summary"
     }
   },
-  'open': {
+  "open": {
     context: {
-      summaryText: 'How to find your NHS number',
+      summaryText: "How to find your NHS number",
       open: true
     },
     callBlock: outdent`
@@ -47,27 +47,27 @@ const fixtures = {
       <p>Ask your GP surgery for help if you cannot find your NHS number.</p>
     `
   },
-  'expander': {
+  "expander": {
     context: {
-      summaryText: 'Opening times',
-      classes: 'nhsuk-expander'
+      summaryText: "Opening times",
+      classes: "nhsuk-expander"
     },
     callBlock: outdent`
-      ${components.render('tables', tablesExamples['with first cell as header'])}
+      ${components.render("tables", tablesExamples["with first cell as header"])}
     `,
     screenshot: {
-      states: ['click'],
-      selector: '.nhsuk-details__summary'
+      states: ["click"],
+      selector: ".nhsuk-details__summary"
     }
   },
-  'expander open': {
+  "expander open": {
     context: {
-      summaryText: 'Opening times',
-      classes: 'nhsuk-expander',
+      summaryText: "Opening times",
+      classes: "nhsuk-expander",
       open: true
     },
     callBlock: outdent`
-      ${components.render('tables', tablesExamples['with first cell as header'])}
+      ${components.render("tables", tablesExamples["with first cell as header"])}
     `
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/do-dont-list/fixtures.mjs
@@ -4,72 +4,72 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      title: 'Do',
-      icon: 'tick',
+      title: "Do",
+      icon: "tick",
       items: [
         {
-          text: 'cover blisters with a soft plaster or padded dressing'
+          text: "cover blisters with a soft plaster or padded dressing"
         },
         {
-          text: 'wash your hands before touching a burst blister'
+          text: "wash your hands before touching a burst blister"
         },
         {
-          text: 'allow the fluid in a burst blister to drain before covering it with a plaster or dressing'
+          text: "allow the fluid in a burst blister to drain before covering it with a plaster or dressing"
         }
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  '(do) with empty items': {
+  "(do) with empty items": {
     context: {
-      title: 'Do',
-      icon: 'tick',
+      title: "Do",
+      icon: "tick",
       items: [
         {
-          text: 'cover blisters with a soft plaster or padded dressing'
+          text: "cover blisters with a soft plaster or padded dressing"
         },
         {
-          text: 'wash your hands before touching a burst blister'
+          text: "wash your hands before touching a burst blister"
         },
         false
       ]
     }
   },
-  '(do) with deprecated options': {
+  "(do) with deprecated options": {
     context: {
-      title: 'Do',
-      icon: 'tick',
+      title: "Do",
+      icon: "tick",
       items: [
         {
-          item: 'cover blisters with a soft plaster or padded dressing'
+          item: "cover blisters with a soft plaster or padded dressing"
         },
         {
-          item: 'wash your hands before touching a burst blister'
+          item: "wash your hands before touching a burst blister"
         },
         {
-          item: 'allow the fluid in a burst blister to drain before covering it with a plaster or dressing'
+          item: "allow the fluid in a burst blister to drain before covering it with a plaster or dressing"
         }
       ]
     }
   },
-  '(do) with custom prefix': {
+  "(do) with custom prefix": {
     context: {
-      title: 'Do',
-      icon: 'tick',
-      prefixText: 'always',
+      title: "Do",
+      icon: "tick",
+      prefixText: "always",
       items: [
         {
-          text: 'cover blisters with a soft plaster or padded dressing'
+          text: "cover blisters with a soft plaster or padded dressing"
         },
         {
-          text: 'wash your hands before touching a burst blister'
+          text: "wash your hands before touching a burst blister"
         },
         {
-          text: 'allow the fluid in a burst blister to drain before covering it with a plaster or dressing'
+          text: "allow the fluid in a burst blister to drain before covering it with a plaster or dressing"
         }
       ]
     }
@@ -77,39 +77,39 @@ const fixtures = {
   "(don't)": {
     context: {
       title: "Don't",
-      icon: 'cross',
+      icon: "cross",
       items: [
         {
-          text: 'burst a blister yourself'
+          text: "burst a blister yourself"
         },
         {
-          text: 'peel the skin off a burst blister'
+          text: "peel the skin off a burst blister"
         },
         {
-          text: 'pick at the edges of the remaining skin'
+          text: "pick at the edges of the remaining skin"
         },
         {
-          text: 'wear the shoes or use the equipment that caused your blister until it heals'
+          text: "wear the shoes or use the equipment that caused your blister until it heals"
         }
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
   "(don't) with empty items": {
     context: {
       title: "Don't",
-      icon: 'cross',
+      icon: "cross",
       items: [
         {
-          text: 'burst a blister yourself'
+          text: "burst a blister yourself"
         },
         {
-          text: 'peel the skin off a burst blister'
+          text: "peel the skin off a burst blister"
         },
         {
-          text: 'pick at the edges of the remaining skin'
+          text: "pick at the edges of the remaining skin"
         },
         false
       ]
@@ -118,40 +118,40 @@ const fixtures = {
   "(don't) with deprecated options": {
     context: {
       title: "Don't",
-      icon: 'cross',
+      icon: "cross",
       items: [
         {
-          item: 'burst a blister yourself'
+          item: "burst a blister yourself"
         },
         {
-          item: 'peel the skin off a burst blister'
+          item: "peel the skin off a burst blister"
         },
         {
-          item: 'pick at the edges of the remaining skin'
+          item: "pick at the edges of the remaining skin"
         },
         {
-          item: 'wear the shoes or use the equipment that caused your blister until it heals'
+          item: "wear the shoes or use the equipment that caused your blister until it heals"
         }
       ]
     }
   },
   "(don't) with custom prefix": {
     context: {
-      title: 'Never',
-      icon: 'cross',
-      prefixText: 'never',
+      title: "Never",
+      icon: "cross",
+      prefixText: "never",
       items: [
         {
-          text: 'burst a blister yourself'
+          text: "burst a blister yourself"
         },
         {
-          text: 'peel the skin off a burst blister'
+          text: "peel the skin off a burst blister"
         },
         {
-          text: 'pick at the edges of the remaining skin'
+          text: "pick at the edges of the remaining skin"
         },
         {
-          text: 'wear the shoes or use the equipment that caused your blister until it heals'
+          text: "wear the shoes or use the equipment that caused your blister until it heals"
         }
       ]
     }
@@ -159,17 +159,17 @@ const fixtures = {
   "(don't) with hidden prefix": {
     context: {
       title: "Don't",
-      icon: 'cross',
+      icon: "cross",
       hidePrefix: true,
       items: [
         {
-          text: 'avoid bursting a blister yourself'
+          text: "avoid bursting a blister yourself"
         },
         {
           text: "certainly don't peel the skin off a burst blister"
         },
         {
-          text: 'absolutely do not pick at the edges of the remaining skin'
+          text: "absolutely do not pick at the edges of the remaining skin"
         },
         {
           text: "please don't wear the shoes or use the equipment that caused your blister until it heals"

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-message/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-message/fixtures.mjs
@@ -4,37 +4,37 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'Enter your full name'
+      text: "Enter your full name"
     },
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'with text escaping': {
+  "with text escaping": {
     context: {
-      text: 'Postcode must not include & and <'
+      text: "Postcode must not include & and <"
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      html: 'Postcode must not include &amp; and &lt;'
+      html: "Postcode must not include &amp; and &lt;"
     }
   },
-  'with HTML via call block': {
-    callBlock: 'Postcode must not include &amp; and &lt;'
+  "with HTML via call block": {
+    callBlock: "Postcode must not include &amp; and &lt;"
   },
-  'with translations': {
+  "with translations": {
     context: {
-      text: 'Rhowch eich enw llawn',
-      visuallyHiddenText: 'Gwall'
+      text: "Rhowch eich enw llawn",
+      visuallyHiddenText: "Gwall"
     }
   },
-  'without visually hidden text': {
+  "without visually hidden text": {
     context: {
-      text: 'There is an error on line 42',
-      visuallyHiddenText: ''
+      text: "There is an error on line 42",
+      visuallyHiddenText: ""
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/fixtures.mjs
@@ -4,134 +4,134 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ]
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-error-summary a'
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-error-summary a"
     }
   },
-  'with multiple errors': {
+  "with multiple errors": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Enter your first name',
-          href: '#example-first-name'
+          text: "Enter your first name",
+          href: "#example-first-name"
         },
         {
-          text: 'Enter your last name',
-          href: '#example-last-name'
+          text: "Enter your last name",
+          href: "#example-last-name"
         }
       ]
     }
   },
-  'with multiple errors (empty items)': {
+  "with multiple errors (empty items)": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Enter your first name',
-          href: '#example-first-name'
+          text: "Enter your first name",
+          href: "#example-first-name"
         },
         false
       ]
     }
   },
-  'with title HTML': {
+  "with title HTML": {
     context: {
-      titleHtml: 'There is a <span>problem</span>',
+      titleHtml: "There is a <span>problem</span>",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ]
     }
   },
-  'with description': {
+  "with description": {
     context: {
-      titleText: 'There is a problem',
-      descriptionText: 'Describe the errors and how to correct them',
+      titleText: "There is a problem",
+      descriptionText: "Describe the errors and how to correct them",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ]
     },
     screenshot: true
   },
-  'with description HTML': {
+  "with description HTML": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       descriptionHtml:
-        'Describe the errors and <span>how to correct them</span>',
+        "Describe the errors and <span>how to correct them</span>",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ]
     }
   },
-  'with description via call block': {
+  "with description via call block": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ]
     },
-    callBlock: 'Describe the errors and <span>how to correct them</span>'
+    callBlock: "Describe the errors and <span>how to correct them</span>"
   },
-  'with description only': {
+  "with description only": {
     context: {
-      titleText: 'There is a problem',
-      descriptionText: 'Describe the errors and how to correct them'
+      titleText: "There is a problem",
+      descriptionText: "Describe the errors and how to correct them"
     }
   },
-  'without error link': {
+  "without error link": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Invalid username or password'
+          text: "Invalid username or password"
         }
       ]
     }
   },
-  'without error link (mixed)': {
+  "without error link (mixed)": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Invalid username or password'
+          text: "Invalid username or password"
         },
         {
-          text: 'Agree to the terms of service to log in',
-          href: '#example-terms-of-service'
+          text: "Agree to the terms of service to log in",
+          href: "#example-terms-of-service"
         }
       ]
     }
   },
-  'auto-focus disabled': {
+  "auto-focus disabled": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ],
       disableAutoFocus: true
@@ -140,13 +140,13 @@ const fixtures = {
       hidden: true
     }
   },
-  'auto-focus explicitly enabled': {
+  "auto-focus explicitly enabled": {
     context: {
-      titleText: 'There is a problem',
+      titleText: "There is a problem",
       errorList: [
         {
-          text: 'Date of birth must be in the past',
-          href: '#example-day'
+          text: "Date of birth must be in the past",
+          href: "#example-day"
         }
       ],
       disableAutoFocus: false

--- a/packages/nhsuk-frontend/src/nhsuk/components/fieldset/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/fieldset/fixtures.mjs
@@ -1,8 +1,8 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as inputExamples } from '../input/fixtures.mjs'
+import { examples as inputExamples } from "../input/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -10,47 +10,47 @@ import { examples as inputExamples } from '../input/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       legend: {
-        text: 'What is your address?',
-        size: 'l',
+        text: "What is your address?",
+        size: "l",
         isPageHeading: true
       }
     },
     screenshot: true
   },
-  'with HTML': {
+  "with HTML": {
     context: {
       legend: {
-        text: 'What is your address?',
-        size: 'l',
+        text: "What is your address?",
+        size: "l",
         isPageHeading: true
       },
       html: outdent`
-        ${components.render('input', inputExamples['example address line 1'])}
-        ${components.render('input', inputExamples['example address line 2'])}
-        ${components.render('input', inputExamples['example address town or city'])}
-        ${components.render('input', inputExamples['example address postcode'])}
+        ${components.render("input", inputExamples["example address line 1"])}
+        ${components.render("input", inputExamples["example address line 2"])}
+        ${components.render("input", inputExamples["example address town or city"])}
+        ${components.render("input", inputExamples["example address postcode"])}
       `
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
       legend: {
-        text: 'What is your address?',
-        size: 'l',
+        text: "What is your address?",
+        size: "l",
         isPageHeading: true
       }
     },
     callBlock: outdent`
-      ${components.render('input', inputExamples['example address line 1'])}
-      ${components.render('input', inputExamples['example address line 2'])}
-      ${components.render('input', inputExamples['example address town or city'])}
-      ${components.render('input', inputExamples['example address postcode'])}
+      ${components.render("input", inputExamples["example address line 1"])}
+      ${components.render("input", inputExamples["example address line 2"])}
+      ${components.render("input", inputExamples["example address town or city"])}
+      ${components.render("input", inputExamples["example address postcode"])}
     `
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/file-upload/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/file-upload/fixtures.mjs
@@ -4,131 +4,131 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload',
+      id: "file-upload",
+      name: "file-upload",
       disabled: true
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Upload your photo',
-        size: 'l',
+        text: "Upload your photo",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder'
+        text: "Your photo may be in your Pictures, Photos, Downloads or Desktop folder"
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'The selected file must be a JPG, BMP or TIF'
+        text: "The selected file must be a JPG, BMP or TIF"
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload',
+      id: "file-upload",
+      name: "file-upload",
       hint: {
-        text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder'
+        text: "Your photo may be in your Pictures, Photos, Downloads or Desktop folder"
       },
       errorMessage: {
-        text: 'The selected file must be a JPG, BMP or TIF'
+        text: "The selected file must be a JPG, BMP or TIF"
       }
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'label': {
+  "label": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           label: {
-            size: 's'
+            size: "s"
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           label: {
-            size: 'm'
+            size: "m"
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           label: {
-            size: 'l'
+            size: "l"
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           label: {
-            size: 'xl'
+            size: "xl"
           }
         }
       },
       {
-        description: 'with id attribute on',
+        description: "with id attribute on",
         context: {
           label: {
-            id: 'custom-id'
+            id: "custom-id"
           }
         },
         options: {
@@ -137,76 +137,76 @@ const fixtures = {
       }
     ]
   },
-  'button': {
+  "button": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     },
     variants: [
       {
-        description: 'with primary',
+        description: "with primary",
         context: {
           chooseFilesButtonClassList: []
         }
       },
       {
-        description: 'with small primary',
+        description: "with small primary",
         context: {
-          chooseFilesButtonClassList: ['nhsuk-button--small']
+          chooseFilesButtonClassList: ["nhsuk-button--small"]
         }
       },
       {
-        description: 'with small secondary',
+        description: "with small secondary",
         context: {
           chooseFilesButtonClassList: [
-            'nhsuk-button--secondary',
-            'nhsuk-button--small'
+            "nhsuk-button--secondary",
+            "nhsuk-button--small"
           ]
         }
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Upload a file'
+        text: "Upload a file"
       },
-      id: 'file-upload',
-      name: 'file-upload'
+      id: "file-upload",
+      name: "file-upload"
     }
   },
-  'with multiple': {
+  "with multiple": {
     context: {
       label: {
-        text: 'Upload multiple files',
-        size: 'l',
+        text: "Upload multiple files",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload',
+      id: "file-upload",
+      name: "file-upload",
       multiple: true,
-      chooseFilesButtonText: 'Choose files',
-      dropInstructionText: 'or drop files',
-      noFileChosenText: 'No files chosen'
+      chooseFilesButtonText: "Choose files",
+      dropInstructionText: "or drop files",
+      noFileChosenText: "No files chosen"
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
       label: {
-        text: 'Llwythwch ffeil i fyny',
-        size: 'l',
+        text: "Llwythwch ffeil i fyny",
+        size: "l",
         isPageHeading: true
       },
-      id: 'file-upload',
-      name: 'file-upload',
+      id: "file-upload",
+      name: "file-upload",
       multiple: true,
-      chooseFilesButtonText: 'Dewiswch ffeil',
-      dropInstructionText: 'neu ollwng ffeil',
+      chooseFilesButtonText: "Dewiswch ffeil",
+      dropInstructionText: "neu ollwng ffeil",
       noFileChosenText: "Dim ffeil wedi'i dewis",
       multipleFilesChosenText: {
         other: "%{count} ffeil wedi'u dewis",
@@ -216,15 +216,15 @@ const fixtures = {
       leftDropZoneText: "Parth gollwng i'r chwith"
     }
   },
-  'to configure in JavaScript': {
+  "to configure in JavaScript": {
     context: {
       label: {
-        text: 'Upload a file',
-        size: 'l',
+        text: "Upload a file",
+        size: "l",
         isPageHeading: true
       },
-      id: 'to-configure-in-javascript',
-      name: 'file-upload'
+      id: "to-configure-in-javascript",
+      name: "file-upload"
     },
     options: {
       hidden: true

--- a/packages/nhsuk-frontend/src/nhsuk/components/footer/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/footer/fixtures.mjs
@@ -1,4 +1,4 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
 /**
  * Nunjucks macro option examples
@@ -6,29 +6,29 @@ import { outdent } from 'outdent'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       meta: {
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Contact us'
+            href: "#",
+            text: "Contact us"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           },
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -37,38 +37,38 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with copyright text only': {
+  "with copyright text only": {
     options: {
       width: false
     }
   },
-  'with custom copyright text': {
+  "with custom copyright text": {
     context: {
       copyright: {
-        text: '© East London NHS Foundation Trust'
+        text: "© East London NHS Foundation Trust"
       }
     },
     options: {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with meta text': {
+  "with meta text": {
     context: {
       meta: {
-        text: 'NHS prototype kit v8.0.0'
+        text: "NHS prototype kit v8.0.0"
       }
     },
     options: {
       width: false
     }
   },
-  'with meta HTML': {
+  "with meta HTML": {
     context: {
       meta: {
         html: '<p class="nhsuk-body-s">NHS prototype kit v8.0.0</p>'
@@ -78,35 +78,35 @@ const fixtures = {
       width: false
     }
   },
-  'with meta HTML via call block': {
+  "with meta HTML via call block": {
     callBlock: '<p class="nhsuk-body-s">NHS prototype kit v8.0.0</p>',
     options: {
       width: false
     }
   },
-  'with meta links': {
+  "with meta links": {
     context: {
       meta: {
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Contact us'
+            href: "#",
+            text: "Contact us"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           },
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -115,36 +115,36 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with meta links and text': {
+  "with meta links and text": {
     context: {
       copyright: {
-        text: '© Crown copyright'
+        text: "© Crown copyright"
       },
       meta: {
-        text: 'All content is available under the Open Government Licence v3.0, except where otherwise stated.',
+        text: "All content is available under the Open Government Licence v3.0, except where otherwise stated.",
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Contact us'
+            href: "#",
+            text: "Contact us"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           },
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -153,13 +153,13 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with meta links and HTML': {
+  "with meta links and HTML": {
     context: {
       copyright: {
-        text: ''
+        text: ""
       },
       meta: {
         html: outdent`
@@ -168,24 +168,24 @@ const fixtures = {
         `,
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Contact us'
+            href: "#",
+            text: "Contact us"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           },
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -194,29 +194,29 @@ const fixtures = {
       width: false
     }
   },
-  'with single navigation group': {
+  "with single navigation group": {
     context: {
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Contact us'
+            href: "#",
+            text: "Contact us"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           },
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -225,26 +225,26 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with single navigation group (empty items)': {
+  "with single navigation group (empty items)": {
     context: {
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           false,
           false,
           {
-            href: '#',
-            text: 'Privacy policy'
+            href: "#",
+            text: "Privacy policy"
           },
           {
-            href: '#',
-            text: 'Terms and conditions'
+            href: "#",
+            text: "Terms and conditions"
           }
         ]
       }
@@ -253,113 +253,113 @@ const fixtures = {
       width: false
     }
   },
-  'with multiple navigation groups': {
+  "with multiple navigation groups": {
     context: {
       copyright: {
-        text: '© Crown copyright'
+        text: "© Crown copyright"
       },
       navigation: [
         {
           items: [
             {
-              href: '#',
-              text: 'Home'
+              href: "#",
+              text: "Home"
             },
             {
-              href: '#',
-              text: 'Health A to Z'
+              href: "#",
+              text: "Health A to Z"
             },
             {
-              href: '#',
-              text: 'NHS services'
+              href: "#",
+              text: "NHS services"
             },
             {
-              href: '#',
-              text: 'Live Well'
+              href: "#",
+              text: "Live Well"
             },
             {
-              href: '#',
-              text: 'Mental health'
+              href: "#",
+              text: "Mental health"
             },
             {
-              href: '#',
-              text: 'Care and support'
+              href: "#",
+              text: "Care and support"
             },
             {
-              href: '#',
-              text: 'Accessibility statement'
+              href: "#",
+              text: "Accessibility statement"
             },
             {
-              href: '#',
-              text: 'Pregnancy'
+              href: "#",
+              text: "Pregnancy"
             },
             {
-              href: '#',
-              text: 'COVID-19'
+              href: "#",
+              text: "COVID-19"
             }
           ]
         },
         {
           items: [
             {
-              href: '#',
-              text: 'NHS App'
+              href: "#",
+              text: "NHS App"
             },
             {
-              href: '#',
-              text: 'Find my NHS number'
+              href: "#",
+              text: "Find my NHS number"
             },
             {
-              href: '#',
-              text: 'View your GP health records'
+              href: "#",
+              text: "View your GP health records"
             },
             {
-              href: '#',
-              text: 'View your test results'
+              href: "#",
+              text: "View your test results"
             },
             {
-              href: '#',
-              text: 'About the NHS'
+              href: "#",
+              text: "About the NHS"
             },
             {
-              href: '#',
-              text: 'Healthcare abroad'
+              href: "#",
+              text: "Healthcare abroad"
             }
           ]
         },
         {
           items: [
             {
-              href: '#',
-              text: 'Other NHS websites'
+              href: "#",
+              text: "Other NHS websites"
             },
             {
-              href: '#',
-              text: 'Profile editor login'
+              href: "#",
+              text: "Profile editor login"
             }
           ]
         },
         {
           items: [
             {
-              href: '#',
-              text: 'About us'
+              href: "#",
+              text: "About us"
             },
             {
-              href: '#',
-              text: 'Give us feedback'
+              href: "#",
+              text: "Give us feedback"
             },
             {
-              href: '#',
-              text: 'Accessibility statement'
+              href: "#",
+              text: "Accessibility statement"
             },
             {
-              href: '#',
-              text: 'Our policies'
+              href: "#",
+              text: "Our policies"
             },
             {
-              href: '#',
-              text: 'Cookies'
+              href: "#",
+              text: "Cookies"
             }
           ]
         }
@@ -369,52 +369,52 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with multiple navigation groups and custom HTML': {
+  "with multiple navigation groups and custom HTML": {
     context: {
       copyright: {
-        text: '© 2025 – Manchester University NHS Foundation Trust'
+        text: "© 2025 – Manchester University NHS Foundation Trust"
       },
       columns: 3,
       navigation: [
         {
-          width: 'one-quarter',
+          width: "one-quarter",
           items: [
             {
-              href: '#',
-              text: 'About us'
+              href: "#",
+              text: "About us"
             },
             {
-              href: '#',
-              text: 'Give us feedback'
+              href: "#",
+              text: "Give us feedback"
             },
             {
-              href: '#',
-              text: 'Accessibility statement'
+              href: "#",
+              text: "Accessibility statement"
             }
           ]
         },
         {
-          width: 'one-quarter',
+          width: "one-quarter",
           items: [
             {
-              href: '#',
-              text: 'Cookies'
+              href: "#",
+              text: "Cookies"
             },
             {
-              href: '#',
-              text: 'Privacy policy'
+              href: "#",
+              text: "Privacy policy"
             },
             {
-              href: '#',
-              text: 'Terms and conditions'
+              href: "#",
+              text: "Terms and conditions"
             }
           ]
         },
         {
-          width: 'one-half',
+          width: "one-half",
           html: outdent`
             <p class="nhsuk-body-s nhsuk-u-margin-bottom-6"><strong>Manchester
             University NHS Foundation Trust (MFT)</strong> was formed on 1st
@@ -424,7 +424,7 @@ const fixtures = {
           `
         },
         {
-          width: 'full',
+          width: "full",
           html: outdent`
             <p class="nhsuk-body-s">Cobbett House, Manchester University NHS
             Foundation Trust, Oxford Road, Manchester, M13 9WL</p>
@@ -436,57 +436,57 @@ const fixtures = {
       width: false
     }
   },
-  'with multiple titled navigation groups': {
+  "with multiple titled navigation groups": {
     context: {
       navigation: [
         {
-          title: 'Legal',
+          title: "Legal",
           items: [
             {
-              href: '#',
-              text: 'Looking after your data'
+              href: "#",
+              text: "Looking after your data"
             },
             {
-              href: '#',
-              text: 'Freedom of information'
+              href: "#",
+              text: "Freedom of information"
             },
             {
-              href: '#',
-              text: 'Modern Slavery and human trafficking statement'
+              href: "#",
+              text: "Modern Slavery and human trafficking statement"
             }
           ]
         },
         {
-          title: 'Get in touch',
+          title: "Get in touch",
           items: [
             {
-              href: '#',
-              text: 'Contact us'
+              href: "#",
+              text: "Contact us"
             },
             {
-              href: '#',
-              text: 'Press office'
+              href: "#",
+              text: "Press office"
             },
             {
-              href: '#',
-              text: 'Tell us what you think of our website'
+              href: "#",
+              text: "Tell us what you think of our website"
             },
             {
-              href: '#',
-              text: 'RSS feeds'
+              href: "#",
+              text: "RSS feeds"
             }
           ]
         },
         {
-          title: 'Follow us',
+          title: "Follow us",
           items: [
             {
-              href: '#',
-              text: 'LinkedIn'
+              href: "#",
+              text: "LinkedIn"
             },
             {
-              href: '#',
-              text: 'YouTube'
+              href: "#",
+              text: "YouTube"
             }
           ]
         }
@@ -496,88 +496,88 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with meta and navigation': {
+  "with meta and navigation": {
     context: {
       copyright: {
-        text: '© Crown copyright'
+        text: "© Crown copyright"
       },
       navigation: [
         {
           items: [
             {
-              href: '#',
-              text: 'Home'
+              href: "#",
+              text: "Home"
             },
             {
-              href: '#',
-              text: 'Health A to Z'
+              href: "#",
+              text: "Health A to Z"
             },
             {
-              href: '#',
-              text: 'Live Well'
+              href: "#",
+              text: "Live Well"
             },
             {
-              href: '#',
-              text: 'Mental health'
+              href: "#",
+              text: "Mental health"
             },
             {
-              href: '#',
-              text: 'Care and support'
+              href: "#",
+              text: "Care and support"
             },
             {
-              href: '#',
-              text: 'Accessibility statement'
+              href: "#",
+              text: "Accessibility statement"
             },
             {
-              href: '#',
-              text: 'Pregnancy'
+              href: "#",
+              text: "Pregnancy"
             },
             {
-              href: '#',
-              text: 'NHS services'
+              href: "#",
+              text: "NHS services"
             },
             {
-              href: '#',
-              text: 'Coronavirus (COVID-19)'
+              href: "#",
+              text: "Coronavirus (COVID-19)"
             }
           ]
         },
         {
           items: [
             {
-              href: '#',
-              text: 'NHS App'
+              href: "#",
+              text: "NHS App"
             },
             {
-              href: '#',
-              text: 'Find my NHS number'
+              href: "#",
+              text: "Find my NHS number"
             },
             {
-              href: '#',
-              text: 'Your health records'
+              href: "#",
+              text: "Your health records"
             },
             {
-              href: '#',
-              text: 'About the NHS'
+              href: "#",
+              text: "About the NHS"
             },
             {
-              href: '#',
-              text: 'Healthcare abroad'
+              href: "#",
+              text: "Healthcare abroad"
             }
           ]
         },
         {
           items: [
             {
-              href: '#',
-              text: 'Other NHS websites'
+              href: "#",
+              text: "Other NHS websites"
             },
             {
-              href: '#',
-              text: 'Profile editor login'
+              href: "#",
+              text: "Profile editor login"
             }
           ]
         }
@@ -593,24 +593,24 @@ const fixtures = {
         `,
         items: [
           {
-            href: '#',
-            text: 'About us'
+            href: "#",
+            text: "About us"
           },
           {
-            href: '#',
-            text: 'Give us feedback'
+            href: "#",
+            text: "Give us feedback"
           },
           {
-            href: '#',
-            text: 'Accessibility statement'
+            href: "#",
+            text: "Accessibility statement"
           },
           {
-            href: '#',
-            text: 'Our policies'
+            href: "#",
+            text: "Our policies"
           },
           {
-            href: '#',
-            text: 'Cookies'
+            href: "#",
+            text: "Cookies"
           }
         ]
       }
@@ -619,7 +619,7 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/fixtures.mjs
@@ -5,12 +5,12 @@
  */
 export const variants = [
   {
-    description: 'blue'
+    description: "blue"
   },
   {
-    description: 'white',
+    description: "white",
     context: {
-      colour: 'white'
+      colour: "white"
     }
   }
 ]
@@ -21,40 +21,40 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       service: {
-        text: 'Digital service manual',
-        href: '#'
+        text: "Digital service manual",
+        href: "#"
       },
       search: {
-        placeholder: 'Search',
-        visuallyHiddenLabel: 'Search the NHS digital service manual'
+        placeholder: "Search",
+        visuallyHiddenLabel: "Search the NHS digital service manual"
       },
       navigation: {
         items: [
           {
-            text: 'NHS service standard',
-            href: '#'
+            text: "NHS service standard",
+            href: "#"
           },
           {
-            text: 'Design system',
-            href: '#'
+            text: "Design system",
+            href: "#"
           },
           {
-            text: 'Content guide',
-            href: '#'
+            text: "Content guide",
+            href: "#"
           },
           {
-            text: 'Accessibility',
-            href: '#'
+            text: "Accessibility",
+            href: "#"
           },
           {
-            text: 'Community and contribution',
-            href: '#'
+            text: "Community and contribution",
+            href: "#"
           }
         ]
       }
@@ -63,13 +63,13 @@ const fixtures = {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'linked logo': {
+  "linked logo": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       }
     },
     options: {
@@ -77,29 +77,29 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      states: ['hover', 'focus'],
-      selector: '.nhsuk-header__service-logo',
-      viewports: ['desktop']
+      states: ["hover", "focus"],
+      selector: ".nhsuk-header__service-logo",
+      viewports: ["desktop"]
     }
   },
-  'unlinked logo': {
+  "unlinked logo": {
     options: {
       width: false
     },
     variants
   },
-  'with account (logged in)': {
+  "with account (logged in)": {
     context: {
       account: {
         items: [
           {
-            href: '#',
-            text: 'florence.nightingale@nhs.net',
+            href: "#",
+            text: "florence.nightingale@nhs.net",
             icon: true
           },
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       }
@@ -109,25 +109,25 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'desktop']
+      viewports: ["mobile", "desktop"]
     }
   },
-  'with account inline (logged in)': {
+  "with account inline (logged in)": {
     context: {
       inline: true,
       logo: {
-        href: '#'
+        href: "#"
       },
       account: {
         items: [
           {
-            href: '#',
-            text: 'Account',
+            href: "#",
+            text: "Account",
             icon: true
           },
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       }
@@ -137,13 +137,13 @@ const fixtures = {
     },
     variants
   },
-  'with account (logged out)': {
+  "with account (logged out)": {
     context: {
       account: {
         items: [
           {
-            href: '#',
-            text: 'Log in'
+            href: "#",
+            text: "Log in"
           }
         ]
       }
@@ -153,20 +153,20 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'desktop']
+      viewports: ["mobile", "desktop"]
     }
   },
-  'with account inline (logged out)': {
+  "with account inline (logged out)": {
     context: {
       inline: true,
       logo: {
-        href: '#'
+        href: "#"
       },
       account: {
         items: [
           {
-            href: '#',
-            text: 'Log in'
+            href: "#",
+            text: "Log in"
           }
         ]
       }
@@ -176,37 +176,37 @@ const fixtures = {
     },
     variants
   },
-  'with navigation': {
+  "with navigation": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Health A to Z'
+            href: "#",
+            text: "Health A to Z"
           },
           {
-            href: '#',
-            text: 'Live Well'
+            href: "#",
+            text: "Live Well"
           },
           {
-            href: '#',
-            text: 'Mental health'
+            href: "#",
+            text: "Mental health"
           },
           {
-            href: '#',
-            text: 'Care and support'
+            href: "#",
+            text: "Care and support"
           },
           {
-            href: '#',
-            text: 'Pregnancy',
+            href: "#",
+            text: "Pregnancy",
             active: true
           },
           {
-            href: '#',
-            text: 'NHS services'
+            href: "#",
+            text: "NHS services"
           }
         ]
       }
@@ -216,36 +216,36 @@ const fixtures = {
     },
     variants
   },
-  'with navigation (unlinked item)': {
+  "with navigation (unlinked item)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Health A to Z'
+            href: "#",
+            text: "Health A to Z"
           },
           {
-            href: '#',
-            text: 'Live Well'
+            href: "#",
+            text: "Live Well"
           },
           {
-            href: '#',
-            text: 'Mental health'
+            href: "#",
+            text: "Mental health"
           },
           {
-            href: '#',
-            text: 'Care and support'
+            href: "#",
+            text: "Care and support"
           },
           {
-            text: 'Pregnancy',
+            text: "Pregnancy",
             current: true
           },
           {
-            href: '#',
-            text: 'NHS services'
+            href: "#",
+            text: "NHS services"
           }
         ]
       }
@@ -255,39 +255,39 @@ const fixtures = {
     },
     variants
   },
-  'with navigation (empty items)': {
+  "with navigation (empty items)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       account: {
         items: [
           {
-            href: '#',
-            text: 'Account',
+            href: "#",
+            text: "Account",
             icon: true
           },
           false,
           false,
           false,
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       },
       navigation: {
         items: [
           {
-            text: 'Home',
-            href: '/'
+            text: "Home",
+            href: "/"
           },
           false,
           false,
           false,
           {
-            text: 'Reports',
-            href: '/'
+            text: "Reports",
+            href: "/"
           }
         ]
       }
@@ -297,38 +297,38 @@ const fixtures = {
     },
     variants
   },
-  'with navigation (justified)': {
+  "with navigation (justified)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       navigation: {
         justified: true,
         items: [
           {
-            href: '#',
-            text: 'Health A to Z'
+            href: "#",
+            text: "Health A to Z"
           },
           {
-            href: '#',
-            text: 'Live Well'
+            href: "#",
+            text: "Live Well"
           },
           {
-            href: '#',
-            text: 'Mental health'
+            href: "#",
+            text: "Mental health"
           },
           {
-            href: '#',
-            text: 'Care and support'
+            href: "#",
+            text: "Care and support"
           },
           {
-            href: '#',
-            text: 'Pregnancy',
+            href: "#",
+            text: "Pregnancy",
             active: true
           },
           {
-            href: '#',
-            text: 'NHS services'
+            href: "#",
+            text: "NHS services"
           }
         ]
       }
@@ -338,56 +338,56 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with navigation (overflow)': {
+  "with navigation (overflow)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       service: {
-        text: 'Digital service manual',
-        href: '#'
+        text: "Digital service manual",
+        href: "#"
       },
       search: {
-        placeholder: 'Search',
-        visuallyHiddenLabel: 'Search the NHS digital service manual'
+        placeholder: "Search",
+        visuallyHiddenLabel: "Search the NHS digital service manual"
       },
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Health A to Z'
+            href: "#",
+            text: "Health A to Z"
           },
           {
-            href: '#',
-            text: 'Live Well'
+            href: "#",
+            text: "Live Well"
           },
           {
-            href: '#',
-            text: 'Mental health'
+            href: "#",
+            text: "Mental health"
           },
           {
-            href: '#',
-            text: 'Care and support'
+            href: "#",
+            text: "Care and support"
           },
           {
-            href: '#',
-            text: 'Pregnancy',
+            href: "#",
+            text: "Pregnancy",
             active: true
           },
           {
-            href: '#',
-            text: 'NHS services'
+            href: "#",
+            text: "NHS services"
           },
           {
-            href: '#',
-            text: 'Another item #1'
+            href: "#",
+            text: "Another item #1"
           },
           {
-            href: '#',
-            text: 'Another item #2'
+            href: "#",
+            text: "Another item #2"
           }
         ]
       }
@@ -397,66 +397,66 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      name: 'menu',
-      states: ['click'],
-      selector: '#toggle-menu',
+      name: "menu",
+      states: ["click"],
+      selector: "#toggle-menu",
       viewports: [
-        'mobile',
-        'tablet',
-        'desktop',
-        'large-desktop',
-        'xlarge-desktop'
+        "mobile",
+        "tablet",
+        "desktop",
+        "large-desktop",
+        "xlarge-desktop"
       ]
     }
   },
-  'with navigation (overflow, white)': {
+  "with navigation (overflow, white)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       service: {
-        text: 'Digital service manual',
-        href: '#'
+        text: "Digital service manual",
+        href: "#"
       },
       search: {
-        placeholder: 'Search',
-        visuallyHiddenLabel: 'Search the NHS digital service manual'
+        placeholder: "Search",
+        visuallyHiddenLabel: "Search the NHS digital service manual"
       },
       navigation: {
-        colour: 'white',
+        colour: "white",
         items: [
           {
-            href: '#',
-            text: 'Health A to Z'
+            href: "#",
+            text: "Health A to Z"
           },
           {
-            href: '#',
-            text: 'Live Well'
+            href: "#",
+            text: "Live Well"
           },
           {
-            href: '#',
-            text: 'Mental health'
+            href: "#",
+            text: "Mental health"
           },
           {
-            href: '#',
-            text: 'Care and support'
+            href: "#",
+            text: "Care and support"
           },
           {
-            href: '#',
-            text: 'Pregnancy',
+            href: "#",
+            text: "Pregnancy",
             active: true
           },
           {
-            href: '#',
-            text: 'NHS services'
+            href: "#",
+            text: "NHS services"
           },
           {
-            href: '#',
-            text: 'Another item #1'
+            href: "#",
+            text: "Another item #1"
           },
           {
-            href: '#',
-            text: 'Another item #2'
+            href: "#",
+            text: "Another item #2"
           }
         ]
       }
@@ -466,10 +466,10 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with search': {
+  "with search": {
     context: {
       search: true
     },
@@ -478,12 +478,12 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      states: ['focus'],
-      selector: '.nhsuk-header__search-form .nhsuk-input',
-      viewports: ['desktop']
+      states: ["focus"],
+      selector: ".nhsuk-header__search-form .nhsuk-input",
+      viewports: ["desktop"]
     }
   },
-  'with search inline': {
+  "with search inline": {
     context: {
       inline: true,
       search: true
@@ -493,13 +493,13 @@ const fixtures = {
     },
     variants
   },
-  'with service name': {
+  "with service name": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       service: {
-        text: 'Find your NHS number'
+        text: "Find your NHS number"
       }
     },
     options: {
@@ -507,17 +507,17 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with service name as separate link': {
+  "with service name as separate link": {
     context: {
       logo: {
-        href: '#/logo'
+        href: "#/logo"
       },
       service: {
-        text: 'Find your NHS number',
-        href: '#/service'
+        text: "Find your NHS number",
+        href: "#/service"
       }
     },
     options: {
@@ -525,18 +525,18 @@ const fixtures = {
     },
     variants
   },
-  'with service name, account inline (logged in)': {
+  "with service name, account inline (logged in)": {
     context: {
       inline: true,
       service: {
-        text: 'Get a self-test kit for HIV',
-        href: '#'
+        text: "Get a self-test kit for HIV",
+        href: "#"
       },
       account: {
         items: [
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       }
@@ -546,18 +546,18 @@ const fixtures = {
     },
     variants
   },
-  'with service name, account inline (logged out)': {
+  "with service name, account inline (logged out)": {
     context: {
       inline: true,
       service: {
-        text: 'Get a self-test kit for HIV',
-        href: '#'
+        text: "Get a self-test kit for HIV",
+        href: "#"
       },
       account: {
         items: [
           {
-            action: '#',
-            text: 'Log in'
+            action: "#",
+            text: "Log in"
           }
         ]
       }
@@ -567,14 +567,14 @@ const fixtures = {
     },
     variants
   },
-  'with service name (linked)': {
+  "with service name (linked)": {
     context: {
       logo: {
-        href: '#nhs'
+        href: "#nhs"
       },
       service: {
-        text: 'Find your NHS number',
-        href: '#'
+        text: "Find your NHS number",
+        href: "#"
       }
     },
     options: {
@@ -583,24 +583,24 @@ const fixtures = {
     variants,
     screenshot: [
       {
-        name: 'name',
-        states: ['hover', 'focus'],
-        selector: '.nhsuk-header__service-name',
-        viewports: ['desktop']
+        name: "name",
+        states: ["hover", "focus"],
+        selector: ".nhsuk-header__service-name",
+        viewports: ["desktop"]
       },
       {
-        name: 'logo',
-        states: ['hover', 'focus'],
-        selector: '.nhsuk-header__service-logo',
-        viewports: ['desktop']
+        name: "logo",
+        states: ["hover", "focus"],
+        selector: ".nhsuk-header__service-logo",
+        viewports: ["desktop"]
       }
     ]
   },
-  'with service name (linked with logo)': {
+  "with service name (linked with logo)": {
     context: {
       service: {
-        text: 'Prototype kit',
-        href: '#'
+        text: "Prototype kit",
+        href: "#"
       }
     },
     options: {
@@ -608,19 +608,19 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      states: ['hover', 'focus'],
-      selector: '.nhsuk-header__service-logo',
-      viewports: ['desktop']
+      states: ["hover", "focus"],
+      selector: ".nhsuk-header__service-logo",
+      viewports: ["desktop"]
     }
   },
-  'with service name (linked and long), search': {
+  "with service name (linked and long), search": {
     context: {
       logo: {
-        href: '#nhs'
+        href: "#nhs"
       },
       service: {
-        text: 'This a really long service name to fully test wrapping',
-        href: '#'
+        text: "This a really long service name to fully test wrapping",
+        href: "#"
       },
       search: true
     },
@@ -629,52 +629,52 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with service name, search, account (logged in, complex), navigation': {
+  "with service name, search, account (logged in, complex), navigation": {
     context: {
       service: {
-        href: '#',
-        text: 'Manage patients'
+        href: "#",
+        text: "Manage patients"
       },
       search: {
-        placeholder: 'Name or NHS number',
-        visuallyHiddenLabel: 'Search patients by name or NHS number'
+        placeholder: "Name or NHS number",
+        visuallyHiddenLabel: "Search patients by name or NHS number"
       },
       account: {
         items: [
           {
-            href: '#',
-            text: 'Florence Nightingale',
+            href: "#",
+            text: "Florence Nightingale",
             icon: true
           },
           {
-            text: 'Regional Manager, Hull and East Yorkshire Hospitals NHS Trust'
+            text: "Regional Manager, Hull and East Yorkshire Hospitals NHS Trust"
           },
           {
-            href: '#',
-            text: 'Change role'
+            href: "#",
+            text: "Change role"
           },
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       },
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Home'
+            href: "#",
+            text: "Home"
           },
           {
-            href: '#',
-            text: 'Create user'
+            href: "#",
+            text: "Create user"
           },
           {
-            href: '#',
-            text: 'Find user'
+            href: "#",
+            text: "Find user"
           }
         ]
       }
@@ -684,48 +684,48 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with service name, search, account, navigation': {
+  "with service name, search, account, navigation": {
     context: {
       service: {
-        text: 'Search patient directory',
-        href: '#'
+        text: "Search patient directory",
+        href: "#"
       },
       search: {
-        placeholder: 'Name or NHS number',
-        visuallyHiddenLabel: 'Search patients by name or NHS number'
+        placeholder: "Name or NHS number",
+        visuallyHiddenLabel: "Search patients by name or NHS number"
       },
       account: {
         items: [
           {
-            text: 'Florence Nightingale',
+            text: "Florence Nightingale",
             icon: true
           },
           {
-            action: '#',
-            text: 'Log out'
+            action: "#",
+            text: "Log out"
           }
         ]
       },
       navigation: {
         items: [
           {
-            href: '#',
-            text: 'Home'
+            href: "#",
+            text: "Home"
           },
           {
-            href: '#',
-            text: 'Patient list'
+            href: "#",
+            text: "Patient list"
           },
           {
-            href: '#',
-            text: 'Advanced search'
+            href: "#",
+            text: "Advanced search"
           },
           {
-            href: '#',
-            text: 'Help guides'
+            href: "#",
+            text: "Help guides"
           }
         ]
       }
@@ -735,13 +735,13 @@ const fixtures = {
     },
     variants
   },
-  'with organisation name': {
+  "with organisation name": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       organisation: {
-        name: 'Business Services Authority'
+        name: "Business Services Authority"
       }
     },
     options: {
@@ -749,17 +749,17 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with organisation name (and descriptor)': {
+  "with organisation name (and descriptor)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       organisation: {
-        name: 'Anytown Anyplace Anywhere',
-        descriptor: 'NHS Foundation Trust'
+        name: "Anytown Anyplace Anywhere",
+        descriptor: "NHS Foundation Trust"
       }
     },
     options: {
@@ -767,18 +767,18 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'with organisation name (split with descriptor)': {
+  "with organisation name (split with descriptor)": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       organisation: {
-        name: 'Anytown Anyplace',
-        split: 'Anywhere',
-        descriptor: 'NHS Foundation Trust'
+        name: "Anytown Anyplace",
+        split: "Anywhere",
+        descriptor: "NHS Foundation Trust"
       }
     },
     options: {
@@ -786,23 +786,23 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      states: ['hover', 'focus'],
-      selector: '.nhsuk-header__service-logo',
-      viewports: ['desktop']
+      states: ["hover", "focus"],
+      selector: ".nhsuk-header__service-logo",
+      viewports: ["desktop"]
     }
   },
-  'with organisation name (split with descriptor), search': {
+  "with organisation name (split with descriptor), search": {
     context: {
       logo: {
-        href: '#'
+        href: "#"
       },
       organisation: {
-        name: 'Anytown Anyplace',
-        split: 'Anywhere',
-        descriptor: 'NHS Foundation Trust'
+        name: "Anytown Anyplace",
+        split: "Anywhere",
+        descriptor: "NHS Foundation Trust"
       },
       search: {
-        visuallyHiddenLabel: 'Search the Anytown Anyplace Anywhere website'
+        visuallyHiddenLabel: "Search the Anytown Anyplace Anywhere website"
       }
     },
     options: {
@@ -810,15 +810,15 @@ const fixtures = {
     },
     variants,
     screenshot: {
-      viewports: ['desktop']
+      viewports: ["desktop"]
     }
   },
-  'white linked logo, ARIA label': {
+  "white linked logo, ARIA label": {
     context: {
-      colour: 'white',
+      colour: "white",
       logo: {
-        ariaLabel: 'NHS white homepage',
-        href: '#'
+        ariaLabel: "NHS white homepage",
+        href: "#"
       }
     },
     options: {
@@ -826,22 +826,22 @@ const fixtures = {
       width: false
     }
   },
-  'white linked logo, custom': {
+  "white linked logo, custom": {
     context: {
-      colour: 'white',
+      colour: "white",
       logo: {
-        href: '#',
-        src: '/nhsuk-frontend/assets/example-logo.svg',
-        alt: 'Great Ormond Street Hospital for Children, NHS Foundation Trust'
+        href: "#",
+        src: "/nhsuk-frontend/assets/example-logo.svg",
+        alt: "Great Ormond Street Hospital for Children, NHS Foundation Trust"
       }
     },
     options: {
       width: false
     },
     screenshot: {
-      states: ['focus'],
-      selector: '.nhsuk-header__service-logo',
-      viewports: ['desktop']
+      states: ["focus"],
+      selector: ".nhsuk-header__service-logo",
+      viewports: ["desktop"]
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
@@ -5,27 +5,27 @@
  */
 export const variants = [
   {
-    description: 'with size S',
+    description: "with size S",
     context: {
-      size: 's'
+      size: "s"
     }
   },
   {
-    description: 'with size M',
+    description: "with size M",
     context: {
-      size: 'm'
+      size: "m"
     }
   },
   {
-    description: 'with size L',
+    description: "with size L",
     context: {
-      size: 'l'
+      size: "l"
     }
   },
   {
-    description: 'with size XL',
+    description: "with size XL",
     context: {
-      size: 'xl'
+      size: "xl"
     }
   }
 ]
@@ -36,122 +36,122 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'What is your full name?',
-      size: 'l'
+      text: "What is your full name?",
+      size: "l"
     },
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'text': {
+  "text": {
     context: {
-      text: 'What is your full name?',
-      size: 'l'
+      text: "What is your full name?",
+      size: "l"
     },
     variants,
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'text and caption': {
+  "text and caption": {
     context: {
-      text: 'What is your home address?',
-      caption: 'About you',
-      size: 'l'
+      text: "What is your home address?",
+      caption: "About you",
+      size: "l"
     },
     variants
   },
   'text and caption "before"': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'before'
+        text: "About you",
+        placement: "before"
       },
-      size: 'l'
+      size: "l"
     },
     variants,
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
   'text and caption "before" as a heading': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'before',
-        element: 'h2'
+        text: "About you",
+        placement: "before",
+        element: "h2"
       },
-      size: 'l'
+      size: "l"
     }
   },
   'text and caption "after"': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'after'
+        text: "About you",
+        placement: "after"
       },
-      size: 'l'
+      size: "l"
     },
     variants,
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
   'text and caption "after" as a paragraph': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'after',
-        element: 'p'
+        text: "About you",
+        placement: "after",
+        element: "p"
       },
-      size: 'l'
+      size: "l"
     }
   },
   'text and caption "start"': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'start'
+        text: "About you",
+        placement: "start"
       },
-      size: 'l'
+      size: "l"
     },
     variants,
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
   'text and caption "end"': {
     context: {
-      text: 'What is your home address?',
+      text: "What is your home address?",
       caption: {
-        text: 'About you',
-        placement: 'end'
+        text: "About you",
+        placement: "end"
       },
-      size: 'l'
+      size: "l"
     },
     variants,
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'size class': {
+  "size class": {
     context: {
-      text: 'What is your full name?',
-      classes: 'nhsuk-heading-l'
+      text: "What is your full name?",
+      classes: "nhsuk-heading-l"
     }
   },
-  'size class overriding size param': {
+  "size class overriding size param": {
     context: {
-      text: 'What is your full name?',
-      classes: 'nhsuk-heading-l',
-      size: 's'
+      text: "What is your full name?",
+      classes: "nhsuk-heading-l",
+      size: "s"
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/fixtures.mjs
@@ -1,6 +1,6 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
 /**
  * Nunjucks macro option examples
@@ -8,81 +8,81 @@ import { components } from '#lib'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       heading: "We're here for you",
-      text: 'Helping you take control of your health and wellbeing.'
+      text: "Helping you take control of your health and wellbeing."
     },
     options: {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'heading': {
+  "heading": {
     context: {
       heading: "We're here for you",
-      text: 'Helping you take control of your health and wellbeing.'
+      text: "Helping you take control of your health and wellbeing."
     },
     options: {
       width: false
     },
     variants: [
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
-          headingSize: 'l'
+          headingSize: "l"
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
-          headingSize: 'xl'
+          headingSize: "xl"
         }
       }
     ]
   },
-  'with image': {
+  "with image": {
     context: {
       image: {
-        src: 'https://assets.nhs.uk/prod/images/S_0818_homepage_hero_1_F0147446.width-1000.jpg'
+        src: "https://assets.nhs.uk/prod/images/S_0818_homepage_hero_1_F0147446.width-1000.jpg"
       }
     },
     options: {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with image, content': {
+  "with image, content": {
     context: {
       heading: "We're here for you",
-      text: 'Helping you take control of your health and wellbeing.',
+      text: "Helping you take control of your health and wellbeing.",
       image: {
-        src: 'https://assets.nhs.uk/prod/images/S_0818_homepage_hero_1_F0147446.width-1000.jpg'
+        src: "https://assets.nhs.uk/prod/images/S_0818_homepage_hero_1_F0147446.width-1000.jpg"
       }
     },
     options: {
       width: false
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with html content': {
+  "with html content": {
     context: {
-      heading: 'This is a header for the product or service',
-      headingSize: 'l',
-      headingClasses: 'nhsuk-u-margin-top-5',
+      heading: "This is a header for the product or service",
+      headingSize: "l",
+      headingClasses: "nhsuk-u-margin-top-5",
       html: outdent`
         <p class="nhsuk-body-l">This is some more content which explains the product or service.</p>
-        ${components.render('button', {
+        ${components.render("button", {
           context: {
-            text: 'Sign up',
-            variant: 'reverse',
-            href: '#'
+            text: "Sign up",
+            variant: "reverse",
+            href: "#"
           }
         })}
       `

--- a/packages/nhsuk-frontend/src/nhsuk/components/hint/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hint/fixtures.mjs
@@ -4,20 +4,20 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'Do not include personal information like your name, date of birth or NHS number'
+      text: "Do not include personal information like your name, date of birth or NHS number"
     },
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
       html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     callBlock:
       'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/images/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/images/fixtures.mjs
@@ -4,46 +4,46 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      src: 'https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg',
+      src: "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
       caption: {
-        text: 'No specific amount of time is recommended, but a typical training session could take less than 20 minutes.'
+        text: "No specific amount of time is recommended, but a typical training session could take less than 20 minutes."
       }
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with srcset': {
+  "with srcset": {
     context: {
-      src: 'https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg',
-      sizes: '(max-width: 768px) 100vw, 66vw',
+      src: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg",
+      sizes: "(max-width: 768px) 100vw, 66vw",
       srcset:
-        'https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w',
+        "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
       caption: {
-        text: 'Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time.'
+        text: "Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time."
       }
     }
   },
-  'with srcset and alt text': {
+  "with srcset and alt text": {
     context: {
-      src: 'https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg',
-      sizes: '(max-width: 768px) 100vw, 66vw',
+      src: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg",
+      sizes: "(max-width: 768px) 100vw, 66vw",
       srcset:
-        'https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w',
+        "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg 600w, https://service-manual.nhs.uk/assets/image-example-stretch-marks-1000w.jpg 1000w",
       alt: "Close-up of a person's tummy showing a number of creases in the skin under their belly button. Shown on light brown skin.",
       caption: {
-        text: 'Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time.'
+        text: "Stretch marks can be pink, red, brown, black, silver or purple. They usually start off darker and fade over time."
       }
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without caption': {
+  "without caption": {
     context: {
-      src: 'https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg',
+      src: "https://service-manual.nhs.uk/assets/image-example-stretch-marks-600w.jpg",
       alt: "Close-up of a person's tummy showing a number of creases in the skin under their belly button. Shown on light brown skin."
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/fixtures.mjs
@@ -1,6 +1,6 @@
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as buttonExamples } from '../button/fixtures.mjs'
+import { examples as buttonExamples } from "../button/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -8,294 +8,294 @@ import { examples as buttonExamples } from '../button/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'What is your full name?',
-        size: 'l',
+        text: "What is your full name?",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example'
+      name: "example"
     },
     screenshot: true
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'What is your full name?',
-        size: 'l',
+        text: "What is your full name?",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       disabled: true
     },
     screenshot: true
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
         html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false
     },
     screenshot: true
   },
-  'with button': {
+  "with button": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-button',
-      name: 'example',
+      id: "with-button",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false,
       formGroup: {
         afterInput: {
           html: components.render(
-            'button',
-            buttonExamples['example secondary search button, small']
+            "button",
+            buttonExamples["example secondary search button, small"]
           )
         }
       }
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with button and error message': {
+  "with button and error message": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Enter NHS number'
+        text: "Enter NHS number"
       },
-      id: 'with-button-error-message',
-      name: 'example',
+      id: "with-button-error-message",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false,
       formGroup: {
         afterInput: {
           html: components.render(
-            'button',
-            buttonExamples['example secondary search button, small']
+            "button",
+            buttonExamples["example secondary search button, small"]
           )
         }
       }
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Enter NHS number'
+        text: "Enter NHS number"
       },
-      id: 'with-error-message',
-      name: 'example',
+      id: "with-error-message",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
         html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
       },
       errorMessage: {
-        text: 'Enter NHS number'
+        text: "Enter NHS number"
       },
-      id: 'with-hint-error',
-      name: 'example',
+      id: "with-hint-error",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false
     },
     screenshot: {
-      states: ['focus'],
-      selector: '#with-hint-error'
+      states: ["focus"],
+      selector: "#with-hint-error"
     }
   },
-  'width': {
+  "width": {
     context: {
-      name: 'example',
-      id: 'input-width'
+      name: "example",
+      id: "input-width"
     },
     variants: [
       {
-        description: 'with 2 character',
+        description: "with 2 character",
         context: {
           label: {
-            text: '2 character width'
+            text: "2 character width"
           },
           width: 2
         }
       },
       {
-        description: 'with 3 character',
+        description: "with 3 character",
         context: {
           label: {
-            text: '3 character width'
+            text: "3 character width"
           },
           width: 3
         }
       },
       {
-        description: 'with 4 character',
+        description: "with 4 character",
         context: {
           label: {
-            text: '4 character width'
+            text: "4 character width"
           },
           width: 4
         }
       },
       {
-        description: 'with 5 character',
+        description: "with 5 character",
         context: {
           label: {
-            text: '5 character width'
+            text: "5 character width"
           },
           width: 5
         }
       },
       {
-        description: 'with 10 character',
+        description: "with 10 character",
         context: {
           label: {
-            text: '10 character width'
+            text: "10 character width"
           },
           width: 10
         }
       },
       {
-        description: 'with 20 character',
+        description: "with 20 character",
         context: {
           label: {
-            text: '20 character width'
+            text: "20 character width"
           },
           width: 20
         }
       },
       {
-        description: 'with 30 character',
+        description: "with 30 character",
         context: {
           label: {
-            text: '30 character width'
+            text: "30 character width"
           },
           width: 30
         }
       }
     ]
   },
-  'width class': {
+  "width class": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'input-width',
-      name: 'example',
-      classes: 'nhsuk-input--width-10'
+      id: "input-width",
+      name: "example",
+      classes: "nhsuk-input--width-10"
     }
   },
-  'width class overriding width param': {
+  "width class overriding width param": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'input-width',
-      name: 'example',
-      classes: 'nhsuk-input--width-10',
+      id: "input-width",
+      name: "example",
+      classes: "nhsuk-input--width-10",
       width: 30
     }
   },
-  'label': {
+  "label": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
-      id: 'custom-size',
-      name: 'example',
+      id: "custom-size",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           label: {
-            size: 's'
+            size: "s"
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           label: {
-            size: 'm'
+            size: "m"
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           label: {
-            size: 'l'
+            size: "l"
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           label: {
-            size: 'xl'
+            size: "xl"
           }
         }
       },
       {
-        description: 'with id attribute on',
+        description: "with id attribute on",
         context: {
           label: {
-            id: 'custom-id'
+            id: "custom-id"
           }
         },
         options: {
@@ -304,277 +304,277 @@ const fixtures = {
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'What is your NHS number?'
+        text: "What is your NHS number?"
       },
-      id: 'without-heading',
-      name: 'example',
+      id: "without-heading",
+      name: "example",
       width: 10,
       code: true,
-      inputmode: 'numeric',
+      inputmode: "numeric",
       spellcheck: false
     }
   },
-  'with code input styling': {
+  "with code input styling": {
     context: {
       label: {
-        text: 'What is your NHS number?',
-        size: 'l',
+        text: "What is your NHS number?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
         html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
       },
-      id: 'with-code-input-styling',
-      name: 'example',
+      id: "with-code-input-styling",
+      name: "example",
       width: 10,
       code: true,
-      value: '999 123 4567',
-      inputmode: 'numeric',
+      value: "999 123 4567",
+      inputmode: "numeric",
       spellcheck: false
     },
     screenshot: true
   },
-  'with prefix': {
+  "with prefix": {
     context: {
       label: {
-        text: 'Cost in pounds',
+        text: "Cost in pounds",
         isPageHeading: true
       },
-      id: 'with-prefix',
-      name: 'example',
+      id: "with-prefix",
+      name: "example",
       prefix: {
-        text: '£'
+        text: "£"
       },
       width: 5
     },
     screenshot: true
   },
-  'with prefix HTML': {
+  "with prefix HTML": {
     context: {
       label: {
-        text: 'Cost in pounds',
+        text: "Cost in pounds",
         isPageHeading: true
       },
-      id: 'with-prefix',
-      name: 'example',
+      id: "with-prefix",
+      name: "example",
       prefix: {
-        html: '<span>£</span>'
+        html: "<span>£</span>"
       },
       width: 5
     }
   },
-  'with prefix deprecated option': {
+  "with prefix deprecated option": {
     context: {
       label: {
-        text: 'Cost in pounds',
+        text: "Cost in pounds",
         isPageHeading: true
       },
-      id: 'with-prefix',
-      name: 'example',
-      prefix: '£',
+      id: "with-prefix",
+      name: "example",
+      prefix: "£",
       width: 5
     }
   },
-  'with suffix': {
+  "with suffix": {
     context: {
       label: {
-        text: 'Weight in kilograms',
+        text: "Weight in kilograms",
         isPageHeading: true
       },
-      id: 'with-suffix',
-      name: 'example',
+      id: "with-suffix",
+      name: "example",
       suffix: {
-        text: 'kg'
+        text: "kg"
       },
       width: 5
     },
     screenshot: true
   },
-  'with suffix HTML': {
+  "with suffix HTML": {
     context: {
       label: {
-        text: 'Weight in kilograms',
+        text: "Weight in kilograms",
         isPageHeading: true
       },
-      id: 'with-suffix',
-      name: 'example',
+      id: "with-suffix",
+      name: "example",
       suffix: {
-        html: '<span>kg</span>'
+        html: "<span>kg</span>"
       },
       width: 5
     }
   },
-  'with suffix deprecated option': {
+  "with suffix deprecated option": {
     context: {
       label: {
-        text: 'Weight in kilograms',
+        text: "Weight in kilograms",
         isPageHeading: true
       },
-      id: 'with-suffix',
-      name: 'example',
-      suffix: 'kg',
+      id: "with-suffix",
+      name: "example",
+      suffix: "kg",
       width: 5
     }
   },
-  'with prefix and suffix': {
+  "with prefix and suffix": {
     context: {
       label: {
-        text: 'Cost per item, in pounds',
+        text: "Cost per item, in pounds",
         isPageHeading: true
       },
-      id: 'with-prefix-suffix',
-      name: 'example',
+      id: "with-prefix-suffix",
+      name: "example",
       prefix: {
-        text: '£'
+        text: "£"
       },
       suffix: {
-        text: 'per item'
+        text: "per item"
       },
       width: 5
     },
     screenshot: true
   },
-  'with prefix and suffix and error message': {
+  "with prefix and suffix and error message": {
     context: {
       label: {
-        text: 'Cost per item, in pounds',
+        text: "Cost per item, in pounds",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Enter a cost per item, in pounds'
+        text: "Enter a cost per item, in pounds"
       },
-      id: 'with-prefix-suffix',
-      name: 'example',
+      id: "with-prefix-suffix",
+      name: "example",
       prefix: {
-        text: '£'
+        text: "£"
       },
       suffix: {
-        text: 'per item'
+        text: "per item"
       },
       width: 5
     },
     screenshot: {
-      states: ['focus'],
-      selector: '#with-prefix-suffix'
+      states: ["focus"],
+      selector: "#with-prefix-suffix"
     }
   },
-  'with autocomplete attribute': {
+  "with autocomplete attribute": {
     context: {
       label: {
-        text: 'Enter a full postcode in England',
+        text: "Enter a full postcode in England",
         isPageHeading: true
       },
       hint: {
-        text: 'For example, LS1 1AB'
+        text: "For example, LS1 1AB"
       },
-      id: 'with-autocomplete-attribute',
-      name: 'example',
-      autocomplete: 'postal-code'
+      id: "with-autocomplete-attribute",
+      name: "example",
+      autocomplete: "postal-code"
     },
     screenshot: true
   },
-  'example email address': {
+  "example email address": {
     context: {
       label: {
-        text: 'Email address'
+        text: "Email address"
       },
-      name: 'contact-by-email',
-      classes: 'nhsuk-u-width-two-thirds',
+      name: "contact-by-email",
+      classes: "nhsuk-u-width-two-thirds",
       spellcheck: false
     },
     options: {
       hidden: true
     }
   },
-  'example phone number': {
+  "example phone number": {
     context: {
       label: {
-        text: 'Phone number'
+        text: "Phone number"
       },
-      type: 'tel',
-      name: 'contact-by-phone',
-      classes: 'nhsuk-u-width-two-thirds'
+      type: "tel",
+      name: "contact-by-phone",
+      classes: "nhsuk-u-width-two-thirds"
     },
     options: {
       hidden: true
     }
   },
-  'example phone number with error message': {
+  "example phone number with error message": {
     context: {
       label: {
-        text: 'Phone number'
+        text: "Phone number"
       },
       errorMessage: {
-        text: 'Enter your phone number'
+        text: "Enter your phone number"
       },
-      type: 'tel',
-      name: 'contact-by-phone',
-      classes: 'nhsuk-u-width-two-thirds'
+      type: "tel",
+      name: "contact-by-phone",
+      classes: "nhsuk-u-width-two-thirds"
     },
     options: {
       hidden: true
     }
   },
-  'example mobile phone number': {
+  "example mobile phone number": {
     context: {
       label: {
-        text: 'Mobile phone number'
+        text: "Mobile phone number"
       },
-      type: 'tel',
-      name: 'contact-by-text',
-      classes: 'nhsuk-u-width-two-thirds'
+      type: "tel",
+      name: "contact-by-text",
+      classes: "nhsuk-u-width-two-thirds"
     },
     options: {
       hidden: true
     }
   },
-  'example address line 1': {
+  "example address line 1": {
     context: {
       label: {
-        text: 'Address line 1'
+        text: "Address line 1"
       },
-      name: 'address-line1',
-      autocomplete: 'address-line1'
+      name: "address-line1",
+      autocomplete: "address-line1"
     },
     options: {
       hidden: true
     }
   },
-  'example address line 2': {
+  "example address line 2": {
     context: {
       label: {
-        text: 'Address line 2 (optional)'
+        text: "Address line 2 (optional)"
       },
-      name: 'address-line2',
-      autocomplete: 'address-line2'
+      name: "address-line2",
+      autocomplete: "address-line2"
     },
     options: {
       hidden: true
     }
   },
-  'example address town or city': {
+  "example address town or city": {
     context: {
       label: {
-        text: 'Town or city'
+        text: "Town or city"
       },
-      name: 'address-town',
-      autocomplete: 'address-level2',
-      classes: 'nhsuk-u-width-two-thirds'
+      name: "address-town",
+      autocomplete: "address-level2",
+      classes: "nhsuk-u-width-two-thirds"
     },
     options: {
       hidden: true
     }
   },
-  'example address postcode': {
+  "example address postcode": {
     context: {
       label: {
-        text: 'Postcode'
+        text: "Postcode"
       },
-      name: 'address-postcode',
-      autocomplete: 'postal-code',
+      name: "address-postcode",
+      autocomplete: "postal-code",
       width: 10
     },
     options: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/inset-text/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/inset-text/fixtures.mjs
@@ -4,19 +4,19 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'You can report any suspected side effect using the Yellow Card safety scheme'
+      text: "You can report any suspected side effect using the Yellow Card safety scheme"
     },
     screenshot: true
   },
-  'with HTML': {
+  "with HTML": {
     context: {
       html: '<p>You can report any suspected side effect using the <a href="#">Yellow Card safety scheme</a>.</p>'
     },
     screenshot: true
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     callBlock:
       '<p>You can report any suspected side effect using the <a href="#">Yellow Card safety scheme</a>.</p>'
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/label/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/label/fixtures.mjs
@@ -4,84 +4,84 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'What is your full name?',
-      size: 'l',
+      text: "What is your full name?",
+      size: "l",
       isPageHeading: true
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'text': {
+  "text": {
     context: {
-      text: 'What is your full name?',
-      size: 'l',
+      text: "What is your full name?",
+      size: "l",
       isPageHeading: true
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
-          size: 's'
+          size: "s"
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
-          size: 'm'
+          size: "m"
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
-          size: 'l'
+          size: "l"
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
-          size: 'xl'
+          size: "xl"
         }
       }
     ],
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'size class': {
+  "size class": {
     context: {
-      text: 'What is your full name?',
-      classes: 'nhsuk-label--l',
+      text: "What is your full name?",
+      classes: "nhsuk-label--l",
       isPageHeading: true
     }
   },
-  'size class overriding size param': {
+  "size class overriding size param": {
     context: {
-      text: 'What is your full name?',
-      classes: 'nhsuk-label--l',
-      size: 's',
+      text: "What is your full name?",
+      classes: "nhsuk-label--l",
+      size: "s",
       isPageHeading: true
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      html: 'What is your full name?',
-      size: 'l',
+      html: "What is your full name?",
+      size: "l",
       isPageHeading: true
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
-      size: 'l',
+      size: "l",
       isPageHeading: true
     },
-    callBlock: 'What is your full name?'
+    callBlock: "What is your full name?"
   },
-  'without page heading': {
+  "without page heading": {
     context: {
-      text: 'What is your full name?'
+      text: "What is your full name?"
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/legend/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/legend/fixtures.mjs
@@ -4,82 +4,82 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'What is your address?',
-      size: 'l',
+      text: "What is your address?",
+      size: "l",
       isPageHeading: true
     },
     screenshot: true
   },
-  'text': {
+  "text": {
     context: {
-      text: 'What is your address?',
-      size: 'l',
+      text: "What is your address?",
+      size: "l",
       isPageHeading: true
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
-          size: 's'
+          size: "s"
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
-          size: 'm'
+          size: "m"
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
-          size: 'l'
+          size: "l"
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
-          size: 'xl'
+          size: "xl"
         }
       }
     ],
     screenshot: {
-      viewports: ['tablet']
+      viewports: ["tablet"]
     }
   },
-  'with size class': {
+  "with size class": {
     context: {
-      text: 'What is your address?',
-      classes: 'nhsuk-fieldset__legend--l',
+      text: "What is your address?",
+      classes: "nhsuk-fieldset__legend--l",
       isPageHeading: true
     }
   },
-  'with size class overriding size param': {
+  "with size class overriding size param": {
     context: {
-      text: 'What is your address?',
-      classes: 'nhsuk-fieldset__legend--l',
-      size: 's',
+      text: "What is your address?",
+      classes: "nhsuk-fieldset__legend--l",
+      size: "s",
       isPageHeading: true
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      text: 'What is your address?',
-      size: 'l',
+      text: "What is your address?",
+      size: "l",
       isPageHeading: true
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
-      size: 'l',
+      size: "l",
       isPageHeading: true
     },
-    callBlock: 'What is your address?'
+    callBlock: "What is your address?"
   },
-  'without page heading': {
+  "without page heading": {
     context: {
-      text: 'What is your address?'
+      text: "What is your address?"
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/notification-banner/fixtures.mjs
@@ -1,4 +1,4 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
 /**
  * Nunjucks macro option examples
@@ -6,18 +6,18 @@ import { outdent } from 'outdent'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      text: 'The patient record was updated.'
+      text: "The patient record was updated."
     },
     screenshot: true
   },
-  'paragraph with heading class': {
+  "paragraph with heading class": {
     context: {
       html: '<p class="nhsuk-notification-banner__heading">You have 9 days to send a response.</p>'
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
       html: outdent`
         <h3 class="nhsuk-notification-banner__heading">
@@ -29,7 +29,7 @@ const fixtures = {
       `
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     callBlock: outdent`
       <h3 class="nhsuk-notification-banner__heading">
         The patient record was updated
@@ -39,16 +39,16 @@ const fixtures = {
       </p>
     `
   },
-  'with success variant': {
+  "with success variant": {
     context: {
-      variant: 'success',
-      text: 'Email sent to example@email.com'
+      variant: "success",
+      text: "Email sent to example@email.com"
     },
     screenshot: true
   },
-  'success with HTML': {
+  "success with HTML": {
     context: {
-      variant: 'success',
+      variant: "success",
       html: outdent`
         <h3 class="nhsuk-notification-banner__heading">
           4 files uploaded
@@ -60,9 +60,9 @@ const fixtures = {
       `
     }
   },
-  'success with HTML via call block': {
+  "success with HTML via call block": {
     context: {
-      variant: 'success'
+      variant: "success"
     },
     callBlock: outdent`
       <h3 class="nhsuk-notification-banner__heading">
@@ -74,7 +74,7 @@ const fixtures = {
       </ul>
     `
   },
-  'with a list': {
+  "with a list": {
     context: {
       html: outdent`
         <h3 class="nhsuk-notification-banner__heading">4 files uploaded</h3>
@@ -87,12 +87,12 @@ const fixtures = {
       `
     }
   },
-  'with long heading': {
+  "with long heading": {
     context: {
-      text: 'The patient record was withdrawn on 7 March 2014, before being sent in, sent back, queried, lost, found, subjected to public inquiry, lost again, and finally buried in soft peat for three months and recycled as firelighters.'
+      text: "The patient record was withdrawn on 7 March 2014, before being sent in, sent back, queried, lost, found, subjected to public inquiry, lost again, and finally buried in soft peat for three months and recycled as firelighters."
     }
   },
-  'with lots of content': {
+  "with lots of content": {
     context: {
       html: outdent`
         <h3 class="nhsuk-notification-banner__heading">
@@ -108,40 +108,40 @@ const fixtures = {
       `
     }
   },
-  'auto-focus disabled, with success variant': {
+  "auto-focus disabled, with success variant": {
     context: {
-      variant: 'success',
+      variant: "success",
       disableAutoFocus: true,
-      text: 'Email sent to example@email.com'
+      text: "Email sent to example@email.com"
     },
     options: {
       hidden: true
     }
   },
-  'auto-focus explicitly enabled, with success variant': {
+  "auto-focus explicitly enabled, with success variant": {
     context: {
-      variant: 'success',
+      variant: "success",
       disableAutoFocus: false,
-      text: 'Email sent to example@email.com'
+      text: "Email sent to example@email.com"
     },
     options: {
       hidden: true
     }
   },
-  'role=alert overridden to role=region, with success variant': {
+  "role=alert overridden to role=region, with success variant": {
     context: {
-      variant: 'success',
-      role: 'region',
-      text: 'Email sent to example@email.com'
+      variant: "success",
+      role: "region",
+      text: "Email sent to example@email.com"
     },
     options: {
       hidden: true
     }
   },
-  'custom tabindex': {
+  "custom tabindex": {
     context: {
-      variant: 'success',
-      text: 'Email sent to example@email.com',
+      variant: "success",
+      text: "Email sent to example@email.com",
       attributes: {
         tabindex: 2
       }

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/fixtures.mjs
@@ -4,180 +4,180 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       previous: {
-        labelText: 'Treatments',
-        href: '#/section/treatments'
+        labelText: "Treatments",
+        href: "#/section/treatments"
       },
       next: {
-        labelText: 'Symptoms',
-        href: '#/section/symptoms'
+        labelText: "Symptoms",
+        href: "#/section/symptoms"
       }
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-pagination-item--previous a',
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-pagination-item--previous a",
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with deprecated options': {
+  "with deprecated options": {
     context: {
-      previousUrl: '#/section/treatments',
-      previousPage: 'Treatments',
-      nextUrl: '#/section/symptoms',
-      nextPage: 'Symptoms'
+      previousUrl: "#/section/treatments",
+      previousPage: "Treatments",
+      nextUrl: "#/section/symptoms",
+      nextPage: "Symptoms"
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with only previous': {
+  "with only previous": {
     context: {
       previous: {
-        labelText: 'Treatments',
-        href: '#/section/treatments'
+        labelText: "Treatments",
+        href: "#/section/treatments"
       }
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with only next': {
+  "with only next": {
     context: {
       next: {
-        labelText: 'Symptoms',
-        href: '#/section/symptoms'
+        labelText: "Symptoms",
+        href: "#/section/symptoms"
       }
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
       previous: {
-        text: 'Blaenorol',
-        labelText: 'Driniaethau',
-        href: '#/section/driniaethau'
+        text: "Blaenorol",
+        labelText: "Driniaethau",
+        href: "#/section/driniaethau"
       },
       next: {
-        text: 'Nesaf',
-        labelText: 'Symptomau',
-        href: '#/section/symptomau'
+        text: "Nesaf",
+        labelText: "Symptomau",
+        href: "#/section/symptomau"
       }
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'numbered': {
+  "numbered": {
     context: {
       previous: {
-        href: '#/section/1'
+        href: "#/section/1"
       },
       next: {
-        href: '#/section/3'
+        href: "#/section/3"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1'
+          href: "#/section/1"
         },
         {
           number: 2,
-          href: '#/section/2',
+          href: "#/section/2",
           current: true
         },
         {
           number: 3,
-          href: '#/section/3'
+          href: "#/section/3"
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      states: ['focus', 'hover', 'active'],
-      selector: '.nhsuk-pagination__item--current a',
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      states: ["focus", "hover", "active"],
+      selector: ".nhsuk-pagination__item--current a",
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'numbered with many pages': {
+  "numbered with many pages": {
     context: {
       previous: {
-        href: '#/section/9'
+        href: "#/section/9"
       },
       next: {
-        href: '#/section/11'
+        href: "#/section/11"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1'
+          href: "#/section/1"
         },
         {
           ellipsis: true
         },
         {
           number: 8,
-          href: '#/section/8'
+          href: "#/section/8"
         },
         {
           number: 9,
-          href: '#/section/9'
+          href: "#/section/9"
         },
         {
           number: 10,
-          href: '#/section/10',
+          href: "#/section/10",
           current: true
         },
         {
           number: 11,
-          href: '#/section/11'
+          href: "#/section/11"
         },
         {
           number: 12,
-          href: '#/section/12'
+          href: "#/section/12"
         },
         {
           ellipsis: true
         },
         {
           number: 40,
-          href: '#/section/40'
+          href: "#/section/40"
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'numbered with many pages (empty items)': {
+  "numbered with many pages (empty items)": {
     context: {
       previous: {
-        href: '#/section/9'
+        href: "#/section/9"
       },
       next: {
-        href: '#/section/11'
+        href: "#/section/11"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1'
+          href: "#/section/1"
         },
         {
           ellipsis: true
@@ -185,16 +185,16 @@ const fixtures = {
         false,
         {
           number: 9,
-          href: '#/section/9'
+          href: "#/section/9"
         },
         {
           number: 10,
-          href: '#/section/10',
+          href: "#/section/10",
           current: true
         },
         {
           number: 11,
-          href: '#/section/11'
+          href: "#/section/11"
         },
         false,
         {
@@ -202,98 +202,98 @@ const fixtures = {
         },
         {
           number: 40,
-          href: '#/section/40'
+          href: "#/section/40"
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'numbered first page': {
+  "numbered first page": {
     context: {
       next: {
-        href: '#/section/2'
+        href: "#/section/2"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1',
+          href: "#/section/1",
           current: true
         },
         {
           number: 2,
-          href: '#/section/2'
+          href: "#/section/2"
         },
         {
           number: 3,
-          href: '#/section/3'
+          href: "#/section/3"
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'numbered last page': {
+  "numbered last page": {
     context: {
       previous: {
-        href: '#/section/2'
+        href: "#/section/2"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1'
+          href: "#/section/1"
         },
         {
           number: 2,
-          href: '#/section/2'
+          href: "#/section/2"
         },
         {
           number: 3,
-          href: '#/section/3',
+          href: "#/section/3",
           current: true
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop', 'large-desktop']
+      viewports: ["mobile", "tablet", "desktop", "large-desktop"]
     }
   },
-  'numbered with translations': {
+  "numbered with translations": {
     context: {
       previous: {
-        text: 'Blaenorol',
-        href: '#/section/1'
+        text: "Blaenorol",
+        href: "#/section/1"
       },
       next: {
-        text: 'Nesaf',
-        href: '#/section/3'
+        text: "Nesaf",
+        href: "#/section/3"
       },
       items: [
         {
           number: 1,
-          href: '#/section/1'
+          href: "#/section/1"
         },
         {
           number: 2,
-          href: '#/section/2',
+          href: "#/section/2",
           current: true
         },
         {
           number: 3,
-          href: '#/section/3'
+          href: "#/section/3"
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/fixtures.mjs
@@ -1,6 +1,6 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
 /**
  * Nunjucks macro option examples
@@ -8,41 +8,41 @@ import { components } from '#lib'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      titleText: 'Booking complete',
-      text: 'We have sent you a confirmation email'
+      titleText: "Booking complete",
+      text: "We have sent you a confirmation email"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      titleText: 'Booking complete',
-      html: 'We have sent you a confirmation email'
+      titleText: "Booking complete",
+      html: "We have sent you a confirmation email"
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
-      titleText: 'Booking complete'
+      titleText: "Booking complete"
     },
-    callBlock: 'We have sent you a confirmation email'
+    callBlock: "We have sent you a confirmation email"
   },
-  'interruption': {
+  "interruption": {
     context: {
-      titleText: 'Jodie Brown had a COVID-19 vaccine less than 3 months ago',
-      titleSize: 'l',
-      variant: 'interruption',
+      titleText: "Jodie Brown had a COVID-19 vaccine less than 3 months ago",
+      titleSize: "l",
+      variant: "interruption",
       html: outdent`
         <p>They had a COVID-19 vaccine on 25 September 2025.</p>
         <p>For most people, the minimum recommended gap between COVID-19 vaccine doses is 3 months.</p>
         <div class="nhsuk-button-group">
-          ${components.render('button', {
+          ${components.render("button", {
             context: {
-              text: 'Continue anyway',
-              variant: 'reverse',
-              href: '#'
+              text: "Continue anyway",
+              variant: "reverse",
+              href: "#"
             }
           })}
           <a href="#">Cancel</a>
@@ -50,23 +50,23 @@ const fixtures = {
       `
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'interruption for confirmation to cancel': {
+  "interruption for confirmation to cancel": {
     context: {
-      titleText: 'Confirm you want to cancel your hospital appointment',
-      titleSize: 'l',
-      variant: 'interruption',
+      titleText: "Confirm you want to cancel your hospital appointment",
+      titleSize: "l",
+      variant: "interruption",
       html: outdent`
         <p>You will be able to reschedule your appointment for another time, but this may delay your treatment.</p>
         <p>Cancelling your appointment cannot be undone.</p>
         <div class="nhsuk-button-group">
-          ${components.render('button', {
+          ${components.render("button", {
             context: {
-              text: 'Cancel appointment',
-              variant: 'reverse',
-              href: '#'
+              text: "Cancel appointment",
+              variant: "reverse",
+              href: "#"
             }
           })}
           <a href="#">Change my weight</a>
@@ -74,19 +74,19 @@ const fixtures = {
       `
     }
   },
-  'interruption for confirmation to continue': {
+  "interruption for confirmation to continue": {
     context: {
-      titleText: 'Is your weight correct?',
-      titleSize: 'l',
-      variant: 'interruption',
+      titleText: "Is your weight correct?",
+      titleSize: "l",
+      variant: "interruption",
       html: outdent`
         <p>You entered your weight as <b>21.4 kilograms</b>. This is lower than expected.</p>
         <div class="nhsuk-button-group">
-          ${components.render('button', {
+          ${components.render("button", {
             context: {
-              text: 'Yes, this is correct',
-              variant: 'reverse',
-              href: '#'
+              text: "Yes, this is correct",
+              variant: "reverse",
+              href: "#"
             }
           })}
           <a href="#">Change my weight</a>
@@ -94,38 +94,38 @@ const fixtures = {
       `
     }
   },
-  'title': {
+  "title": {
     context: {
-      titleText: 'Booking complete',
-      titleSize: 'l',
-      text: 'We have sent you a confirmation email'
+      titleText: "Booking complete",
+      titleSize: "l",
+      text: "We have sent you a confirmation email"
     },
     variants: [
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
-          titleSize: 'm'
+          titleSize: "m"
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
-          titleSize: 'l'
+          titleSize: "l"
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
-          titleSize: 'xl'
+          titleSize: "xl"
         }
       }
     ]
   },
-  'with title classes and heading level': {
+  "with title classes and heading level": {
     context: {
-      titleText: 'Booking complete',
-      titleClasses: 'nhsuk-panel__title--l',
-      text: 'We have sent you a confirmation email',
+      titleText: "Booking complete",
+      titleClasses: "nhsuk-panel__title--l",
+      text: "We have sent you a confirmation email",
       headingLevel: 2
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/password-input/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/password-input/fixtures.mjs
@@ -4,221 +4,221 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example'
+      name: "example"
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       disabled: true
     },
     screenshot: true
   },
-  'disabled with enabled button': {
+  "disabled with enabled button": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       disabled: true,
       button: {
         disabled: false
       }
     }
   },
-  'disabled button': {
+  "disabled button": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       button: {
         disabled: true
       }
     }
   },
-  'with button double click prevented': {
+  "with button double click prevented": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       button: {
         preventDoubleClick: true
       }
     }
   },
-  'with button double click not prevented': {
+  "with button double click not prevented": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       button: {
         preventDoubleClick: false
       }
     }
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'It probably has some letters, numbers and maybe even some symbols in it'
+        text: "It probably has some letters, numbers and maybe even some symbols in it"
       },
-      id: 'with-hint-text',
-      name: 'example'
+      id: "with-hint-text",
+      name: "example"
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Enter a password'
+        text: "Enter a password"
       },
-      id: 'with-error-message',
-      name: 'example'
+      id: "with-error-message",
+      name: "example"
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'It probably has some letters, numbers and maybe even some symbols in it'
+        text: "It probably has some letters, numbers and maybe even some symbols in it"
       },
       errorMessage: {
-        text: 'Enter a password'
+        text: "Enter a password"
       },
-      id: 'with-error-message',
-      name: 'example'
+      id: "with-error-message",
+      name: "example"
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with prefix': {
+  "with prefix": {
     context: {
       label: {
-        text: 'Secret code',
-        size: 'm',
+        text: "Secret code",
+        size: "m",
         isPageHeading: true
       },
       prefix: {
-        text: 'PIN'
+        text: "PIN"
       },
-      id: 'with-prefix',
-      name: 'example',
-      value: '3.14159',
+      id: "with-prefix",
+      name: "example",
+      value: "3.14159",
       width: 5,
       code: true,
       button: {
-        variant: 'brand'
+        variant: "brand"
       }
     }
   },
-  'with prefix and error message': {
+  "with prefix and error message": {
     context: {
       label: {
-        text: 'Secret code',
-        size: 'm',
+        text: "Secret code",
+        size: "m",
         isPageHeading: true
       },
       prefix: {
-        text: 'PIN'
+        text: "PIN"
       },
       errorMessage: {
-        text: 'Enter secret code'
+        text: "Enter secret code"
       },
-      id: 'with-prefix',
-      name: 'example',
+      id: "with-prefix",
+      name: "example",
       width: 5,
       code: true,
       button: {
-        variant: 'brand'
+        variant: "brand"
       }
     }
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Password'
+        text: "Password"
       },
-      id: 'without-heading',
-      name: 'example'
+      id: "without-heading",
+      name: "example"
     }
   },
-  'with width': {
+  "with width": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      id: 'width-class',
-      name: 'example',
+      id: "width-class",
+      name: "example",
       width: 10
     }
   },
-  'with autocomplete attribute': {
+  "with autocomplete attribute": {
     context: {
       label: {
-        text: 'Password',
-        size: 'l',
+        text: "Password",
+        size: "l",
         isPageHeading: true
       },
-      id: 'new-password',
-      name: 'example',
-      autocomplete: 'new-password'
+      id: "new-password",
+      name: "example",
+      autocomplete: "new-password"
     }
   },
-  'with translations': {
+  "with translations": {
     context: {
       label: {
-        text: 'Cyfrinair',
-        size: 'l',
+        text: "Cyfrinair",
+        size: "l",
         isPageHeading: true
       },
-      id: 'password-translated',
-      name: 'example',
-      showPasswordText: 'Datguddia',
-      hidePasswordText: 'Cuddio',
-      showPasswordAriaLabelText: 'Datgelu cyfrinair',
-      hidePasswordAriaLabelText: 'Cuddio cyfrinair',
-      passwordShownAnnouncementText: 'Mae eich cyfrinair yn weladwy.',
+      id: "password-translated",
+      name: "example",
+      showPasswordText: "Datguddia",
+      hidePasswordText: "Cuddio",
+      showPasswordAriaLabelText: "Datgelu cyfrinair",
+      hidePasswordAriaLabelText: "Cuddio cyfrinair",
+      passwordShownAnnouncementText: "Mae eich cyfrinair yn weladwy.",
       passwordHiddenAnnouncementText: "Mae eich cyfrinair wedi'i guddio."
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/fixtures.mjs
@@ -1,8 +1,8 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as inputExamples } from '../input/fixtures.mjs'
+import { examples as inputExamples } from "../input/fixtures.mjs"
 
 /**
  * Nunjucks macro option variants
@@ -14,12 +14,12 @@ export const variants = [
     // Regular variant
   },
   {
-    description: 'small',
+    description: "small",
     context: {
       small: true,
       fieldset: {
         legend: {
-          size: 'm'
+          size: "m"
         }
       }
     }
@@ -32,479 +32,479 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      name: 'example',
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'disabled',
-      name: 'example',
+      idPrefix: "disabled",
+      name: "example",
       disabled: true,
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'disabled input': {
+  "disabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'disabled-input',
-      name: 'example',
+      idPrefix: "disabled-input",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message',
+          value: "text",
+          text: "Text message",
           disabled: true
         }
       ]
     },
     variants
   },
-  'disabled with enabled input': {
+  "disabled with enabled input": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'disabled-enabled-input',
-      name: 'example',
+      idPrefix: "disabled-enabled-input",
+      name: "example",
       disabled: true,
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message',
+          value: "text",
+          text: "Text message",
           disabled: false
         }
       ]
     },
     variants
   },
-  'with hint': {
+  "with hint": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'with-hint',
-      name: 'example',
+      idPrefix: "with-hint",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants
   },
-  'inline': {
+  "inline": {
     context: {
       fieldset: {
         legend: {
-          text: 'Are you 18 or over?',
-          size: 'l',
+          text: "Are you 18 or over?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'inline',
-      name: 'example',
+      idPrefix: "inline",
+      name: "example",
       inline: true,
       items: [
         {
-          value: 'yes',
-          text: 'Yes'
+          value: "yes",
+          text: "Yes"
         },
         {
-          value: 'no',
-          text: 'No'
+          value: "no",
+          text: "No"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'legend': {
+  "legend": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l'
+          text: "How do you want to be contacted about this?",
+          size: "l"
         }
       },
-      idPrefix: 'custom-size',
-      name: 'example',
+      idPrefix: "custom-size",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           fieldset: {
             legend: {
-              size: 's'
+              size: "s"
             }
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           fieldset: {
             legend: {
-              size: 'm'
+              size: "m"
             }
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           fieldset: {
             legend: {
-              size: 'l'
+              size: "l"
             }
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           fieldset: {
             legend: {
-              size: 'xl'
+              size: "xl"
             }
           }
         }
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
+          text: "How do you want to be contacted about this?",
           isPageHeading: false
         }
       },
-      idPrefix: 'without-heading',
-      name: 'example',
+      idPrefix: "without-heading",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants
   },
-  'with pre-checked value': {
+  "with pre-checked value": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'conditional',
-      name: 'example',
-      value: 'email',
+      idPrefix: "conditional",
+      name: "example",
+      value: "email",
       items: getItems()
     },
     variants
   },
-  'with divider': {
+  "with divider": {
     context: {
       fieldset: {
         legend: {
-          text: 'Do you know your NHS number?',
-          size: 'l',
+          text: "Do you know your NHS number?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
         html: 'This is a 10 digit number (like <span class="nhsuk-u-nowrap">999 123 4567</span>) that you can find on an NHS letter, prescription or in the NHS App'
       },
-      idPrefix: 'with-divider',
-      name: 'example',
+      idPrefix: "with-divider",
+      name: "example",
       items: [
         {
-          value: 'yes',
-          text: 'Yes, I know my NHS number'
+          value: "yes",
+          text: "Yes, I know my NHS number"
         },
         {
-          value: 'no',
-          text: 'No, I do not know my NHS number'
+          value: "no",
+          text: "No, I do not know my NHS number"
         },
         {
-          divider: 'or'
+          divider: "or"
         },
         {
-          value: 'not sure',
+          value: "not sure",
           text: "I'm not sure"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with hints on items': {
+  "with hints on items": {
     context: {
       fieldset: {
         legend: {
-          text: 'Do you have a mobile phone with signal?',
-          size: 'l',
+          text: "Do you have a mobile phone with signal?",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'with-hint-item',
-      name: 'example',
+      idPrefix: "with-hint-item",
+      name: "example",
       items: [
         {
-          value: 'mobile',
-          text: 'Yes, I have a mobile phone with signal',
+          value: "mobile",
+          text: "Yes, I have a mobile phone with signal",
           hint: {
-            text: 'We will text you a 6 digit security code'
+            text: "We will text you a 6 digit security code"
           }
         },
         {
-          value: 'landline',
-          text: 'No, I want to use my landline',
+          value: "landline",
+          text: "No, I want to use my landline",
           hint: {
-            text: 'We will call you to give you a 6 digit security code'
+            text: "We will call you to give you a 6 digit security code"
           }
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without fieldset': {
+  "without fieldset": {
     context: {
       fieldset: null,
-      idPrefix: 'without-fieldset',
-      name: 'colours',
+      idPrefix: "without-fieldset",
+      name: "colours",
       items: [
         {
-          value: 'red',
-          text: 'Red'
+          value: "red",
+          text: "Red"
         },
         {
-          value: 'green',
-          text: 'Green'
+          value: "green",
+          text: "Green"
         },
         {
-          value: 'blue',
-          text: 'Blue'
+          value: "blue",
+          text: "Blue"
         }
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       errorMessage: {
-        text: 'Select how you want to be contacted'
+        text: "Select how you want to be contacted"
       },
-      idPrefix: 'with-error-message',
-      name: 'example',
+      idPrefix: "with-error-message",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
       errorMessage: {
-        text: 'Select how you want to be contacted'
+        text: "Select how you want to be contacted"
       },
-      idPrefix: 'with-hint-error',
-      name: 'example',
+      idPrefix: "with-hint-error",
+      name: "example",
       items: [
         {
-          value: 'email',
-          text: 'Email'
+          value: "email",
+          text: "Email"
         },
         {
-          value: 'phone',
-          text: 'Phone'
+          value: "phone",
+          text: "Phone"
         },
         {
-          value: 'text',
-          text: 'Text message'
+          value: "text",
+          text: "Text message"
         }
       ]
     },
     variants,
     screenshot: {
-      states: ['focus'],
-      selector: '#with-hint-error',
-      viewports: ['mobile', 'tablet', 'desktop']
+      states: ["focus"],
+      selector: "#with-hint-error",
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with long text': {
+  "with long text": {
     context: {
       fieldset: {
         legend: {
-          text: 'Venenatis Condimentum',
-          size: 'l',
+          text: "Venenatis Condimentum",
+          size: "l",
           isPageHeading: true
         }
       },
-      idPrefix: 'with-long-text',
-      name: 'example',
+      idPrefix: "with-long-text",
+      name: "example",
       items: [
         {
-          value: 'nullam',
+          value: "nullam",
           text: outdent`
             Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
             quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
@@ -513,7 +513,7 @@ const fixtures = {
           `
         },
         {
-          value: 'aenean',
+          value: "aenean",
           text: outdent`
             Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
             vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
@@ -525,7 +525,7 @@ const fixtures = {
           `
         },
         {
-          value: 'fusce',
+          value: "fusce",
           text: outdent`
             Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
             nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
@@ -539,38 +539,38 @@ const fixtures = {
     },
     variants
   },
-  'with conditional content': {
+  "with conditional content": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'conditional',
-      name: 'example',
+      idPrefix: "conditional",
+      name: "example",
       items: getItems()
     },
     variants
   },
-  'with conditional content, special characters': {
+  "with conditional content, special characters": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'user.profile[contact-prefs]',
-      name: 'example',
+      idPrefix: "user.profile[contact-prefs]",
+      name: "example",
       items: getItems()
     },
     options: {
@@ -578,86 +578,86 @@ const fixtures = {
     },
     variants
   },
-  'with conditional content, error message': {
+  "with conditional content, error message": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
       errorMessage: {
-        text: 'Select how you want to be contacted'
+        text: "Select how you want to be contacted"
       },
-      idPrefix: 'conditional',
-      name: 'example',
+      idPrefix: "conditional",
+      name: "example",
       items: getItems()
     },
     variants
   },
-  'with conditional content, error message (nested)': {
+  "with conditional content, error message (nested)": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'conditional',
-      name: 'example',
-      value: 'phone',
+      idPrefix: "conditional",
+      name: "example",
+      value: "phone",
       items: getItems({ invalid: true })
     },
     variants,
     screenshot: {
-      states: ['focus'],
-      selector: '#conditional-2',
-      viewports: ['mobile', 'tablet', 'desktop']
+      states: ["focus"],
+      selector: "#conditional-2",
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with nested conditional radios': {
+  "with nested conditional radios": {
     context: {
       fieldset: {
         legend: {
-          text: 'How do you want to be contacted about this?',
-          size: 'l',
+          text: "How do you want to be contacted about this?",
+          size: "l",
           isPageHeading: true
         }
       },
       hint: {
-        text: 'Select 1 option'
+        text: "Select 1 option"
       },
-      idPrefix: 'conditional-nested',
-      name: 'example-outer',
+      idPrefix: "conditional-nested",
+      name: "example-outer",
       items: [
         {
-          value: 'no-conditional',
-          text: 'No conditional'
+          value: "no-conditional",
+          text: "No conditional"
         },
         {
-          value: 'nested',
-          text: 'Nested conditional',
+          value: "nested",
+          text: "Nested conditional",
           conditional: {
-            html: components.render('radios', {
+            html: components.render("radios", {
               context: {
                 fieldset: {
                   legend: {
-                    text: 'How do you want to be contacted about this?',
-                    size: 's'
+                    text: "How do you want to be contacted about this?",
+                    size: "s"
                   }
                 },
                 hint: {
-                  text: 'Select 1 option'
+                  text: "Select 1 option"
                 },
-                name: 'example-inner',
+                name: "example-inner",
                 items: getItems()
               }
             })
@@ -675,35 +675,35 @@ const fixtures = {
  * @returns {object[]}
  */
 function getItems(options = {}) {
-  let input1 = inputExamples['example email address']
-  let input2 = inputExamples['example phone number']
-  let input3 = inputExamples['example mobile phone number']
+  let input1 = inputExamples["example email address"]
+  let input2 = inputExamples["example phone number"]
+  let input3 = inputExamples["example mobile phone number"]
 
   // Include error message example (optional)
   if (options.invalid) {
-    input2 = inputExamples['example phone number with error message']
+    input2 = inputExamples["example phone number with error message"]
   }
 
   return [
     {
-      value: 'email',
-      text: 'Email',
+      value: "email",
+      text: "Email",
       conditional: {
-        html: components.render('input', input1)
+        html: components.render("input", input1)
       }
     },
     {
-      value: 'phone',
-      text: 'Phone',
+      value: "phone",
+      text: "Phone",
       conditional: {
-        html: components.render('input', input2)
+        html: components.render("input", input2)
       }
     },
     {
-      value: 'text',
-      text: 'Text message',
+      value: "text",
+      text: "Text message",
       conditional: {
-        html: components.render('input', input3)
+        html: components.render("input", input3)
       }
     }
   ]

--- a/packages/nhsuk-frontend/src/nhsuk/components/search-input/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/search-input/fixtures.mjs
@@ -4,334 +4,334 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
-      placeholder: 'NHS number',
+      placeholder: "NHS number",
       hint: {
-        text: 'This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App'
+        text: "This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
-      placeholder: 'NHS number',
-      name: 'example',
+      placeholder: "NHS number",
+      name: "example",
       disabled: true
     },
     screenshot: true
   },
-  'disabled with enabled button': {
+  "disabled with enabled button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
-      placeholder: 'NHS number',
-      name: 'example',
+      placeholder: "NHS number",
+      name: "example",
       disabled: true,
       button: {
         disabled: false
       }
     }
   },
-  'disabled button': {
+  "disabled button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
-      placeholder: 'NHS number',
-      name: 'example',
+      placeholder: "NHS number",
+      name: "example",
       button: {
         disabled: true
       }
     }
   },
-  'large': {
+  "large": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'l',
+        text: "Search by NHS number",
+        size: "l",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       large: true,
       width: 30
     },
     screenshot: true
   },
-  'large with brand button': {
+  "large with brand button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'l',
+        text: "Search by NHS number",
+        size: "l",
         isPageHeading: true
       },
       button: {
-        variant: 'brand'
+        variant: "brand"
       },
-      name: 'example',
+      name: "example",
       large: true,
       width: 30
     }
   },
-  'with alternative icon': {
+  "with alternative icon": {
     context: {
       label: {
-        text: 'Search by postcode',
-        size: 'm',
+        text: "Search by postcode",
+        size: "m",
         isPageHeading: true
       },
       button: {
-        icon: 'arrow-right'
+        icon: "arrow-right"
       },
-      name: 'example',
+      name: "example",
       width: 10
     }
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       hint: {
-        text: 'This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App'
+        text: "This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App"
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       width: 20
     },
     screenshot: true
   },
-  'with hint and value': {
+  "with hint and value": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       hint: {
-        text: 'This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App'
+        text: "This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App"
       },
-      name: 'example',
-      value: '999 123 4567',
+      name: "example",
+      value: "999 123 4567",
       width: 20
     },
     screenshot: true
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Enter NHS number'
+        text: "Enter NHS number"
       },
-      name: 'example',
-      value: '999 123 4567',
+      name: "example",
+      value: "999 123 4567",
       width: 20
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       hint: {
-        text: 'This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App'
+        text: "This is a 10 digit number (like 999 123 4567) that you can find on an NHS letter, prescription or in the NHS App"
       },
       errorMessage: {
-        text: 'Enter NHS number'
+        text: "Enter NHS number"
       },
-      name: 'example',
-      value: '999 123 4567',
+      name: "example",
+      value: "999 123 4567",
       width: 20
     },
     screenshot: true
   },
-  'with prefix': {
+  "with prefix": {
     context: {
       label: {
-        text: 'Code lookup',
-        size: 'm',
+        text: "Code lookup",
+        size: "m",
         isPageHeading: true
       },
       prefix: {
-        text: 'SNOMED'
+        text: "SNOMED"
       },
-      id: 'with-prefix',
-      name: 'example',
-      value: '160245001',
+      id: "with-prefix",
+      name: "example",
+      value: "160245001",
       width: 10,
       code: true,
       button: {
-        icon: 'arrow-right',
-        variant: 'brand'
+        icon: "arrow-right",
+        variant: "brand"
       }
     }
   },
-  'with prefix and error message': {
+  "with prefix and error message": {
     context: {
       label: {
-        text: 'Code lookup',
-        size: 'm',
+        text: "Code lookup",
+        size: "m",
         isPageHeading: true
       },
       prefix: {
-        text: 'SNOMED'
+        text: "SNOMED"
       },
       errorMessage: {
-        text: 'Enter a SNOMED code'
+        text: "Enter a SNOMED code"
       },
-      id: 'with-prefix',
-      name: 'example',
+      id: "with-prefix",
+      name: "example",
       width: 10,
       code: true,
       button: {
-        icon: 'arrow-right',
-        variant: 'brand'
+        icon: "arrow-right",
+        variant: "brand"
       }
     }
   },
-  'with hidden label': {
+  "with hidden label": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        classes: 'nhsuk-u-visually-hidden'
+        text: "Search by NHS number",
+        classes: "nhsuk-u-visually-hidden"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'with brand button': {
+  "with brand button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       button: {
-        variant: 'brand'
+        variant: "brand"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'with brand button text': {
+  "with brand button text": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       button: {
-        text: 'Search',
-        variant: 'brand'
+        text: "Search",
+        variant: "brand"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'with brand button text only': {
+  "with brand button text only": {
     context: {
       label: {
-        text: 'Product order number',
-        size: 'm',
+        text: "Product order number",
+        size: "m",
         isPageHeading: true
       },
       button: {
         icon: false,
-        text: 'Find',
-        variant: 'brand'
+        text: "Find",
+        variant: "brand"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'with secondary button': {
+  "with secondary button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       button: {
-        variant: 'secondary'
+        variant: "secondary"
       },
-      name: 'example',
+      name: "example",
       width: 20
     },
     screenshot: true
   },
-  'with secondary button text': {
+  "with secondary button text": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       button: {
-        text: 'Search',
-        variant: 'secondary'
+        text: "Search",
+        variant: "secondary"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'with secondary button text only': {
+  "with secondary button text only": {
     context: {
       label: {
-        text: 'Product order number',
-        size: 'm',
+        text: "Product order number",
+        size: "m",
         isPageHeading: true
       },
       button: {
         icon: false,
-        text: 'Find',
-        variant: 'secondary'
+        text: "Find",
+        variant: "secondary"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'without button': {
+  "without button": {
     context: {
       label: {
-        text: 'Search by NHS number',
-        size: 'm',
+        text: "Search by NHS number",
+        size: "m",
         isPageHeading: true
       },
       button: false,
-      name: 'example',
+      name: "example",
       width: 20
     }
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Search by NHS number'
+        text: "Search by NHS number"
       },
-      name: 'example',
+      name: "example",
       width: 20
     }
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/select/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/select/fixtures.mjs
@@ -1,6 +1,6 @@
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as buttonExamples } from '../button/fixtures.mjs'
+import { examples as buttonExamples } from "../button/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -8,378 +8,378 @@ import { examples as buttonExamples } from '../button/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Sort by',
+        text: "Sort by",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments'
+          value: "comments",
+          text: "Most comments"
         }
       ]
     },
     screenshot: true
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Sort by',
+        text: "Sort by",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       disabled: true,
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments'
+          value: "comments",
+          text: "Most comments"
         }
       ]
     },
     screenshot: true
   },
-  'disabled option': {
+  "disabled option": {
     context: {
       label: {
-        text: 'Sort by',
+        text: "Sort by",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments',
+          value: "comments",
+          text: "Most comments",
           disabled: true
         }
       ]
     }
   },
-  'with divider': {
+  "with divider": {
     context: {
       label: {
-        text: 'Sort by',
+        text: "Sort by",
         isPageHeading: true
       },
-      name: 'example',
+      name: "example",
       items: [
         {
-          value: 'first-name-ascending',
-          text: 'First name (A to Z)'
+          value: "first-name-ascending",
+          text: "First name (A to Z)"
         },
         {
-          value: 'first-name-descending',
-          text: 'First name (Z to A)'
+          value: "first-name-descending",
+          text: "First name (Z to A)"
         },
         {
           divider: true
         },
         {
-          value: 'last-name-ascending',
-          text: 'Last name (A to Z)'
+          value: "last-name-ascending",
+          text: "Last name (A to Z)"
         },
         {
-          value: 'last-name-descending',
-          text: 'Last name (Z to A)'
+          value: "last-name-descending",
+          text: "Last name (Z to A)"
         }
       ]
     }
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Choose location',
+        text: "Choose location",
         isPageHeading: true
       },
       hint: {
-        text: 'This can be different to where you went before'
+        text: "This can be different to where you went before"
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       items: [
         {
-          value: 'choose',
-          text: 'Choose location'
+          value: "choose",
+          text: "Choose location"
         },
         {
-          value: 'eastmidlands',
-          text: 'East Midlands'
+          value: "eastmidlands",
+          text: "East Midlands"
         },
         {
-          value: 'eastofengland',
-          text: 'East of England'
+          value: "eastofengland",
+          text: "East of England"
         },
         {
-          value: 'london',
-          text: 'London'
+          value: "london",
+          text: "London"
         },
         {
-          value: 'northeast',
-          text: 'North East'
+          value: "northeast",
+          text: "North East"
         },
         {
-          value: 'northwest',
-          text: 'North West'
+          value: "northwest",
+          text: "North West"
         },
         {
-          value: 'southeast',
-          text: 'South East'
+          value: "southeast",
+          text: "South East"
         },
         {
-          value: 'southwest',
-          text: 'South West'
+          value: "southwest",
+          text: "South West"
         },
         {
-          value: 'westmidlands',
-          text: 'West Midlands'
+          value: "westmidlands",
+          text: "West Midlands"
         },
         {
-          value: 'yorkshire',
-          text: 'Yorkshire and the Humber'
+          value: "yorkshire",
+          text: "Yorkshire and the Humber"
         }
       ]
     },
     screenshot: true
   },
-  'with button': {
+  "with button": {
     context: {
       label: {
-        text: 'Choose location',
+        text: "Choose location",
         isPageHeading: true
       },
       hint: {
-        text: 'This can be different to where you went before'
+        text: "This can be different to where you went before"
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       items: [
         {
-          value: 'choose',
-          text: 'Choose location'
+          value: "choose",
+          text: "Choose location"
         },
         {
-          value: 'eastmidlands',
-          text: 'East Midlands'
+          value: "eastmidlands",
+          text: "East Midlands"
         },
         {
-          value: 'eastofengland',
-          text: 'East of England'
+          value: "eastofengland",
+          text: "East of England"
         },
         {
-          value: 'london',
-          text: 'London'
+          value: "london",
+          text: "London"
         },
         {
-          value: 'northeast',
-          text: 'North East'
+          value: "northeast",
+          text: "North East"
         },
         {
-          value: 'northwest',
-          text: 'North West'
+          value: "northwest",
+          text: "North West"
         },
         {
-          value: 'southeast',
-          text: 'South East'
+          value: "southeast",
+          text: "South East"
         },
         {
-          value: 'southwest',
-          text: 'South West'
+          value: "southwest",
+          text: "South West"
         },
         {
-          value: 'westmidlands',
-          text: 'West Midlands'
+          value: "westmidlands",
+          text: "West Midlands"
         },
         {
-          value: 'yorkshire',
-          text: 'Yorkshire and the Humber'
+          value: "yorkshire",
+          text: "Yorkshire and the Humber"
         }
       ],
       formGroup: {
         afterInput: {
           html: components.render(
-            'button',
-            buttonExamples['example secondary save button, small']
+            "button",
+            buttonExamples["example secondary save button, small"]
           )
         }
       }
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'with button and error message': {
+  "with button and error message": {
     context: {
       label: {
-        text: 'Choose location',
+        text: "Choose location",
         isPageHeading: true
       },
       hint: {
-        text: 'This can be different to where you went before'
+        text: "This can be different to where you went before"
       },
       errorMessage: {
-        text: 'Select a location'
+        text: "Select a location"
       },
-      id: 'with-hint',
-      name: 'example',
+      id: "with-hint",
+      name: "example",
       items: [
         {
-          value: 'choose',
-          text: 'Choose location'
+          value: "choose",
+          text: "Choose location"
         },
         {
-          value: 'eastmidlands',
-          text: 'East Midlands'
+          value: "eastmidlands",
+          text: "East Midlands"
         },
         {
-          value: 'eastofengland',
-          text: 'East of England'
+          value: "eastofengland",
+          text: "East of England"
         },
         {
-          value: 'london',
-          text: 'London'
+          value: "london",
+          text: "London"
         },
         {
-          value: 'northeast',
-          text: 'North East'
+          value: "northeast",
+          text: "North East"
         },
         {
-          value: 'northwest',
-          text: 'North West'
+          value: "northwest",
+          text: "North West"
         },
         {
-          value: 'southeast',
-          text: 'South East'
+          value: "southeast",
+          text: "South East"
         },
         {
-          value: 'southwest',
-          text: 'South West'
+          value: "southwest",
+          text: "South West"
         },
         {
-          value: 'westmidlands',
-          text: 'West Midlands'
+          value: "westmidlands",
+          text: "West Midlands"
         },
         {
-          value: 'yorkshire',
-          text: 'Yorkshire and the Humber'
+          value: "yorkshire",
+          text: "Yorkshire and the Humber"
         }
       ],
       formGroup: {
         afterInput: {
           html: components.render(
-            'button',
-            buttonExamples['example secondary save button, small']
+            "button",
+            buttonExamples["example secondary save button, small"]
           )
         }
       }
     },
     screenshot: {
-      viewports: ['watch', 'mobile', 'tablet', 'desktop']
+      viewports: ["watch", "mobile", "tablet", "desktop"]
     }
   },
-  'label': {
+  "label": {
     context: {
       label: {
-        text: 'Sort by',
-        size: 'l',
+        text: "Sort by",
+        size: "l",
         isPageHeading: true
       },
-      id: 'custom-size',
-      name: 'example',
+      id: "custom-size",
+      name: "example",
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments'
+          value: "comments",
+          text: "Most comments"
         }
       ]
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           label: {
-            size: 's'
+            size: "s"
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           label: {
-            size: 'm'
+            size: "m"
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           label: {
-            size: 'l'
+            size: "l"
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           label: {
-            size: 'xl'
+            size: "xl"
           }
         }
       },
       {
-        description: 'with id attribute on',
+        description: "with id attribute on",
         context: {
           label: {
-            id: 'custom-id'
+            id: "custom-id"
           }
         },
         options: {
@@ -388,175 +388,175 @@ const fixtures = {
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Sort by'
+        text: "Sort by"
       },
-      id: 'without-heading',
-      name: 'example',
+      id: "without-heading",
+      name: "example",
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments'
+          value: "comments",
+          text: "Most comments"
         }
       ]
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Choose location',
+        text: "Choose location",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'Select a location'
+        text: "Select a location"
       },
-      id: 'with-error-message',
-      name: 'example',
+      id: "with-error-message",
+      name: "example",
       items: [
         {
-          value: 'choose',
-          text: 'Choose location'
+          value: "choose",
+          text: "Choose location"
         },
         {
-          value: 'eastmidlands',
-          text: 'East Midlands'
+          value: "eastmidlands",
+          text: "East Midlands"
         },
         {
-          value: 'eastofengland',
-          text: 'East of England'
+          value: "eastofengland",
+          text: "East of England"
         },
         {
-          value: 'london',
-          text: 'London'
+          value: "london",
+          text: "London"
         },
         {
-          value: 'northeast',
-          text: 'North East'
+          value: "northeast",
+          text: "North East"
         },
         {
-          value: 'northwest',
-          text: 'North West'
+          value: "northwest",
+          text: "North West"
         },
         {
-          value: 'southeast',
-          text: 'South East'
+          value: "southeast",
+          text: "South East"
         },
         {
-          value: 'southwest',
-          text: 'South West'
+          value: "southwest",
+          text: "South West"
         },
         {
-          value: 'westmidlands',
-          text: 'West Midlands'
+          value: "westmidlands",
+          text: "West Midlands"
         },
         {
-          value: 'yorkshire',
-          text: 'Yorkshire and the Humber'
+          value: "yorkshire",
+          text: "Yorkshire and the Humber"
         }
       ]
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Choose location',
+        text: "Choose location",
         isPageHeading: true
       },
       hint: {
-        text: 'This can be different to where you went before'
+        text: "This can be different to where you went before"
       },
       errorMessage: {
-        text: 'Select a location'
+        text: "Select a location"
       },
-      id: 'with-hint-error',
-      name: 'example',
+      id: "with-hint-error",
+      name: "example",
       items: [
         {
-          value: 'choose',
-          text: 'Choose location'
+          value: "choose",
+          text: "Choose location"
         },
         {
-          value: 'eastmidlands',
-          text: 'East Midlands'
+          value: "eastmidlands",
+          text: "East Midlands"
         },
         {
-          value: 'eastofengland',
-          text: 'East of England'
+          value: "eastofengland",
+          text: "East of England"
         },
         {
-          value: 'london',
-          text: 'London'
+          value: "london",
+          text: "London"
         },
         {
-          value: 'northeast',
-          text: 'North East'
+          value: "northeast",
+          text: "North East"
         },
         {
-          value: 'northwest',
-          text: 'North West'
+          value: "northwest",
+          text: "North West"
         },
         {
-          value: 'southeast',
-          text: 'South East'
+          value: "southeast",
+          text: "South East"
         },
         {
-          value: 'southwest',
-          text: 'South West'
+          value: "southwest",
+          text: "South West"
         },
         {
-          value: 'westmidlands',
-          text: 'West Midlands'
+          value: "westmidlands",
+          text: "West Midlands"
         },
         {
-          value: 'yorkshire',
-          text: 'Yorkshire and the Humber'
+          value: "yorkshire",
+          text: "Yorkshire and the Humber"
         }
       ]
     },
     screenshot: {
-      states: ['focus'],
-      selector: '#with-hint-error'
+      states: ["focus"],
+      selector: "#with-hint-error"
     }
   },
-  'with selected value': {
+  "with selected value": {
     context: {
       label: {
-        text: 'Sort by',
+        text: "Sort by",
         isPageHeading: true
       },
-      id: 'with-value',
-      name: 'example',
-      value: 'updated',
+      id: "with-value",
+      name: "example",
+      value: "updated",
       items: [
         {
-          value: 'published',
-          text: 'Recently published'
+          value: "published",
+          text: "Recently published"
         },
         {
-          value: 'updated',
-          text: 'Recently updated'
+          value: "updated",
+          text: "Recently updated"
         },
         {
-          value: 'views',
-          text: 'Most views'
+          value: "views",
+          text: "Most views"
         },
         {
-          value: 'comments',
-          text: 'Most comments'
+          value: "comments",
+          text: "Most comments"
         }
       ]
     }

--- a/packages/nhsuk-frontend/src/nhsuk/components/skip-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/skip-link/fixtures.mjs
@@ -4,26 +4,26 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      href: '#maincontent',
-      text: 'Skip to main content'
+      href: "#maincontent",
+      text: "Skip to main content"
     }
   },
-  'without hash fragment': {
+  "without hash fragment": {
     context: {
-      href: '/nhsuk-frontend/components/boilerplate/',
-      text: 'Skip to main content'
+      href: "/nhsuk-frontend/components/boilerplate/",
+      text: "Skip to main content"
     },
     options: {
       hidden: true,
       throwOnError: false
     }
   },
-  'without link target': {
+  "without link target": {
     context: {
-      href: '#this-element-does-not-exist',
-      text: 'Skip to main content'
+      href: "#this-element-does-not-exist",
+      text: "Skip to main content"
     },
     options: {
       hidden: true,

--- a/packages/nhsuk-frontend/src/nhsuk/components/summary-list/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/summary-list/fixtures.mjs
@@ -1,6 +1,6 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
 /**
  * Nunjucks macro option examples
@@ -8,28 +8,28 @@ import { components } from '#lib'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -41,7 +41,7 @@ const fixtures = {
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -53,49 +53,49 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with actions': {
+  "with actions": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           },
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'name'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "name"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -107,16 +107,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -127,9 +127,9 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
@@ -137,49 +137,49 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with actions as buttons': {
+  "with actions as buttons": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           },
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'name'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "name"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -191,16 +191,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -211,9 +211,9 @@ const fixtures = {
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
@@ -221,40 +221,40 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with multiple actions': {
+  "with multiple actions": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -266,16 +266,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -286,21 +286,21 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new contact details'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new contact details"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Medicines'
+            text: "Medicines"
           },
           value: {
             html: outdent`
@@ -312,14 +312,14 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new medicine'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new medicine"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'medicines'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "medicines"
               }
             ]
           }
@@ -327,40 +327,40 @@ const fixtures = {
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with multiple actions as buttons': {
+  "with multiple actions as buttons": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -372,16 +372,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -392,21 +392,21 @@ const fixtures = {
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Add',
-                visuallyHiddenText: 'new contact details'
+                element: "button",
+                text: "Add",
+                visuallyHiddenText: "new contact details"
               },
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Medicines'
+            text: "Medicines"
           },
           value: {
             html: outdent`
@@ -418,14 +418,14 @@ const fixtures = {
           actions: {
             items: [
               {
-                element: 'button',
-                text: 'Add',
-                visuallyHiddenText: 'new medicine'
+                element: "button",
+                text: "Add",
+                visuallyHiddenText: "new medicine"
               },
               {
-                element: 'button',
-                text: 'Change',
-                visuallyHiddenText: 'medicines'
+                element: "button",
+                text: "Change",
+                visuallyHiddenText: "medicines"
               }
             ]
           }
@@ -433,41 +433,41 @@ const fixtures = {
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with multiple actions (empty items)': {
+  "with multiple actions (empty items)": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               false,
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -480,16 +480,16 @@ const fixtures = {
             items: [
               false,
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -500,21 +500,21 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new contact details'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new contact details"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Medicines'
+            text: "Medicines"
           },
           value: {
             html: outdent`
@@ -526,14 +526,14 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new medicine'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new medicine"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'medicines'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "medicines"
               }
             ]
           }
@@ -541,32 +541,32 @@ const fixtures = {
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'without border': {
+  "without border": {
     context: {
       border: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -578,7 +578,7 @@ const fixtures = {
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -590,32 +590,32 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without last row border': {
+  "without last row border": {
     context: {
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -627,7 +627,7 @@ const fixtures = {
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -639,31 +639,31 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without specific row border': {
+  "without specific row border": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -676,7 +676,7 @@ const fixtures = {
         {
           border: false,
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -688,50 +688,50 @@ const fixtures = {
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'as a card': {
+  "as a card": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm'
+        heading: "Regional Manager",
+        headingSize: "m"
       },
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card with multiple actions': {
+  "as a card with multiple actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'l',
+        heading: "Regional Manager",
+        headingSize: "l",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -740,32 +740,32 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           },
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'date of birth'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact information'
+            text: "Contact information"
           },
           value: {
             html: outdent`
@@ -777,16 +777,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact information'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact information"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Contact details'
+            text: "Contact details"
           },
           value: {
             html: outdent`
@@ -797,21 +797,21 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new contact details'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new contact details"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'contact details'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "contact details"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Medicines'
+            text: "Medicines"
           },
           value: {
             html: outdent`
@@ -823,14 +823,14 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/add',
-                text: 'Add',
-                visuallyHiddenText: 'new medicine'
+                href: "#/add",
+                text: "Add",
+                visuallyHiddenText: "new medicine"
               },
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'medicines'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "medicines"
               }
             ]
           }
@@ -838,19 +838,19 @@ const fixtures = {
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'as a card with action': {
+  "as a card with action": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
+        heading: "Regional Manager",
+        headingSize: "m",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             }
           ]
         }
@@ -859,33 +859,33 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card with action as a button': {
+  "as a card with action as a button": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
+        heading: "Regional Manager",
+        headingSize: "m",
         actions: {
           items: [
             {
-              element: 'button',
-              text: 'Delete'
+              element: "button",
+              text: "Delete"
             }
           ]
         }
@@ -894,37 +894,37 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card with actions': {
+  "as a card with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
+        heading: "Regional Manager",
+        headingSize: "m",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -933,37 +933,37 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card with actions as buttons': {
+  "as a card with actions as buttons": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
+        heading: "Regional Manager",
+        headingSize: "m",
         actions: {
           items: [
             {
-              element: 'button',
-              text: 'Delete'
+              element: "button",
+              text: "Delete"
             },
             {
-              element: 'button',
-              text: 'Withdraw'
+              element: "button",
+              text: "Withdraw"
             }
           ]
         }
@@ -972,38 +972,38 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (secondary) with actions': {
+  "as a card (secondary) with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
-        variant: 'secondary',
+        heading: "Regional Manager",
+        headingSize: "m",
+        variant: "secondary",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -1012,38 +1012,38 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (feature) with actions': {
+  "as a card (feature) with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
-        variant: 'feature',
+        heading: "Regional Manager",
+        headingSize: "m",
+        variant: "feature",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -1052,43 +1052,43 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (feature) with custom HTML': {
+  "as a card (feature) with custom HTML": {
     context: {
       card: {
-        heading: 'Your read',
-        headingSize: 'm',
-        variant: 'feature'
+        heading: "Your read",
+        headingSize: "m",
+        variant: "feature"
       },
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Opinion'
+            text: "Opinion"
           },
           value: {
             html: outdent`
               <p class="nhsuk-u-margin-bottom-3">
-                ${components.render('tag', {
+                ${components.render("tag", {
                   context: {
-                    text: 'Recall for assessment',
-                    colour: 'red'
+                    text: "Recall for assessment",
+                    colour: "red"
                   }
                 })}
               </p>
@@ -1097,16 +1097,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'opinion'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "opinion"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Detailed opinion'
+            text: "Detailed opinion"
           },
           value: {
             html: outdent`
@@ -1116,10 +1116,10 @@ const fixtures = {
                     Right breast
                   </p>
                   <p class="nhsuk-u-margin-bottom-3">
-                    ${components.render('tag', {
+                    ${components.render("tag", {
                       context: {
-                        text: 'Abnormal',
-                        colour: 'red'
+                        text: "Abnormal",
+                        colour: "red"
                       }
                     })}
                   </p>
@@ -1139,16 +1139,16 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'detailed opinion'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "detailed opinion"
               }
             ]
           }
         },
         {
           key: {
-            text: 'Annotations'
+            text: "Annotations"
           },
           value: {
             html: outdent`
@@ -1163,9 +1163,9 @@ const fixtures = {
           actions: {
             items: [
               {
-                href: '#/change',
-                text: 'Change',
-                visuallyHiddenText: 'annotations'
+                href: "#/change",
+                text: "Change",
+                visuallyHiddenText: "annotations"
               }
             ]
           }
@@ -1173,55 +1173,55 @@ const fixtures = {
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'as a card (clickable) without actions': {
+  "as a card (clickable) without actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        headingSize: 'm',
-        href: '#/card-clickable',
+        heading: "Regional Manager",
+        headingSize: "m",
+        href: "#/card-clickable",
         clickable: true
       },
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (type non-urgent) with actions': {
+  "as a card (type non-urgent) with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        variant: 'non-urgent',
+        heading: "Regional Manager",
+        variant: "non-urgent",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -1230,37 +1230,37 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (type urgent) with actions': {
+  "as a card (type urgent) with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        variant: 'urgent',
+        heading: "Regional Manager",
+        variant: "urgent",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -1269,37 +1269,37 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'as a card (type emergency) with actions': {
+  "as a card (type emergency) with actions": {
     context: {
       card: {
-        heading: 'Regional Manager',
-        variant: 'emergency',
+        heading: "Regional Manager",
+        variant: "emergency",
         actions: {
           items: [
             {
-              text: 'Delete',
-              href: '#/delete'
+              text: "Delete",
+              href: "#/delete"
             },
             {
-              text: 'Withdraw',
-              href: '#/withdraw'
+              text: "Withdraw",
+              href: "#/withdraw"
             }
           ]
         }
@@ -1308,40 +1308,40 @@ const fixtures = {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
     }
   },
-  'example person: Karen Francis': {
+  "example person: Karen Francis": {
     context: {
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
@@ -1350,24 +1350,24 @@ const fixtures = {
       hidden: true
     }
   },
-  'example person: Karen Francis (no border)': {
+  "example person: Karen Francis (no border)": {
     context: {
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Karen Francis'
+            text: "Karen Francis"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '15 March 1984'
+            text: "15 March 1984"
           }
         }
       ]
@@ -1376,24 +1376,24 @@ const fixtures = {
       hidden: true
     }
   },
-  'example person: Sarah Philips (no border)': {
+  "example person: Sarah Philips (no border)": {
     context: {
       lastRowBorder: false,
       rows: [
         {
           key: {
-            text: 'Name'
+            text: "Name"
           },
           value: {
-            text: 'Sarah Philips'
+            text: "Sarah Philips"
           }
         },
         {
           key: {
-            text: 'Date of birth'
+            text: "Date of birth"
           },
           value: {
-            text: '5 January 1978'
+            text: "5 January 1978"
           }
         }
       ]

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/fixtures.mjs
@@ -1,6 +1,6 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
 /**
  * Nunjucks macro option variants
@@ -12,46 +12,46 @@ export const variants = [
     // Regular variant
   },
   {
-    description: 'compact',
+    description: "compact",
     context: {
       compact: true
     }
   },
   {
-    description: 'striped',
+    description: "striped",
     context: {
       striped: true
     }
   },
   {
-    description: 'striped compact',
+    description: "striped compact",
     context: {
       compact: true,
       striped: true
     }
   },
   {
-    description: 'responsive',
+    description: "responsive",
     context: {
       responsive: true
     }
   },
   {
-    description: 'responsive compact',
+    description: "responsive compact",
     context: {
       compact: true,
       responsive: true
     }
   },
   {
-    description: 'responsive striped',
+    description: "responsive striped",
     context: {
       responsive: true,
       striped: true
     }
   },
   {
-    description: 'responsive striped compact',
+    description: "responsive striped compact",
     context: {
       compact: true,
       responsive: true,
@@ -59,43 +59,43 @@ export const variants = [
     }
   },
   {
-    description: 'reverse',
+    description: "reverse",
     context: {
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
   {
-    description: 'reverse compact',
+    description: "reverse compact",
     context: {
       compact: true,
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
   {
-    description: 'reverse striped',
+    description: "reverse striped",
     context: {
       striped: true,
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   },
   {
-    description: 'reverse striped compact',
+    description: "reverse striped compact",
     context: {
       compact: true,
       striped: true,
-      variant: 'reverse'
+      variant: "reverse"
     },
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     }
   }
 ]
@@ -106,67 +106,67 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      caption: 'Impetigo can look similar to other skin conditions',
-      captionSize: 'm',
+      caption: "Impetigo can look similar to other skin conditions",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Skin symptoms'
+          text: "Skin symptoms"
         },
         {
-          text: 'Possible cause'
+          text: "Possible cause"
         }
       ],
       rows: [
         [
           {
-            text: 'Blisters on lips or around the mouth'
+            text: "Blisters on lips or around the mouth"
           },
           {
-            text: 'Cold sores'
+            text: "Cold sores"
           }
         ],
         [
           {
-            text: 'Itchy, dry, cracked, sore'
+            text: "Itchy, dry, cracked, sore"
           },
           {
-            text: 'Eczema'
+            text: "Eczema"
           }
         ],
         [
           {
-            text: 'Itchy blisters'
+            text: "Itchy blisters"
           },
           {
-            text: 'Shingles, chickenpox'
+            text: "Shingles, chickenpox"
           }
         ]
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with column widths': {
+  "with column widths": {
     context: {
-      caption: 'Ibuprofen syrup dosages for children',
-      captionSize: 'm',
+      caption: "Ibuprofen syrup dosages for children",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Age',
-          width: 'one-third'
+          text: "Age",
+          width: "one-third"
         },
         {
-          text: 'How much?',
-          width: 'one-quarter'
+          text: "How much?",
+          width: "one-quarter"
         },
         {
-          text: 'How often?'
+          text: "How often?"
         }
       ],
       rows: [
@@ -175,118 +175,118 @@ const fixtures = {
             html: '3 to 5 months <span class="nhsuk-u-font-weight-normal">(weighing more than 5kg)</span>'
           },
           {
-            text: '2.5ml'
+            text: "2.5ml"
           },
           {
-            text: 'Max 3 times in 24 hours'
+            text: "Max 3 times in 24 hours"
           }
         ],
         [
           {
-            text: '6 to 11 months'
+            text: "6 to 11 months"
           },
           {
-            text: '2.5ml'
+            text: "2.5ml"
           },
           {
-            text: 'Max 3 to 4 times in 24 hours'
+            text: "Max 3 to 4 times in 24 hours"
           }
         ],
         [
           {
-            text: '1 to 3 years'
+            text: "1 to 3 years"
           },
           {
-            text: '5ml'
+            text: "5ml"
           },
           {
-            text: 'Max 3 times in 24 hours'
+            text: "Max 3 times in 24 hours"
           }
         ],
         [
           {
-            text: '4 to 6 years'
+            text: "4 to 6 years"
           },
           {
-            text: '7.5ml'
+            text: "7.5ml"
           },
           {
-            text: 'Max 3 times in 24 hours'
+            text: "Max 3 times in 24 hours"
           }
         ],
         [
           {
-            text: '7 to 9 years'
+            text: "7 to 9 years"
           },
           {
-            text: '10ml'
+            text: "10ml"
           },
           {
-            text: 'Max 3 times in 24 hours'
+            text: "Max 3 times in 24 hours"
           }
         ],
         [
           {
-            text: '10 to 11 years'
+            text: "10 to 11 years"
           },
           {
-            text: '15ml'
+            text: "15ml"
           },
           {
-            text: 'Max 3 times in 24 hours'
+            text: "Max 3 times in 24 hours"
           }
         ],
         [
           {
-            text: '12 to 17 years'
+            text: "12 to 17 years"
           },
           {
-            text: '15ml to 20ml'
+            text: "15ml to 20ml"
           },
           {
-            text: 'Max 3 to 4 times in 24 hours'
+            text: "Max 3 to 4 times in 24 hours"
           }
         ]
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with custom HTML': {
+  "with custom HTML": {
     context: {
-      caption: 'Nunjucks macro options',
+      caption: "Nunjucks macro options",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Name'
+          text: "Name"
         },
         {
-          text: 'Type'
+          text: "Type"
         },
         {
-          text: 'Description'
+          text: "Description"
         }
       ],
       rows: [
         [
           {
-            text: 'id'
+            text: "id"
           },
           {
-            text: 'string'
+            text: "string"
           },
           {
-            text: 'The ID of the table.'
+            text: "The ID of the table."
           }
         ],
         [
           {
-            text: 'rows'
+            text: "rows"
           },
           {
-            text: 'array'
+            text: "array"
           },
           {
             html: outdent`
@@ -297,10 +297,10 @@ const fixtures = {
         ],
         [
           {
-            text: 'head'
+            text: "head"
           },
           {
-            text: 'array'
+            text: "array"
           },
           {
             html: outdent`
@@ -311,32 +311,32 @@ const fixtures = {
         ],
         [
           {
-            text: 'caption'
+            text: "caption"
           },
           {
-            text: 'string'
+            text: "string"
           },
           {
-            text: 'Caption text.'
+            text: "Caption text."
           }
         ],
         [
           {
-            text: 'captionClasses'
+            text: "captionClasses"
           },
           {
-            text: 'string'
+            text: "string"
           },
           {
-            text: 'Classes for caption text size. Classes should correspond to the available typography heading classes.'
+            text: "Classes for caption text size. Classes should correspond to the available typography heading classes."
           }
         ],
         [
           {
-            text: 'firstCellIsHeader'
+            text: "firstCellIsHeader"
           },
           {
-            text: 'string'
+            text: "string"
           },
           {
             html: outdent`
@@ -346,121 +346,121 @@ const fixtures = {
         ],
         [
           {
-            text: 'classes'
+            text: "classes"
           },
           {
-            text: 'string'
+            text: "string"
           },
           {
-            text: 'Classes to add to the table container.'
+            text: "Classes to add to the table container."
           }
         ],
         [
           {
-            text: 'attributes'
+            text: "attributes"
           },
           {
-            text: 'object'
+            text: "object"
           },
           {
-            text: '	HTML attributes (for example data attributes) to add to the table container.'
+            text: "	HTML attributes (for example data attributes) to add to the table container."
           }
         ]
       ]
     }
   },
-  'with first cell as header': {
+  "with first cell as header": {
     context: {
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Day of the week'
+          text: "Day of the week"
         },
         {
-          text: 'Opening hours'
+          text: "Opening hours"
         }
       ],
       rows: [
         [
           {
-            text: 'Monday'
+            text: "Monday"
           },
           {
-            text: '9am to 6pm'
+            text: "9am to 6pm"
           }
         ],
         [
           {
-            text: 'Tuesday'
+            text: "Tuesday"
           },
           {
-            text: '9am to 6pm'
+            text: "9am to 6pm"
           }
         ],
         [
           {
-            text: 'Wednesday'
+            text: "Wednesday"
           },
           {
-            text: '9am to 6pm'
+            text: "9am to 6pm"
           }
         ],
         [
           {
-            text: 'Thursday'
+            text: "Thursday"
           },
           {
-            text: '9am to 6pm'
+            text: "9am to 6pm"
           }
         ],
         [
           {
-            text: 'Friday'
+            text: "Friday"
           },
           {
-            text: '9am to 6pm'
+            text: "9am to 6pm"
           }
         ],
         [
           {
-            text: 'Saturday'
+            text: "Saturday"
           },
           {
-            text: '9am to 1pm'
+            text: "9am to 1pm"
           }
         ],
         [
           {
-            text: 'Sunday'
+            text: "Sunday"
           },
           {
-            text: 'Closed'
+            text: "Closed"
           }
         ]
       ]
     }
   },
-  'with empty items': {
+  "with empty items": {
     context: {
-      caption: 'Vaccinations given',
-      captionSize: 'm',
+      caption: "Vaccinations given",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Date'
+          text: "Date"
         },
         {
-          text: 'Vaccine'
+          text: "Vaccine"
         },
         false
       ],
       rows: [
         [
           {
-            text: '10 July 2024'
+            text: "10 July 2024"
           },
           {
-            text: 'RSV'
+            text: "RSV"
           },
           false
         ],
@@ -468,405 +468,405 @@ const fixtures = {
       ]
     }
   },
-  'with missing data': {
+  "with missing data": {
     context: {
-      caption: 'Vaccinations given',
-      captionSize: 'm',
+      caption: "Vaccinations given",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Date'
+          text: "Date"
         },
         {
-          text: 'Vaccine'
+          text: "Vaccine"
         },
         {
-          text: 'Product'
+          text: "Product"
         }
       ],
       rows: [
         [
           {
-            text: '10 July 2024'
+            text: "10 July 2024"
           },
           {
-            text: 'RSV'
+            text: "RSV"
           },
           {
-            text: 'Abrysvo'
+            text: "Abrysvo"
           }
         ],
         [
           {
-            text: '6 September 2023'
+            text: "6 September 2023"
           },
           {
-            text: 'Flu'
+            text: "Flu"
           },
           {
-            text: 'No data',
-            classes: 'nhsuk-u-secondary-text-colour'
+            text: "No data",
+            classes: "nhsuk-u-secondary-text-colour"
           }
         ]
       ]
     }
   },
-  'with numeric format': {
+  "with numeric format": {
     context: {
-      caption: 'Prescription prepayment certificate (PPC) charges',
-      captionSize: 'm',
+      caption: "Prescription prepayment certificate (PPC) charges",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Item'
+          text: "Item"
         },
         {
-          text: 'Current charge',
-          format: 'numeric'
+          text: "Current charge",
+          format: "numeric"
         },
         {
-          text: 'New charge',
-          format: 'numeric'
+          text: "New charge",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: '3-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "3-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£31.25'
+            text: "£31.25"
           },
           {
-            text: '£32.05'
+            text: "£32.05"
           }
         ],
         [
           {
-            text: '12-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "12-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£111.60'
+            text: "£111.60"
           },
           {
-            text: '£114.50'
+            text: "£114.50"
           }
         ],
         [
           {
-            text: 'HRT'
+            text: "HRT"
           },
           {
-            text: '£19.30'
+            text: "£19.30"
           },
           {
-            text: '£19.80'
+            text: "£19.80"
           }
         ]
       ]
     },
     variants
   },
-  'with numeric format and missing data': {
+  "with numeric format and missing data": {
     context: {
-      caption: 'Prescription prepayment certificate (PPC) charges',
-      captionSize: 'm',
+      caption: "Prescription prepayment certificate (PPC) charges",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Item'
+          text: "Item"
         },
         {
-          text: 'Current charge',
-          format: 'numeric'
+          text: "Current charge",
+          format: "numeric"
         },
         {
-          text: 'New charge',
-          format: 'numeric'
+          text: "New charge",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: '3-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "3-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£31.25'
+            text: "£31.25"
           },
           {
-            text: '£32.05'
+            text: "£32.05"
           }
         ],
         [
           {
-            text: '12-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "12-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£111.60'
+            text: "£111.60"
           },
           {
-            text: 'No data',
-            format: 'string',
-            classes: 'nhsuk-u-secondary-text-colour'
+            text: "No data",
+            format: "string",
+            classes: "nhsuk-u-secondary-text-colour"
           }
         ],
         [
           {
-            text: 'HRT'
+            text: "HRT"
           },
           {
-            text: '£19.30'
+            text: "£19.30"
           },
           {
-            text: '£19.80'
+            text: "£19.80"
           }
         ]
       ]
     },
     variants
   },
-  'with numeric format (full width, past day)': {
+  "with numeric format (full width, past day)": {
     context: {
-      caption: 'Past day',
+      caption: "Past day",
       head: [
         {
-          text: 'Case manager'
+          text: "Case manager"
         },
         {
-          text: 'Cases opened',
-          format: 'numeric'
+          text: "Cases opened",
+          format: "numeric"
         },
         {
-          text: 'Cases closed',
-          format: 'numeric'
+          text: "Cases closed",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: 'David Francis'
+            text: "David Francis"
           },
           {
-            text: '3'
+            text: "3"
           },
           {
-            text: '0'
+            text: "0"
           }
         ],
         [
           {
-            text: 'Paul Farmer'
+            text: "Paul Farmer"
           },
           {
-            text: '1'
+            text: "1"
           },
           {
-            text: '0'
+            text: "0"
           }
         ],
         [
           {
-            text: 'Rita Patel'
+            text: "Rita Patel"
           },
           {
-            text: '2'
+            text: "2"
           },
           {
-            text: '0'
+            text: "0"
           }
         ]
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with numeric format (full width, past week)': {
+  "with numeric format (full width, past week)": {
     context: {
-      caption: 'Past week',
+      caption: "Past week",
       head: [
         {
-          text: 'Case manager'
+          text: "Case manager"
         },
         {
-          text: 'Cases opened',
-          format: 'numeric'
+          text: "Cases opened",
+          format: "numeric"
         },
         {
-          text: 'Cases closed',
-          format: 'numeric'
+          text: "Cases closed",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: 'David Francis'
+            text: "David Francis"
           },
           {
-            text: '24'
+            text: "24"
           },
           {
-            text: '18'
+            text: "18"
           }
         ],
         [
           {
-            text: 'Paul Farmer'
+            text: "Paul Farmer"
           },
           {
-            text: '16'
+            text: "16"
           },
           {
-            text: '20'
+            text: "20"
           }
         ],
         [
           {
-            text: 'Rita Patel'
+            text: "Rita Patel"
           },
           {
-            text: '24'
+            text: "24"
           },
           {
-            text: '27'
+            text: "27"
           }
         ]
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with numeric format (full width, past month)': {
+  "with numeric format (full width, past month)": {
     context: {
-      caption: 'Past month',
+      caption: "Past month",
       head: [
         {
-          text: 'Case manager'
+          text: "Case manager"
         },
         {
-          text: 'Cases opened',
-          format: 'numeric'
+          text: "Cases opened",
+          format: "numeric"
         },
         {
-          text: 'Cases closed',
-          format: 'numeric'
+          text: "Cases closed",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: 'David Francis'
+            text: "David Francis"
           },
           {
-            text: '98'
+            text: "98"
           },
           {
-            text: '95'
+            text: "95"
           }
         ],
         [
           {
-            text: 'Paul Farmer'
+            text: "Paul Farmer"
           },
           {
-            text: '122'
+            text: "122"
           },
           {
-            text: '131'
+            text: "131"
           }
         ],
         [
           {
-            text: 'Rita Patel'
+            text: "Rita Patel"
           },
           {
-            text: '126'
+            text: "126"
           },
           {
-            text: '142'
+            text: "142"
           }
         ]
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with numeric format (full width, past year)': {
+  "with numeric format (full width, past year)": {
     context: {
-      caption: 'Past year',
+      caption: "Past year",
       head: [
         {
-          text: 'Case manager'
+          text: "Case manager"
         },
         {
-          text: 'Cases opened',
-          format: 'numeric'
+          text: "Cases opened",
+          format: "numeric"
         },
         {
-          text: 'Cases closed',
-          format: 'numeric'
+          text: "Cases closed",
+          format: "numeric"
         }
       ],
       rows: [
         [
           {
-            text: 'David Francis'
+            text: "David Francis"
           },
           {
-            text: '1380'
+            text: "1380"
           },
           {
-            text: '1472'
+            text: "1472"
           }
         ],
         [
           {
-            text: 'Paul Farmer'
+            text: "Paul Farmer"
           },
           {
-            text: '1129'
+            text: "1129"
           },
           {
-            text: '1083'
+            text: "1083"
           }
         ],
         [
           {
-            text: 'Rita Patel'
+            text: "Rita Patel"
           },
           {
-            text: '1539'
+            text: "1539"
           },
           {
-            text: '1265'
+            text: "1265"
           }
         ]
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     }
   },
-  'with word breaks': {
+  "with word breaks": {
     context: {
-      caption: 'Users',
-      captionSize: 'm',
+      caption: "Users",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Name'
+          text: "Name"
         },
         {
-          text: 'Email address'
+          text: "Email address"
         },
         {
-          text: 'Status'
+          text: "Status"
         },
         {
           html: outdent`
@@ -877,36 +877,36 @@ const fixtures = {
       rows: [
         [
           {
-            text: 'Stephanie Meyer',
-            classes: 'nhsuk-u-text-break-word'
+            text: "Stephanie Meyer",
+            classes: "nhsuk-u-text-break-word"
           },
           {
-            text: 'stephanie.meyer9@test.com',
-            classes: 'nhsuk-u-text-break-word'
+            text: "stephanie.meyer9@test.com",
+            classes: "nhsuk-u-text-break-word"
           },
           {
-            html: components.render('tag', {
+            html: components.render("tag", {
               context: {
-                text: 'Active',
-                colour: 'green'
+                text: "Active",
+                colour: "green"
               }
             })
           }
         ],
         [
           {
-            text: 'Aleksandrina Featherstonehaugh-Whitehead',
-            classes: 'nhsuk-u-text-break-word'
+            text: "Aleksandrina Featherstonehaugh-Whitehead",
+            classes: "nhsuk-u-text-break-word"
           },
           {
-            text: 'aleksandrina.featherstonehaughwhitehead23@folkestonepharmacy.test.com',
-            classes: 'nhsuk-u-text-break-word'
+            text: "aleksandrina.featherstonehaughwhitehead23@folkestonepharmacy.test.com",
+            classes: "nhsuk-u-text-break-word"
           },
           {
-            html: components.render('tag', {
+            html: components.render("tag", {
               context: {
-                text: 'Inactive',
-                colour: 'grey'
+                text: "Inactive",
+                colour: "grey"
               }
             })
           }
@@ -914,43 +914,43 @@ const fixtures = {
       ]
     }
   },
-  'as a card': {
+  "as a card": {
     context: {
       card: true,
-      caption: 'Impetigo can look similar to other skin conditions',
-      captionSize: 'm',
+      caption: "Impetigo can look similar to other skin conditions",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Skin symptoms'
+          text: "Skin symptoms"
         },
         {
-          text: 'Possible cause'
+          text: "Possible cause"
         }
       ],
       rows: [
         [
           {
-            text: 'Blisters on lips or around the mouth'
+            text: "Blisters on lips or around the mouth"
           },
           {
-            text: 'Cold sores'
+            text: "Cold sores"
           }
         ],
         [
           {
-            text: 'Itchy, dry, cracked, sore'
+            text: "Itchy, dry, cracked, sore"
           },
           {
-            text: 'Eczema'
+            text: "Eczema"
           }
         ],
         [
           {
-            text: 'Itchy blisters'
+            text: "Itchy blisters"
           },
           {
-            text: 'Shingles, chickenpox'
+            text: "Shingles, chickenpox"
           }
         ]
       ]
@@ -961,47 +961,47 @@ const fixtures = {
       variants[4] // Responsive variant
     ]
   },
-  'as a card (feature)': {
+  "as a card (feature)": {
     context: {
       card: {
-        heading: 'Other conditions like impetigo',
-        headingSize: 'm',
-        variant: 'feature'
+        heading: "Other conditions like impetigo",
+        headingSize: "m",
+        variant: "feature"
       },
-      caption: 'Impetigo can look similar to other skin conditions',
-      captionSize: 's',
+      caption: "Impetigo can look similar to other skin conditions",
+      captionSize: "s",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Skin symptoms'
+          text: "Skin symptoms"
         },
         {
-          text: 'Possible cause'
+          text: "Possible cause"
         }
       ],
       rows: [
         [
           {
-            text: 'Blisters on lips or around the mouth'
+            text: "Blisters on lips or around the mouth"
           },
           {
-            text: 'Cold sores'
+            text: "Cold sores"
           }
         ],
         [
           {
-            text: 'Itchy, dry, cracked, sore'
+            text: "Itchy, dry, cracked, sore"
           },
           {
-            text: 'Eczema'
+            text: "Eczema"
           }
         ],
         [
           {
-            text: 'Itchy blisters'
+            text: "Itchy blisters"
           },
           {
-            text: 'Shingles, chickenpox'
+            text: "Shingles, chickenpox"
           }
         ]
       ]
@@ -1012,226 +1012,226 @@ const fixtures = {
       variants[4] // Responsive variant
     ],
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'sortable': {
+  "sortable": {
     context: {
-      caption: 'Appointments',
+      caption: "Appointments",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Time',
-          sort: 'ascending'
+          text: "Time",
+          sort: "ascending"
         },
         {
-          text: 'Name',
+          text: "Name",
           sort: true
         },
         {
-          text: 'Date of birth',
-          classes: 'nhsuk-u-nowrap'
+          text: "Date of birth",
+          classes: "nhsuk-u-nowrap"
         }
       ],
       rows: [
         [
           {
-            text: '11:00'
+            text: "11:00"
           },
           {
-            text: 'Laura Stone'
+            text: "Laura Stone"
           },
           {
-            text: '4 January 1986'
+            text: "4 January 1986"
           }
         ],
         [
           {
-            text: '11:30'
+            text: "11:30"
           },
           {
-            text: 'Emma Katie-Brown'
+            text: "Emma Katie-Brown"
           },
           {
-            text: '7 February 1976'
+            text: "7 February 1976"
           }
         ],
         [
           {
-            text: '13:10'
+            text: "13:10"
           },
           {
-            text: 'David Chen'
+            text: "David Chen"
           },
           {
-            text: '19 March 1981'
+            text: "19 March 1981"
           }
         ],
         [
           {
-            text: '13:40'
+            text: "13:40"
           },
           {
-            text: 'Michael Thompson'
+            text: "Michael Thompson"
           },
           {
-            text: '6 December 1964'
+            text: "6 December 1964"
           }
         ],
         [
           {
-            text: '14:20'
+            text: "14:20"
           },
           {
-            text: 'Juan Martinez'
+            text: "Juan Martinez"
           },
           {
-            text: '18 April 1975'
+            text: "18 April 1975"
           }
         ]
       ]
     },
     variants,
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'sortable server-side': {
+  "sortable server-side": {
     context: {
-      caption: 'Appointments',
+      caption: "Appointments",
       firstCellIsHeader: true,
       head: [
         {
-          href: '#',
-          text: 'Time',
-          sort: 'ascending'
+          href: "#",
+          text: "Time",
+          sort: "ascending"
         },
         {
-          href: '#',
-          text: 'Name',
+          href: "#",
+          text: "Name",
           sort: true
         },
         {
-          text: 'Date of birth',
-          classes: 'nhsuk-u-nowrap'
+          text: "Date of birth",
+          classes: "nhsuk-u-nowrap"
         }
       ],
       rows: [
         [
           {
-            text: '11:00'
+            text: "11:00"
           },
           {
-            text: 'Laura Stone'
+            text: "Laura Stone"
           },
           {
-            text: '4 January 1986'
+            text: "4 January 1986"
           }
         ],
         [
           {
-            text: '11:30'
+            text: "11:30"
           },
           {
-            text: 'Emma Katie-Brown'
+            text: "Emma Katie-Brown"
           },
           {
-            text: '7 February 1976'
+            text: "7 February 1976"
           }
         ],
         [
           {
-            text: '13:10'
+            text: "13:10"
           },
           {
-            text: 'David Chen'
+            text: "David Chen"
           },
           {
-            text: '19 March 1981'
+            text: "19 March 1981"
           }
         ],
         [
           {
-            text: '13:40'
+            text: "13:40"
           },
           {
-            text: 'Michael Thompson'
+            text: "Michael Thompson"
           },
           {
-            text: '6 December 1964'
+            text: "6 December 1964"
           }
         ],
         [
           {
-            text: '14:20'
+            text: "14:20"
           },
           {
-            text: 'Juan Martinez'
+            text: "Juan Martinez"
           },
           {
-            text: '18 April 1975'
+            text: "18 April 1975"
           }
         ]
       ]
     },
     variants
   },
-  'sortable with numeric format': {
+  "sortable with numeric format": {
     context: {
-      caption: 'Prescription prepayment certificate (PPC) charges',
-      captionSize: 'm',
+      caption: "Prescription prepayment certificate (PPC) charges",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Item'
+          text: "Item"
         },
         {
-          text: 'Current charge',
-          format: 'numeric',
+          text: "Current charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         },
         {
-          text: 'New charge',
-          format: 'numeric',
+          text: "New charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         }
       ],
       rows: [
         [
           {
-            text: '3-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "3-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£31.25'
+            text: "£31.25"
           },
           {
-            text: '£32.05'
+            text: "£32.05"
           }
         ],
         [
           {
-            text: '12-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "12-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£111.60'
+            text: "£111.60"
           },
           {
-            text: '£114.50'
+            text: "£114.50"
           }
         ],
         [
           {
-            text: 'HRT'
+            text: "HRT"
           },
           {
-            text: '£19.30'
+            text: "£19.30"
           },
           {
-            text: '£19.80'
+            text: "£19.80"
           }
         ]
       ]
@@ -1241,64 +1241,64 @@ const fixtures = {
       variants[2] // Responsive variant
     ]
   },
-  'sortable with numeric format and missing data': {
+  "sortable with numeric format and missing data": {
     context: {
-      caption: 'Prescription prepayment certificate (PPC) charges',
-      captionSize: 'm',
+      caption: "Prescription prepayment certificate (PPC) charges",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Item'
+          text: "Item"
         },
         {
-          text: 'Current charge',
-          format: 'numeric',
+          text: "Current charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         },
         {
-          text: 'New charge',
-          format: 'numeric',
+          text: "New charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         }
       ],
       rows: [
         [
           {
-            text: '3-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "3-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£31.25'
+            text: "£31.25"
           },
           {
-            text: '£32.05'
+            text: "£32.05"
           }
         ],
         [
           {
-            text: '12-month',
-            classes: 'nhsuk-u-nowrap'
+            text: "12-month",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£111.60'
+            text: "£111.60"
           },
           {
-            text: 'No data',
-            format: 'string',
-            classes: 'nhsuk-u-secondary-text-colour'
+            text: "No data",
+            format: "string",
+            classes: "nhsuk-u-secondary-text-colour"
           }
         ],
         [
           {
-            text: 'HRT'
+            text: "HRT"
           },
           {
-            text: '£19.30'
+            text: "£19.30"
           },
           {
-            text: '£19.80'
+            text: "£19.80"
           }
         ]
       ]
@@ -1308,165 +1308,165 @@ const fixtures = {
       variants[2] // Responsive variant
     ]
   },
-  'sortable with numeric format and sort values': {
+  "sortable with numeric format and sort values": {
     context: {
-      caption: 'Prescription prepayment certificate (PPC) charges',
-      captionSize: 'm',
+      caption: "Prescription prepayment certificate (PPC) charges",
+      captionSize: "m",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Item',
-          sort: 'ascending'
+          text: "Item",
+          sort: "ascending"
         },
         {
-          text: 'Current charge',
-          format: 'numeric',
+          text: "Current charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         },
         {
-          text: 'New charge',
-          format: 'numeric',
+          text: "New charge",
+          format: "numeric",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         }
       ],
       rows: [
         [
           {
-            text: '3-month',
-            sortValue: '3',
-            classes: 'nhsuk-u-nowrap'
+            text: "3-month",
+            sortValue: "3",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£31.25',
-            sortValue: '31.25'
+            text: "£31.25",
+            sortValue: "31.25"
           },
           {
-            text: '£32.05',
-            sortValue: '32.05'
+            text: "£32.05",
+            sortValue: "32.05"
           }
         ],
         [
           {
-            text: '12-month',
-            sortValue: '12',
-            classes: 'nhsuk-u-nowrap'
+            text: "12-month",
+            sortValue: "12",
+            classes: "nhsuk-u-nowrap"
           },
           {
-            text: '£111.60',
-            sortValue: '111.60'
+            text: "£111.60",
+            sortValue: "111.60"
           },
           {
-            text: '£114.50',
-            sortValue: '114.50'
+            text: "£114.50",
+            sortValue: "114.50"
           }
         ],
         [
           {
-            text: 'HRT',
-            sortValue: '100'
+            text: "HRT",
+            sortValue: "100"
           },
           {
-            text: '£19.30',
-            sortValue: '19.30'
+            text: "£19.30",
+            sortValue: "19.30"
           },
           {
-            text: '£19.80',
-            sortValue: '19.80'
+            text: "£19.80",
+            sortValue: "19.80"
           }
         ]
       ]
     }
   },
-  'sortable with sort values': {
+  "sortable with sort values": {
     context: {
-      caption: 'Appointments',
+      caption: "Appointments",
       firstCellIsHeader: true,
       head: [
         {
-          text: 'Time',
-          sort: 'ascending'
+          text: "Time",
+          sort: "ascending"
         },
         {
-          text: 'Name',
+          text: "Name",
           sort: true
         },
         {
-          text: 'Date of birth',
+          text: "Date of birth",
           sort: true,
-          sortNext: 'descending'
+          sortNext: "descending"
         }
       ],
       rows: [
         [
           {
-            text: '11:00am',
-            sortValue: '11:00'
+            text: "11:00am",
+            sortValue: "11:00"
           },
           {
-            text: 'Laura Stone',
-            sortValue: 'Stone, Laura'
+            text: "Laura Stone",
+            sortValue: "Stone, Laura"
           },
           {
-            text: '4 January 1986',
-            sortValue: '1986-01-04'
+            text: "4 January 1986",
+            sortValue: "1986-01-04"
           }
         ],
         [
           {
-            text: '11:30am',
-            sortValue: '11:30'
+            text: "11:30am",
+            sortValue: "11:30"
           },
           {
-            text: 'Emma Katie-Brown',
-            sortValue: 'Katie-Brown, Emma'
+            text: "Emma Katie-Brown",
+            sortValue: "Katie-Brown, Emma"
           },
           {
-            text: '7 February 1976',
-            sortValue: '1976-02-07'
+            text: "7 February 1976",
+            sortValue: "1976-02-07"
           }
         ],
         [
           {
-            text: '1:10pm',
-            sortValue: '13:10'
+            text: "1:10pm",
+            sortValue: "13:10"
           },
           {
-            text: 'David Chen',
-            sortValue: 'Chen, David'
+            text: "David Chen",
+            sortValue: "Chen, David"
           },
           {
-            text: '19 March 1981',
-            sortValue: '1981-03-19'
+            text: "19 March 1981",
+            sortValue: "1981-03-19"
           }
         ],
         [
           {
-            text: '1:40pm',
-            sortValue: '13:40'
+            text: "1:40pm",
+            sortValue: "13:40"
           },
           {
-            text: 'Michael Thompson',
-            sortValue: 'Thompson, Michael'
+            text: "Michael Thompson",
+            sortValue: "Thompson, Michael"
           },
           {
-            text: '6 December 1964',
-            sortValue: '1964-12-06'
+            text: "6 December 1964",
+            sortValue: "1964-12-06"
           }
         ],
         [
           {
-            text: '2:20pm',
-            sortValue: '14:20'
+            text: "2:20pm",
+            sortValue: "14:20"
           },
           {
-            text: 'Juan Martinez',
-            sortValue: 'Martinez, Juan'
+            text: "Juan Martinez",
+            sortValue: "Martinez, Juan"
           },
           {
-            text: '18 April 1975',
-            sortValue: '1975-04-18'
+            text: "18 April 1975",
+            sortValue: "1975-04-18"
           }
         ]
       ]

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/fixtures.mjs
@@ -1,8 +1,8 @@
-import { outdent } from 'outdent'
+import { outdent } from "outdent"
 
-import { components } from '#lib'
+import { components } from "#lib"
 
-import { examples as tableExamples } from '../tables/fixtures.mjs'
+import { examples as tableExamples } from "../tables/fixtures.mjs"
 
 /**
  * Nunjucks macro option examples
@@ -10,64 +10,64 @@ import { examples as tableExamples } from '../tables/fixtures.mjs'
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       items: [
         {
-          label: 'Past day',
-          id: 'past-day',
+          label: "Past day",
+          id: "past-day",
           panel: {
             html: components.render(
-              'tables',
-              tableExamples['with numeric format (full width, past day)']
+              "tables",
+              tableExamples["with numeric format (full width, past day)"]
             )
           }
         },
         {
-          label: 'Past week',
-          id: 'past-week',
+          label: "Past week",
+          id: "past-week",
           panel: {
             html: components.render(
-              'tables',
-              tableExamples['with numeric format (full width, past week)']
+              "tables",
+              tableExamples["with numeric format (full width, past week)"]
             )
           }
         },
         {
-          label: 'Past month',
-          id: 'past-month',
+          label: "Past month",
+          id: "past-month",
           panel: {
             html: components.render(
-              'tables',
-              tableExamples['with numeric format (full width, past month)']
+              "tables",
+              tableExamples["with numeric format (full width, past month)"]
             )
           }
         },
         {
-          label: 'Past year',
-          id: 'past-year',
+          label: "Past year",
+          id: "past-year",
           panel: {
             html: components.render(
-              'tables',
-              tableExamples['with numeric format (full width, past year)']
+              "tables",
+              tableExamples["with numeric format (full width, past year)"]
             )
           }
         }
       ]
     },
     options: {
-      width: 'full'
+      width: "full"
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with anchor in panel': {
+  "with anchor in panel": {
     context: {
       items: [
         {
-          label: 'Tab 1',
-          id: 'tab-1',
+          label: "Tab 1",
+          id: "tab-1",
           panel: {
             html: outdent`
               <h2>Tab 1 content</h2>
@@ -81,8 +81,8 @@ const fixtures = {
           }
         },
         {
-          label: 'Tab 2',
-          id: 'tab-2',
+          label: "Tab 2",
+          id: "tab-2",
           panel: {
             html: outdent`
               <h2>Tab 2 content</h2>
@@ -91,8 +91,8 @@ const fixtures = {
           }
         },
         {
-          label: 'Tab 3',
-          id: 'tab-3',
+          label: "Tab 3",
+          id: "tab-3",
           panel: {
             html: outdent`
               <h2>Tab 3 content</h2>

--- a/packages/nhsuk-frontend/src/nhsuk/components/tag/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tag/fixtures.mjs
@@ -6,77 +6,77 @@
 export const variants = [
   {
     context: {
-      text: 'Active'
+      text: "Active"
     }
   },
   {
-    description: 'white',
+    description: "white",
     context: {
-      text: 'In progress',
-      colour: 'white'
+      text: "In progress",
+      colour: "white"
     }
   },
   {
-    description: 'grey',
+    description: "grey",
     context: {
-      text: 'Inactive',
-      colour: 'grey'
+      text: "Inactive",
+      colour: "grey"
     }
   },
   {
-    description: 'green',
+    description: "green",
     context: {
-      text: 'New',
-      colour: 'green'
+      text: "New",
+      colour: "green"
     }
   },
   {
-    description: 'aqua-green',
+    description: "aqua-green",
     context: {
-      text: 'Active',
-      colour: 'aqua-green'
+      text: "Active",
+      colour: "aqua-green"
     }
   },
   {
-    description: 'blue',
+    description: "blue",
     context: {
-      text: 'Pending',
-      colour: 'blue'
+      text: "Pending",
+      colour: "blue"
     }
   },
   {
-    description: 'purple',
+    description: "purple",
     context: {
-      text: 'Received',
-      colour: 'purple'
+      text: "Received",
+      colour: "purple"
     }
   },
   {
-    description: 'pink',
+    description: "pink",
     context: {
-      text: 'Sent',
-      colour: 'pink'
+      text: "Sent",
+      colour: "pink"
     }
   },
   {
-    description: 'red',
+    description: "red",
     context: {
-      text: 'Rejected',
-      colour: 'red'
+      text: "Rejected",
+      colour: "red"
     }
   },
   {
-    description: 'orange',
+    description: "orange",
     context: {
-      text: 'Declined',
-      colour: 'orange'
+      text: "Declined",
+      colour: "orange"
     }
   },
   {
-    description: 'yellow',
+    description: "yellow",
     context: {
-      text: 'Delayed',
-      colour: 'yellow'
+      text: "Delayed",
+      colour: "yellow"
     }
   }
 ]
@@ -87,53 +87,53 @@ export const variants = [
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     variants,
     screenshot: {
-      viewports: ['mobile']
+      viewports: ["mobile"]
     }
   },
-  'colour class': {
+  "colour class": {
     context: {
-      text: 'Green',
-      classes: 'nhsuk-tag--green'
+      text: "Green",
+      classes: "nhsuk-tag--green"
     }
   },
-  'colour class overriding colour param': {
+  "colour class overriding colour param": {
     context: {
-      text: 'Not green',
-      colour: 'green',
-      classes: 'nhsuk-tag--red'
+      text: "Not green",
+      colour: "green",
+      classes: "nhsuk-tag--red"
     }
   },
-  'with text escaping': {
+  "with text escaping": {
     context: {
-      text: 'A&E',
-      colour: 'red'
+      text: "A&E",
+      colour: "red"
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      html: 'A&amp;E',
-      colour: 'red'
+      html: "A&amp;E",
+      colour: "red"
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
-      colour: 'red'
+      colour: "red"
     },
-    callBlock: 'A&amp;E'
+    callBlock: "A&amp;E"
   },
-  'without border': {
+  "without border": {
     context: {
       border: false
     },
     variants,
     options: {
-      layout: 'background-blue'
+      layout: "background-blue"
     },
     screenshot: {
-      viewports: ['mobile']
+      viewports: ["mobile"]
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/task-list/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/task-list/fixtures.mjs
@@ -4,107 +4,107 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      idPrefix: 'your-health',
+      idPrefix: "your-health",
       items: [
         {
           title: {
-            text: 'Exercise'
+            text: "Exercise"
           },
-          href: '#',
+          href: "#",
           status: {
-            text: 'Completed',
-            classes: 'nhsuk-task-list__status--completed'
+            text: "Completed",
+            classes: "nhsuk-task-list__status--completed"
           }
         },
         {
           title: {
-            text: 'Personal health'
+            text: "Personal health"
           },
-          href: '#',
+          href: "#",
           status: {
-            text: 'Completed',
-            classes: 'nhsuk-task-list__status--completed'
+            text: "Completed",
+            classes: "nhsuk-task-list__status--completed"
           }
         },
         {
           title: {
-            text: 'Family health history'
+            text: "Family health history"
           },
           hint: {
-            text: 'Details of your parents, brothers and sisters'
+            text: "Details of your parents, brothers and sisters"
           },
-          href: '#',
+          href: "#",
           status: {
             tag: {
-              text: 'Incomplete',
-              colour: 'blue'
+              text: "Incomplete",
+              colour: "blue"
             }
           }
         },
         {
           title: {
-            text: 'Smoking history'
+            text: "Smoking history"
           },
-          href: '#',
+          href: "#",
           status: {
             tag: {
-              text: 'Incomplete',
-              colour: 'blue'
+              text: "Incomplete",
+              colour: "blue"
             }
           }
         },
         {
           title: {
-            text: 'Blood test'
+            text: "Blood test"
           },
           status: {
-            text: 'Cannot start yet',
-            classes: 'nhsuk-task-list__status--cannot-start-yet'
+            text: "Cannot start yet",
+            classes: "nhsuk-task-list__status--cannot-start-yet"
           }
         }
       ]
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with empty items': {
+  "with empty items": {
     context: {
-      idPrefix: 'your-health',
+      idPrefix: "your-health",
       items: [
         {
           title: {
-            text: 'Exercise'
+            text: "Exercise"
           },
-          href: '#',
+          href: "#",
           status: {
-            text: 'Completed',
-            classes: 'nhsuk-task-list__status--completed'
+            text: "Completed",
+            classes: "nhsuk-task-list__status--completed"
           }
         },
         {
           title: {
-            text: 'Personal health'
+            text: "Personal health"
           },
-          href: '#',
+          href: "#",
           status: {
-            text: 'Completed',
-            classes: 'nhsuk-task-list__status--completed'
+            text: "Completed",
+            classes: "nhsuk-task-list__status--completed"
           }
         },
         false,
         false,
         {
           title: {
-            text: 'Blood test'
+            text: "Blood test"
           },
-          href: '#',
+          href: "#",
           status: {
             tag: {
-              text: 'Incomplete',
-              colour: 'blue'
+              text: "Incomplete",
+              colour: "blue"
             }
           }
         }

--- a/packages/nhsuk-frontend/src/nhsuk/components/textarea/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/textarea/fixtures.mjs
@@ -4,100 +4,100 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      name: 'example'
+      name: "example"
     },
     screenshot: true
   },
-  'disabled': {
+  "disabled": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      name: 'example',
+      name: "example",
       disabled: true
     },
     screenshot: true
   },
-  'with hint': {
+  "with hint": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      id: 'with-hint',
-      name: 'example'
+      id: "with-hint",
+      name: "example"
     }
   },
-  'label': {
+  "label": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      id: 'custom-size',
-      name: 'example'
+      id: "custom-size",
+      name: "example"
     },
     variants: [
       {
-        description: 'with size S',
+        description: "with size S",
         context: {
           label: {
-            size: 's'
+            size: "s"
           }
         }
       },
       {
-        description: 'with size M',
+        description: "with size M",
         context: {
           label: {
-            size: 'm'
+            size: "m"
           }
         }
       },
       {
-        description: 'with size L',
+        description: "with size L",
         context: {
           label: {
-            size: 'l'
+            size: "l"
           }
         }
       },
       {
-        description: 'with size XL',
+        description: "with size XL",
         context: {
           label: {
-            size: 'xl'
+            size: "xl"
           }
         }
       },
       {
-        description: 'with id attribute on',
+        description: "with id attribute on",
         context: {
           label: {
-            id: 'custom-id'
+            id: "custom-id"
           }
         },
         options: {
@@ -106,63 +106,63 @@ const fixtures = {
       }
     ]
   },
-  'without page heading': {
+  "without page heading": {
     context: {
       label: {
-        text: 'Can you provide more detail?'
+        text: "Can you provide more detail?"
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
-      id: 'without-heading',
-      name: 'example'
+      id: "without-heading",
+      name: "example"
     }
   },
-  'with error message': {
+  "with error message": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       errorMessage: {
-        text: 'You must provide an explanation'
+        text: "You must provide an explanation"
       },
-      id: 'with-error-message',
-      name: 'example'
+      id: "with-error-message",
+      name: "example"
     },
     screenshot: {
-      states: ['focus'],
-      selector: '#with-error-message'
+      states: ["focus"],
+      selector: "#with-error-message"
     }
   },
-  'with error message and hint': {
+  "with error message and hint": {
     context: {
       label: {
-        text: 'Can you provide more detail?',
-        size: 'l',
+        text: "Can you provide more detail?",
+        size: "l",
         isPageHeading: true
       },
       hint: {
-        text: 'Do not include personal information like your name, date of birth or NHS number'
+        text: "Do not include personal information like your name, date of birth or NHS number"
       },
       errorMessage: {
-        text: 'You must provide an explanation'
+        text: "You must provide an explanation"
       },
-      id: 'with-hint-error',
-      name: 'example'
+      id: "with-hint-error",
+      name: "example"
     }
   },
-  'with autocomplete attribute': {
+  "with autocomplete attribute": {
     context: {
       label: {
-        text: 'Full address',
-        size: 'l',
+        text: "Full address",
+        size: "l",
         isPageHeading: true
       },
-      id: 'with-autocomplete-attribute',
-      name: 'example',
-      autocomplete: 'street-address'
+      id: "with-autocomplete-attribute",
+      name: "example",
+      autocomplete: "street-address"
     }
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/warning-callout/fixtures.mjs
@@ -4,40 +4,40 @@
  * @satisfies {{ [example: string]: MacroExample }}
  */
 const fixtures = {
-  'default': {
+  "default": {
     context: {
-      heading: 'Important',
+      heading: "Important",
       text: "For safety, tell your doctor or pharmacist if you're taking any other medicines, including herbal medicines, vitamins or supplements."
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'with HTML': {
+  "with HTML": {
     context: {
-      heading: 'Important',
+      heading: "Important",
       html: '<p class="nhsuk-card__description">Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>'
     }
   },
-  'with HTML via call block': {
+  "with HTML via call block": {
     context: {
-      heading: 'Important'
+      heading: "Important"
     },
     callBlock:
       '<p class="nhsuk-card__description">Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>'
   },
-  'with custom heading': {
+  "with custom heading": {
     context: {
-      heading: 'School, nursery or work',
-      text: 'Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.'
+      heading: "School, nursery or work",
+      text: "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
     },
     screenshot: {
-      viewports: ['mobile', 'tablet', 'desktop']
+      viewports: ["mobile", "tablet", "desktop"]
     }
   },
-  'without heading': {
+  "without heading": {
     context: {
-      text: 'Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.'
+      text: "Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared."
     },
     options: {
       hidden: true

--- a/packages/nhsuk-frontend/tasks/fixtures.mjs
+++ b/packages/nhsuk-frontend/tasks/fixtures.mjs
@@ -1,8 +1,8 @@
-import { join } from 'node:path'
+import { join } from "node:path"
 
-import * as config from '@nhsuk/frontend-config'
-import { components, task } from '@nhsuk/frontend-tasks'
-import gulp from 'gulp'
+import * as config from "@nhsuk/frontend-config"
+import { components, task } from "@nhsuk/frontend-tasks"
+import gulp from "gulp"
 
 /**
  * Component fixtures and macro options
@@ -11,18 +11,18 @@ export const compile = gulp.series(
   /**
    * Generate NHS.UK frontend fixtures.json
    */
-  task.name('fixtures:examples', () =>
+  task.name("fixtures:examples", () =>
     components.generateFixtures({
-      destPath: join(config.paths.pkg, 'dist/nhsuk/components')
+      destPath: join(config.paths.pkg, "dist/nhsuk/components")
     })
   ),
 
   /**
    * Generate NHS.UK frontend macro-options.json
    */
-  task.name('fixtures:macro-options', () =>
+  task.name("fixtures:macro-options", () =>
     components.generateMacroOptions({
-      destPath: join(config.paths.pkg, 'dist/nhsuk/components')
+      destPath: join(config.paths.pkg, "dist/nhsuk/components")
     })
   )
 )


### PR DESCRIPTION
## Description

This PR updates the Prettier config to format with double quotes in **fixtures.mjs** files

We often copy and paste from **fixtures.mjs** → **.njk** and it's a pain to fix the formatting

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
