### PR TITLE
[v10] Update table captions to use heading component

### DIFF
--- a/packages/nhsuk-frontend-review/src/examples/small-form-controls.njk
+++ b/packages/nhsuk-frontend-review/src/examples/small-form-controls.njk
@@ -28,6 +28,19 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-one-third">
 
+      {{ searchInput({
+        label: {
+          text: "Search",
+          size: "s"
+        },
+        hint: {
+          text: "Integer posuere erat a ante venenatis dapibus posuere"
+        },
+        name: "search",
+        value: "lorem ipsum",
+        classes: "nhsuk-u-width-two-thirds"
+      }) }}
+
       {{ checkboxes({
         fieldset: {
           legend: {
@@ -37,6 +50,7 @@
         },
         idPrefix: "display",
         name: "display",
+        values: ["consultations"],
         small: true,
         items: [
           {
@@ -67,6 +81,7 @@
         },
         idPrefix: "include",
         name: "include",
+        value: "everything",
         small: true,
         items: [
           {
@@ -86,67 +101,153 @@
 
     </div>
 
-    <div class="nhsuk-grid-column-two-thirds">
-
-      {{ radios({
-        fieldset: {
-          legend: {
-            text: "Sort by",
-            size: "s"
-          }
+    <div class="nhsuk-grid-column-two-thirds nhsuk-u-margin-bottom-7">
+      {{ heading({
+        text: "Search results for lorem ipsum",
+        caption: {
+          text: "1 – 3 of 9 results",
+          placement: "after",
+          element: "p"
         },
-        formGroup: {
-          classes: "nhsuk-u-margin-bottom-0"
-        },
-        idPrefix: "sort",
-        name: "sort",
-        small: true,
-        inline: true,
-        items: [
-          {
-            value: "relevance",
-            text: "Relevance"
-          },
-          {
-            value: "created",
-            text: "Created"
-          },
-          {
-            value: "title",
-            text: "Title"
-          }
-        ]
+        size: "l",
+        level: 2
       }) }}
 
-      {{ checkboxes({
-        name: "grobulate",
-        small: true,
-        formGroup: {
-          classes: "nhsuk-u-margin-bottom-0"
+      {{ select({
+        label: {
+          text: "Sort by"
         },
+        id: "sort-by",
+        name: "sort-by",
+        classes: "nhsuk-u-width-full",
         items: [
           {
-            value: "grobulate",
-            text: "Grobulate results"
+            value: "published",
+            text: "Recently published"
+          },
+          {
+            value: "updated",
+            text: "Recently updated"
+          },
+          {
+            value: "views",
+            text: "Most views"
+          },
+          {
+            value: "comments",
+            text: "Most comments"
           }
-        ]
+        ],
+        formGroup: {
+          classes: "nhsuk-u-width-one-half",
+          afterInput: {
+            html: button({
+              text: "Sort",
+              variant: "secondary",
+              small: true
+            })
+          }
+        }
       }) }}
 
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
 
-      <h2 class="nhsuk-heading-m">Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit</h2>
+      {{ heading({
+        text: "Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit",
+        caption: {
+          text: "4 August 2026",
+          placement: "end"
+        },
+        href: "#/result/1",
+        classes: "nhsuk-u-margin-bottom-3",
+        size: "m",
+        level: 3
+      }) }}
+
       <p class="nhsuk-body">Aenean lacinia bibendum nulla sed consectetur. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.</p>
 
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
 
-      <h2 class="nhsuk-heading-m">Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh</h2>
+      {{ heading({
+        text: "Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh",
+        caption: {
+          text: "19 July 2026",
+          placement: "end"
+        },
+        href: "#/result/2",
+        classes: "nhsuk-u-margin-bottom-3",
+        size: "m",
+        level: 3
+      }) }}
+
       <p class="nhsuk-body">Cras justo odio, dapibus ac facilisis in, egestas eget quam. Maecenas sed diam eget risus varius blandit sit amet non magna.</p>
 
       <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
 
-      <h2 class="nhsuk-heading-m">Bibendum Commodo Ullamcorper Vulputate</h2>
+      {{ heading({
+        text: "Bibendum commodo ullamcorper vulputate",
+        caption: {
+          text: "1 July 2026",
+          placement: "end"
+        },
+        href: "#/result/2",
+        classes: "nhsuk-u-margin-bottom-3",
+        size: "m",
+        level: 3
+      }) }}
+
       <p class="nhsuk-body">Cras mattis consectetur purus sit amet fermentum. Curabitur blandit tempus porttitor.</p>
+
+      {{ pagination({
+        next: {
+          href: "#"
+        },
+        items: [
+          {
+            number: 1,
+            href: "#",
+            current: true
+          },
+          {
+            number: 2,
+            href: "#"
+          },
+          {
+            number: 3,
+            href: "#"
+          }
+        ]
+      }) }}
 
     </div>
   </div>
+{% endblock %}
+
+{% block footer %}
+  {{ footer({
+    meta: {
+      items: [
+        {
+          href: "#",
+          text: "Accessibility statement"
+        },
+        {
+          href: "#",
+          text: "Contact us"
+        },
+        {
+          href: "#",
+          text: "Cookies"
+        },
+        {
+          href: "#",
+          text: "Privacy policy"
+        },
+        {
+          href: "#",
+          text: "Terms and conditions"
+        }
+      ]
+    }
+  }) }}
 {% endblock %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
@@ -154,6 +154,21 @@ const fixtures = {
       size: "s"
     }
   },
+  "with link": {
+    context: {
+      text: "Skin colour changes",
+      href: "#/result/1",
+      size: "l"
+    }
+  },
+  "with link and caption": {
+    context: {
+      text: "Skin colour changes",
+      caption: "A to Z of NHS health writing",
+      href: "#/result/1",
+      size: "l"
+    }
+  },
   "with visually hidden text": {
     context: {
       text: "Home address",

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/fixtures.mjs
@@ -153,6 +153,21 @@ const fixtures = {
       classes: "nhsuk-heading-l",
       size: "s"
     }
+  },
+  "with visually hidden text": {
+    context: {
+      text: "Home address",
+      visuallyHiddenText: "(Karen Francis)",
+      size: "l"
+    }
+  },
+  "with visually hidden text and caption": {
+    context: {
+      text: "Home address",
+      visuallyHiddenText: "(Karen Francis)",
+      caption: "About you",
+      size: "l"
+    }
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
@@ -33,6 +33,12 @@ const options = {
       'Not strictly a parameter but Nunjucks code convention. Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire heading component in a `call` block.',
     released: '10.6.0'
   },
+  visuallyHiddenText: {
+    type: 'string',
+    required: false,
+    description: 'A visually hidden suffix added to the heading.',
+    released: '10.6.0'
+  },
   caption: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
@@ -39,6 +39,12 @@ const options = {
     description: 'A visually hidden suffix added to the heading.',
     released: '10.6.0'
   },
+  href: {
+    type: 'string',
+    required: false,
+    description: 'If set, the heading will become a link.',
+    released: '10.6.0'
+  },
   caption: {
     type: 'object',
     required: false,

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/macro-options.mjs
@@ -86,6 +86,13 @@ const options = {
     description:
       'HTML attributes (for example data attributes) to add to the heading.',
     released: '10.6.0'
+  },
+  element: {
+    type: 'string',
+    required: false,
+    description:
+      'HTML element for the heading component – for example, `"caption"`. Defaults to the `level` option prefixed with `"h"`.',
+    released: '10.6.0'
   }
 }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
@@ -43,6 +43,14 @@
 {%- set hasCaption = headingCaption.text or headingCaption.html -%}
 
 {%- if caller or params.html or params.text %}
+{%- set innerHtml %}
+  {%- if params.html %}
+    {{- params.html | safe -}}
+  {% elif params.text %}
+    {{- params.text -}}
+  {% endif -%}
+{% endset %}
+
 {%- set captionHtml = caption({
   id: headingCaption.id,
   element: headingCaption.element,
@@ -67,12 +75,19 @@
 {% if headingCaption.placement == "start" or (hasCaption and not headingCaption.placement) %}
   {{ captionHtml | safe | trim | indent(2) }}
 {% endif %}
-{% if caller %}
-  {{- caller() }}
-{% elif params.html %}
-  {{ params.html | safe | trim | indent(2) }}
+{% if params.visuallyHiddenText %}
+  {% if caller %}
+    {{- caller() }}
+  {% else %}
+    {{- innerHtml | safe | trim | indent(2, true) -}}
+  {% endif -%}
+  <span class="nhsuk-u-visually-hidden"> {{ params.visuallyHiddenText }}</span>
 {% else %}
-  {{ params.text | trim | indent(2) }}
+  {% if caller %}
+    {{- caller() }}
+  {% else %}
+    {{- innerHtml | safe | trim | indent(2, true) }}
+  {% endif %}
 {% endif %}
 {% if headingCaption.placement == "end" %}
   {{ captionHtml | safe | trim | indent(2) }}

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
@@ -43,11 +43,21 @@
 {%- set hasCaption = headingCaption.text or headingCaption.html -%}
 
 {%- if caller or params.html or params.text %}
-{%- set innerHtml %}
+{%- set innerText %}
   {%- if params.html %}
     {{- params.html | safe -}}
   {% elif params.text %}
     {{- params.text -}}
+  {% endif -%}
+{% endset %}
+
+{%- set innerHtml %}
+  {%- if params.href -%}
+    <a class="nhsuk-link" href="{{ params.href }}">
+      {{- innerText | safe | trim -}}
+    </a>
+  {%- else %}
+    {{- innerText | safe | trim -}}
   {% endif -%}
 {% endset %}
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/heading/template.njk
@@ -58,7 +58,10 @@
 {{ captionHtml | safe | trim }}
 {% endif -%}
 
-<h{{ headingLevel }} class="{{ classNames }}"
+{#- Determine type of element to use, if not explicitly set #}
+{%- set element = (params.element | default("h" ~ headingLevel)) | lower -%}
+
+<{{ element }} class="{{ classNames }}"
   {%- if params.id %} id="{{ params.id }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }}>
 {% if headingCaption.placement == "start" or (hasCaption and not headingCaption.placement) %}
@@ -74,7 +77,7 @@
 {% if headingCaption.placement == "end" %}
   {{ captionHtml | safe | trim | indent(2) }}
 {% endif %}
-</h{{ headingLevel }}>
+</{{ element }}>
 {% if headingCaption.placement == "after" %}
 {{ captionHtml | safe | trim }}
 {% endif %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/template.njk
@@ -1,6 +1,7 @@
 {% from "nhsuk/macros/attributes.njk" import nhsukAttributes %}
 {% from "nhsuk/macros/i18n.njk" import nhsukI18nAttributes %}
 {% from "nhsuk/components/card/macro.njk" import card %}
+{% from "nhsuk/components/heading/macro.njk" import heading %}
 {% from "nhsuk/macros/icon.njk" import nhsukIcon %}
 
 {#- Set variant for this component #}
@@ -53,28 +54,11 @@
   {% set classNames = classNames ~ " nhsuk-table--striped" %}
 {% endif %}
 
-{%- if params.captionSize and
-  params.captionSize in ["s", "m", "l", "xl"] and (
-    not params.captionClasses or (
-      not "nhsuk-table__caption--s" in params.captionClasses and
-      not "nhsuk-table__caption--m" in params.captionClasses and
-      not "nhsuk-table__caption--l" in params.captionClasses and
-      not "nhsuk-table__caption--xl" in params.captionClasses
-    )
-  )
-%}
-  {% set classNamesCaption = classNamesCaption ~ " nhsuk-table__caption--" ~ params.captionSize %}
-{% endif %}
-
 {%- if params.classes or params.tableClasses %}
   {% set classNames = classNames ~ " " ~ (params.classes or params.tableClasses) %}
 {% endif %}
 
-{%- if params.captionClasses %}
-  {% set classNamesCaption = classNamesCaption ~ " " ~ params.captionClasses %}
-{% endif %}
-
-{%- set captionDescriptionText = params.captionDescriptionText | default("Column headers are sortable") %}
+{%- set captionDescriptionText = params.captionDescriptionText | default("Column headers are sortable" if "nhsuk-table--sortable" in classNames else undefined) %}
 
 {%- set attributesHtml %}
   {{- nhsukAttributes({
@@ -222,13 +206,16 @@
 {%- set tableHtml -%}
 <table {{- attributesHtml | safe }}>
 {% if params.caption %}
-  <caption class="{{ classNamesCaption }}">
-  {% if "nhsuk-table--sortable" in classNames %}
-    {{ params.caption }}<span class="nhsuk-u-visually-hidden"> ({{ captionDescriptionText }})</span>
-  {% else %}
-    {{ params.caption }}
-  {% endif %}
-  </caption>
+  {{ heading({
+    text: params.caption,
+    visuallyHiddenText: "(" ~ captionDescriptionText ~ ")" if captionDescriptionText else undefined,
+    size: params.captionSize,
+    sizes: ["s", "m", "l", "xl"],
+    className: classNamesCaption,
+    classPrefix: classNamesCaption ~ "--",
+    classes: params.captionClasses,
+    element: "caption"
+  }) | trim | indent(2) }}
 {% endif %}
 {% if head | length %}
   <thead class="nhsuk-table__head" {%- if params.responsive %} role="rowgroup"{% endif %}>


### PR DESCRIPTION
## Description

This PR updates table captions to use the heading component

Heading components now support the `element`, `href` and `visuallyHiddenText` options

I've also updated the small form controls full page example to show search results:

<img width="1100" height="1150" alt="Search results example" src="https://github.com/user-attachments/assets/e60db595-1dc1-4ddc-992a-0b611e43f351" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
