### PR TITLE
[v10] Fix missing date input form group error class without error message

### DIFF
--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -8,16 +8,8 @@
 {%- set classNames = "nhsuk-date-input" -%}
 {%- set classNamesFormGroup = "nhsuk-form-group" -%}
 
-{%- if params.errorMessage %}
-  {% set classNamesFormGroup = classNamesFormGroup ~ " nhsuk-form-group--error" %}
-{% endif %}
-
 {%- if params.classes %}
   {% set classNames = classNames ~ " " ~ params.classes %}
-{% endif %}
-
-{%- if params.formGroup.classes %}
-  {% set classNamesFormGroup = classNamesFormGroup ~ " " ~ params.formGroup.classes %}
 {% endif %}
 
 {#- a record of other elements that we need to associate with the input using
@@ -159,6 +151,14 @@
     {% endif %}
   </div>
 {% endset -%}
+
+{%- if params.errorMessage %}
+  {% set classNamesFormGroup = classNamesFormGroup ~ " nhsuk-form-group--error" %}
+{% endif %}
+
+{%- if params.formGroup.classes %}
+  {% set classNamesFormGroup = classNamesFormGroup ~ " " ~ params.formGroup.classes %}
+{% endif -%}
 
 <div class="{{ classNamesFormGroup }}" {{- nhsukAttributes(params.formGroup.attributes) }}>
 {% if hasFieldset %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -92,7 +92,8 @@
       classes: "nhsuk-date-input__label" ~ (" " ~ itemLabel.classes if itemLabel.classes),
       attributes: itemLabel.attributes
     },
-    errorMessage: itemHasError or (item.error != false and params.errorMessage and not anyItemHasError),
+    errorMessage: (not item.classes or not "nhsuk-input--error" in itemClasses) and
+      (itemHasError or (item.error != false and params.errorMessage and not anyItemHasError)),
     id: item.id if item.id else (params.id ~ "-" ~ itemName),
     name: (params.namePrefix ~ "[" ~ itemName ~ "]") if params.namePrefix else itemName,
     value: itemValue | default(params.values[itemName]),

--- a/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/date-input/template.njk
@@ -152,7 +152,7 @@
   </div>
 {% endset -%}
 
-{%- if params.errorMessage %}
+{%- if params.errorMessage or anyItemHasError %}
   {% set classNamesFormGroup = classNamesFormGroup ~ " nhsuk-form-group--error" %}
 {% endif %}
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/legend/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/legend/template.njk
@@ -35,11 +35,10 @@
 
 <legend {{- nhsukAttributes({ class: classNames }) }}>
 {% if params.isPageHeading %}
-  {% call heading({
+  {{ heading({
+    html: innerHtml,
     className: classNamesHeading
-  }) %}
-    {{ innerHtml | safe | trim | indent(4) }}
-  {%- endcall %}
+  }) | trim | indent(2) }}
 {% else %}
   {{ innerHtml | safe | trim | indent(2) }}
 {% endif %}


### PR DESCRIPTION
## Description

This PR adds the `nhsuk-form-group--error` class to date input fields with errors (but without an error message)

### Before

<img width="541" height="305" alt="Date input fields with missing class" src="https://github.com/user-attachments/assets/2cd59754-9acf-4d44-8a69-f954b6a41235" />

### After

<img width="559" height="310" alt="Date input fields" src="https://github.com/user-attachments/assets/753e9803-5c2a-41b5-8f94-14592887d9fe" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry
