### PR TITLE
Prevent divider on last account link item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,10 @@ We've changed the hover and active icon colour for the action link component so 
 
 This change was introduced in [pull request #1802: Change action link icon colour on hover and active](https://github.com/nhsuk/nhsuk-frontend/pull/1802).
 
+### :wrench: **Fixes**
+
+- [#2035: Prevent divider on last account link item](https://github.com/nhsuk/nhsuk-frontend/pull/2035)
+
 ## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -294,6 +294,7 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
 
     &:last-child {
       flex-grow: 0;
+      outline: none;
     }
   }
 


### PR DESCRIPTION
## Description
Add rule to set the outline colour of the first item to match the background colour. This fixes a small gap that is visible when there is only 1 item in the account menu.
This should have no effect on the account items when there is more than 1.
<img width="318" height="200" alt="image" src="https://github.com/user-attachments/assets/8be2f959-eabf-46fc-9ab9-004734fc43ff" />
<img width="935" height="136" alt="image" src="https://github.com/user-attachments/assets/cc08f1e6-212e-41ac-9447-5c3fa4a325bf" />

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
