### PR TITLE
[v10] Backport prevent divider on last account link item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,6 +621,7 @@ This change was introduced in [pull request #2002: Add image component `backgrou
 - [#1997: Preserve conditionally revealed content margins when JavaScript is not supported](https://github.com/nhsuk/nhsuk-frontend/pull/1997)
 - [#2000: Update responsive table row margin and border width](https://github.com/nhsuk/nhsuk-frontend/pull/2000)
 - [#2032: Fix secondary text colour override when reversed](https://github.com/nhsuk/nhsuk-frontend/pull/2032)
+- [#2035: Prevent divider on last account link item](https://github.com/nhsuk/nhsuk-frontend/pull/2035)
 
 ## 10.5.2 - 8 June 2026
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/_index.scss
@@ -288,6 +288,7 @@ $nhsuk-header-reverse-item-active-colour: $nhsuk-reverse-text-colour;
 
     &:last-child {
       flex-grow: 0;
+      outline: none;
     }
   }
 


### PR DESCRIPTION
## Description

This PR backports https://github.com/nhsuk/nhsuk-frontend/pull/2035 from `main` into `support/10.x`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
