### PR TITLE
[v10] Fix secondary text colour override when reversed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -620,6 +620,7 @@ This change was introduced in [pull request #2002: Add image component `backgrou
 - [#1996: Update hover colour for task list and pagination](https://github.com/nhsuk/nhsuk-frontend/pull/1996)
 - [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997)
 - [#2000: Update responsive table row margin and border width](https://github.com/nhsuk/nhsuk-frontend/pull/2000)
+- [#2032: Fix secondary text colour override when reversed](https://github.com/nhsuk/nhsuk-frontend/pull/2032)
 
 ## 10.5.2 - 8 June 2026
 

--- a/packages/nhsuk-frontend-review/src/examples/code-blocks.njk
+++ b/packages/nhsuk-frontend-review/src/examples/code-blocks.njk
@@ -340,7 +340,7 @@
             rows: [
               {
                 key: {
-                  html: '<code class="nhsuk-code--inline nhsuk-code--inverse">nhsuk-u-margin-0</code>',
+                  html: '<code class="nhsuk-code--inline nhsuk-code--reverse">nhsuk-u-margin-0</code>',
                   classes: "nhsuk-u-width-one-half"
                 },
                 value: {
@@ -349,7 +349,7 @@
               },
               {
                 key: {
-                  html: '<code class="nhsuk-code--inline nhsuk-code--inverse">nhsuk-u-margin-top-0</code>'
+                  html: '<code class="nhsuk-code--inline nhsuk-code--reverse">nhsuk-u-margin-top-0</code>'
                 },
                 value: {
                   text: "Responsive margin on the top"

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/_index.scss
@@ -59,6 +59,13 @@
       line-height: nhsuk-line-height($_large-icon-size, $font-size: 22px);
     }
 
+    &:focus .nhsuk-u-secondary-text-colour,
+    &:hover .nhsuk-u-secondary-text-colour,
+    &:active .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: currentcolor !important;
+    }
+
     .nhsuk-icon {
       position: absolute;
       left: -$_small-icon-spacing;
@@ -83,6 +90,11 @@
 
   .nhsuk-action-link--reverse {
     @include nhsuk-link-style-reverse;
+
+    .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: $nhsuk-reverse-secondary-text-colour !important;
+    }
 
     &:not(:focus) .nhsuk-icon,
     &:not(:focus):hover .nhsuk-icon,

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
@@ -29,7 +29,7 @@ const fixtures = {
   "default": {
     context: {
       text: "Find your nearest A&E",
-      href: "#"
+      href: "#/find"
     },
     variants,
     screenshot: {
@@ -53,10 +53,15 @@ const fixtures = {
       html: outdent`
         Start session<br>
         <span class="nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>
-      `
-    }
+      `,
+      href: "#/start"
+    },
+    variants
   },
   "with HTML via call block": {
+    context: {
+      href: "#/start"
+    },
     callBlock: outdent`
       Start session<br>
       <span class="nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>

--- a/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/action-link/fixtures.mjs
@@ -52,7 +52,7 @@ const fixtures = {
     context: {
       html: outdent`
         Start session<br>
-        <span class="nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>
+        <span class="nhsuk-u-secondary-text-colour nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>
       `,
       href: "#/start"
     },
@@ -64,7 +64,7 @@ const fixtures = {
     },
     callBlock: outdent`
       Start session<br>
-      <span class="nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>
+      <span class="nhsuk-u-secondary-text-colour nhsuk-u-font-weight-normal nhsuk-u-font-size-19">(11 cases)</span>
     `
   }
 }

--- a/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/details/_index.scss
@@ -42,6 +42,11 @@ $expander-icon-size: $nhsuk-expander-icon-size;
 
   .nhsuk-details--reverse {
     color: $nhsuk-reverse-text-colour;
+
+    .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: $nhsuk-reverse-secondary-text-colour !important;
+    }
   }
 
   .nhsuk-details__summary {

--- a/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/hero/_index.scss
@@ -43,6 +43,11 @@
     a:not(.nhsuk-button) {
       @include nhsuk-link-style-reverse;
     }
+
+    .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: $nhsuk-reverse-secondary-text-colour !important;
+    }
   }
 
   .nhsuk-hero .nhsuk-width-container {

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/_index.scss
@@ -45,6 +45,11 @@ $nhsuk-border-width-panel: $nhsuk-panel-border-width;
       @include nhsuk-link-style-reverse;
     }
 
+    .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: $nhsuk-reverse-secondary-text-colour !important;
+    }
+
     @media #{nhsuk-until-breakpoint(tablet)} {
       padding: nhsuk-spacing(4) - $nhsuk-panel-border-width; /* [2] */
       @include nhsuk-text-break-word; /* [3] */

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
@@ -388,6 +388,11 @@
       @include nhsuk-link-style-reverse;
     }
 
+    .nhsuk-u-secondary-text-colour {
+      // stylelint-disable-next-line declaration-no-important
+      color: $nhsuk-reverse-secondary-text-colour !important;
+    }
+
     // Add a white bottom border to the header cell currently sorted
     .nhsuk-table__header[aria-sort] .nhsuk-link::before {
       border-color: $nhsuk-reverse-text-colour;

--- a/packages/nhsuk-frontend/src/nhsuk/core/core.unit.test.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/core/core.unit.test.mjs
@@ -46,6 +46,7 @@ describe('Core', () => {
         --nhsuk-card-background-colour: white;
         --nhsuk-print-text-colour: black;
         --nhsuk-secondary-text-colour: #4c6272;
+        --nhsuk-reverse-secondary-text-colour: #c7dcef;
         --nhsuk-focus-colour: #ffeb3b;
         --nhsuk-focus-text-colour: #212b32;
         --nhsuk-error-colour: #d5281b;

--- a/packages/nhsuk-frontend/src/nhsuk/core/elements/_links.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/elements/_links.scss
@@ -67,10 +67,6 @@ button.nhsuk-link {
 
 .nhsuk-link--reverse {
   @include nhsuk-link-style-reverse;
-
-  @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-    color: LinkText;
-  }
 }
 
 .nhsuk-link--no-underline {

--- a/packages/nhsuk-frontend/src/nhsuk/core/settings/_colours-applied.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/settings/_colours-applied.scss
@@ -65,6 +65,14 @@ $nhsuk-print-text-colour: #000000 !default;
 
 $nhsuk-secondary-text-colour: nhsuk-colour("grey-1") !default;
 
+/// Reverse secondary text colour
+///
+/// Used in for example 'muted' text and help text.
+///
+/// @type Colour
+
+$nhsuk-reverse-secondary-text-colour: nhsuk-tint($nhsuk-brand-colour, 78%) !default;
+
 /// Focus colour
 ///
 /// Used for outline (and background, where appropriate) when interactive


### PR DESCRIPTION
## Description

This PR adds a new Sass `$nhsuk-reverse-secondary-text-colour` colour

Actions links, details, hero, panel and table components apply this colour to `nhsuk-u-secondary-text-colour`

<img width="538" height="252" alt="Action link with secondary text colour" src="https://github.com/user-attachments/assets/9586b862-0b9f-4e45-88cf-308f474d0e1d" />

<img width="732" height="477" alt="Table with secondary text colour" src="https://github.com/user-attachments/assets/7a30cfaa-9cf3-465e-9d99-85c4235dc779" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
