### PR TITLE
[v10] Remove negative margin top from caption when heading has margin override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: This release was created from the `support/10.x` branch.
 ### :wrench: **Fixes**
 
 - [#2055: Guard against Nunjucks filter errors on `undefined` text](https://github.com/nhsuk/nhsuk-frontend/pull/2055)
+- [#2056: Remove negative margin top from caption when heading has margin override](https://github.com/nhsuk/nhsuk-frontend/pull/2056)
 
 ## 10.6.0 - 13 August 2026
 

--- a/packages/nhsuk-frontend-review/src/examples/typography.njk
+++ b/packages/nhsuk-frontend-review/src/examples/typography.njk
@@ -254,6 +254,26 @@
 
       <hr>
 
+      <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-0">nhsuk-heading-xl</h1>
+      <span class="nhsuk-caption-xl nhsuk-u-margin-bottom-7">nhsuk-caption-xl</span>
+
+      <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-0">nhsuk-heading-xl</h1>
+      <span class="nhsuk-caption-l nhsuk-u-margin-bottom-7">nhsuk-caption-l</span>
+
+      <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-0">nhsuk-heading-l</h2>
+      <span class="nhsuk-caption-l nhsuk-u-margin-bottom-4">nhsuk-caption-l</span>
+
+      <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-0">nhsuk-heading-l</h2>
+      <span class="nhsuk-caption-m nhsuk-u-margin-bottom-4">nhsuk-caption-m</span>
+
+      <h3 class="nhsuk-heading-m nhsuk-u-margin-bottom-0">nhsuk-heading-m</h3>
+      <span class="nhsuk-caption-m nhsuk-u-margin-bottom-4">nhsuk-caption-m</span>
+
+      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-0">nhsuk-heading-s</h3>
+      <span class="nhsuk-caption-s nhsuk-u-margin-bottom-4">nhsuk-caption-s</span>
+
+      <hr>
+
       <span class="nhsuk-heading-l">Span using nhsuk-heading-l</span>
       <span class="nhsuk-heading-m">Span using nhsuk-heading-m</span>
       <span class="nhsuk-heading-s">Span using nhsuk-heading-s</span>

--- a/packages/nhsuk-frontend/src/nhsuk/core/styles/_typography.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/core/styles/_typography.scss
@@ -173,6 +173,24 @@ h6 + .nhsuk-caption--bottom,
   @include nhsuk-responsive-margin(4, "bottom");
 }
 
+h1,
+.nhsuk-heading-xl,
+h2,
+.nhsuk-heading-l,
+h3,
+.nhsuk-heading-m,
+h4,
+.nhsuk-heading-s,
+h5,
+.nhsuk-heading-xs,
+h6,
+.nhsuk-heading-xxs {
+  // Remove negative top margin from caption when heading has manual bottom margin
+  &[class*="nhsuk-u-margin-bottom-"] + [class^="nhsuk-caption"] {
+    margin-top: 0;
+  }
+}
+
 // Body (paragraphs)
 
 %nhsuk-body-l {


### PR DESCRIPTION
## Description

Matching heading + caption pairs use negative margins to bring them closer together:

```html
<h1 class="nhsuk-heading-xl">nhsuk-heading-xl</h1>
<span class="nhsuk-caption-xl">nhsuk-caption-xl</span>
```

This PR removes the unnecessary negative margin when heading margins are set manually:

```
<h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-0">nhsuk-heading-xl</h1>
<span class="nhsuk-caption-xl nhsuk-u-margin-bottom-7">nhsuk-caption-xl</span>
```

Without this fix we'd end up with the issue shown in the screenshot

Thanks to @paulrobertlloyd for reporting this issue

<img width="523" height="558" alt="Captions with negative margins incorrectly displayed above the preceding heading" src="https://github.com/user-attachments/assets/f5c4e6cc-e290-4f91-89a4-0a383a0ca9e4" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
