### PR TITLE
[v10] Guard against Nunjucks filter errors on `undefined` text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+Note: This release was created from the `support/10.x` branch.
+
+### :wrench: **Fixes**
+
+- [#2055: Guard against Nunjucks filter errors on `undefined` text](https://github.com/nhsuk/nhsuk-frontend/pull/2055)
+
 ## 10.6.0 - 13 August 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/breadcrumb/template.njk
@@ -33,7 +33,7 @@
     </li>
   {% endif %}
 {% endfor %}
-{% if params.href %}
+{% if params.text and params.href %}
     <li class="nhsuk-breadcrumb__list-item">
       <a class="nhsuk-breadcrumb__link" href="{{ params.href }}">
         {{ params.text | trim | indent(8) }}

--- a/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/card/template.njk
@@ -128,11 +128,11 @@
   classPrefix: "nhsuk-heading-",
   attributes: params.attributes
 }) %}
-{% if parent.params.href and not "nhsuk-card--feature" in classNames %}
+{% if params.text and parent.params.href and not "nhsuk-card--feature" in classNames %}
   <a class="nhsuk-card__link" href="{{ parent.params.href }}">
     {{- params.text | trim | indent(2) -}}
   </a>
-{%- elif params.visuallyHiddenText %}
+{%- elif params.text and params.visuallyHiddenText %}
   <span role="text">
     <span class="nhsuk-u-visually-hidden">{{ params.visuallyHiddenText }}: </span>
     {{- params.text | trim | indent(4) }}

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/fixtures.mjs
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/fixtures.mjs
@@ -625,6 +625,18 @@ const fixtures = {
       viewports: ["desktop"]
     }
   },
+  "with service name (linked with logo, empty)": {
+    context: {
+      service: {
+        text: null,
+        href: "#"
+      }
+    },
+    options: {
+      hidden: true,
+      width: false
+    }
+  },
   "with service name (linked and long), search": {
     context: {
       logo: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -45,7 +45,7 @@
 {#- The NHS logo and service name are combined into a single link if either
     the logo doesn’t have an `href` set but the service name does, or if both
     have an exact `href`. This avoids having 2 links to same destination. -#}
-{%- set combineLogoAndServiceNameLinks = (params.service.href and not (params.logo.href)) or (params.service.href and (params.service.href == params.logo.href)) %}
+{%- set combineLogoAndServiceNameLinks = params.service.text | length and (params.service.href and not params.logo.href) or (params.service.href and (params.service.href == params.logo.href)) %}
 
 {%- set logoAlt = params.logo.alt | default("NHS") %}
 {%- set logoHref = params.service.href if combineLogoAndServiceNameLinks else params.logo.href %}
@@ -68,11 +68,11 @@
 {% endmacro %}
 
 {%- macro _serviceName(text, href) %}
-{% if href -%}
+{% if text and href -%}
 <a class="nhsuk-header__service-name" href="{{ href }}">
   {{- text | trim -}}
 </a>
-{% else -%}
+{% elif text -%}
 <span class="nhsuk-header__service-name">
   {{- text | trim -}}
 </span>


### PR DESCRIPTION
## Description

This PR fixes a few more examples of `| trim` being run on `undefined` text missed from https://github.com/nhsuk/nhsuk-frontend/commit/5b7c7ea92e7f914c67e19c2171396fd8f099df45

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
