### PR TITLE
[v10] Fix radio button and check mark alignment on Windows 125% scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -937,6 +937,7 @@ This change was introduced in [pull request #2002: Add image component `backgrou
 - [#2032: Fix secondary text colour override when reversed](https://github.com/nhsuk/nhsuk-frontend/pull/2032)
 - [#2035: Prevent divider on last account link item](https://github.com/nhsuk/nhsuk-frontend/pull/2035)
 - [#2048: Fix margin and line height issues for labels and legends as page headings](https://github.com/nhsuk/nhsuk-frontend/pull/2048)
+- [#2049: Fix radio button and check mark alignment on Windows 125% scaling](https://github.com/nhsuk/nhsuk-frontend/pull/2049)
 
 ## 10.5.2 - 8 June 2026
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -121,6 +121,9 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
   // The check mark is a box with a border on the left and bottom side (└──),
   // rotated 45 degrees
   .nhsuk-checkboxes__label::after {
+    $check-mark-width: nhsuk-px-to-rem(22px);
+    $check-mark-height: nhsuk-px-to-rem(10px);
+
     content: "";
 
     box-sizing: border-box;
@@ -129,13 +132,13 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
 
     // Use "magic numbers" to define shape and position of check mark because
     // the complexity of the shape makes it difficult to calculate dynamically.
-    top: nhsuk-px-to-rem(15px);
-    left: nhsuk-px-to-rem(12px);
+    top: $check-mark-height;
+    left: $check-mark-width + nhsuk-px-to-rem(1px);
 
-    width: nhsuk-px-to-rem(22px);
-    height: nhsuk-px-to-rem(10px);
+    width: $check-mark-width;
+    height: $check-mark-height;
 
-    transform: rotate(-45deg);
+    transform: rotate(-45deg) translate(-50%, -50%);
 
     border: solid;
     border-width: 0 0 nhsuk-px-to-rem(4px) nhsuk-px-to-rem(4px);
@@ -299,10 +302,13 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
     //
     // Reduce the size of the check mark and re-align within the checkbox
     .nhsuk-checkboxes__label::after {
-      top: nhsuk-px-to-rem(18px);
-      left: nhsuk-px-to-rem(8px);
-      width: nhsuk-px-to-rem(12px);
-      height: nhsuk-px-to-rem(6px);
+      $check-mark-width: nhsuk-px-to-rem(12px);
+      $check-mark-height: nhsuk-px-to-rem(6px);
+
+      top: $check-mark-height + $input-offset - nhsuk-px-to-rem(0.5px);
+      left: $check-mark-width + nhsuk-px-to-rem($nhsuk-checkboxes-offset + 1px);
+      width: $check-mark-width;
+      height: $check-mark-height;
       border-width: 0 0 nhsuk-px-to-rem(3px) nhsuk-px-to-rem(3px);
     }
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/radios/_index.scss
@@ -116,22 +116,22 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
   // We create the 'button' entirely out of 'border' so that they remain
   // 'filled' even when colours are overridden in the browser.
   .nhsuk-radios__label::after {
-    $radio-button-size: nhsuk-px-to-rem(10px);
-
     content: "";
 
     position: absolute;
 
     // Positioned by getting half the touch target, so we have the centre of the
-    // input, and then moving back by the button's border width, thus positioning
+    // input, then moving into position using CSS translate, thus positioning
     // the centre of the button in the centre of the input.
-    top: math.div($nhsuk-touch-target-size, 2) - $radio-button-size;
-    left: math.div($nhsuk-touch-target-size, 2) - $radio-button-size;
+    top: math.div($nhsuk-touch-target-size, 2);
+    left: math.div($nhsuk-touch-target-size, 2);
 
     width: 0;
     height: 0;
 
-    border: $radio-button-size solid currentcolor;
+    transform: translate(-50%, -50%);
+
+    border: nhsuk-px-to-rem(10px) solid currentcolor;
     border-radius: 50%;
 
     opacity: 0;
@@ -289,15 +289,11 @@ $nhsuk-radios-offset: $nhsuk-border-width-form-element;
 
     //  •  Radio button
     //
-    // Reduce the size of the 'button' and center it within the ring
+    // Reduce the size of the 'button' within the ring
     .nhsuk-radios__label::after {
-      $radio-button-size: nhsuk-px-to-rem(5px);
-
-      // The same calculation as normal radio buttons but reduce the border width
-      top: math.div($nhsuk-touch-target-size, 2) - $radio-button-size;
-      left: (math.div($nhsuk-touch-target-size, 2) - $radio-button-size) - $input-offset +
-        nhsuk-px-to-rem($nhsuk-radios-offset);
-      border-width: $radio-button-size;
+      top: math.div($nhsuk-touch-target-size, 2);
+      left: math.div($nhsuk-touch-target-size, 2) - $input-offset + nhsuk-px-to-rem($nhsuk-radios-offset);
+      border-width: nhsuk-px-to-rem(5px);
     }
 
     // Fix position of hint with small radios


### PR DESCRIPTION
## Description

This PR fixes https://github.com/nhsuk/nhsuk-frontend/issues/1887 and uses the suggestion from:

* https://github.com/alphagov/govuk-frontend/issues/7272

<br>

<img width="530" height="289" alt="Small selected radio" src="https://github.com/user-attachments/assets/7719c5ed-1208-42d4-b391-dbc84c05e997" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
