### PR TITLE
[v10] Rename title and heading HTML classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Note: This release was created from the `support/10.x` branch.
 - [#2055: Guard against Nunjucks filter errors on `undefined` text](https://github.com/nhsuk/nhsuk-frontend/pull/2055)
 - [#2056: Remove negative margin top from caption when heading has margin override](https://github.com/nhsuk/nhsuk-frontend/pull/2056)
 
+### :recycle: **Changes**
+
+#### Rename title and heading HTML classes
+
+HTML classes for the error summary, panel and tabs component headings have been renamed from `__title` to `__heading` to match their corresponding Nunjucks option.
+
+If you are not using Nunjucks macros, change the classes as follows:
+
+- Rename the `<h2 class="nhsuk-error-summary__title"` class attribute to match `<h2 class="nhsuk-error-summary__heading"`.
+- Rename the `<h1 class="nhsuk-panel__title"` class attribute to match `<h1 class="nhsuk-panel__heading"`.
+- Rename the `<h2 class="nhsuk-tabs__title"` class attribute to match `<h2 class="nhsuk-tabs__heading"`.
+
+The previous class names are deprecated and will be removed in a future release.
+
+This change was introduced in [pull request #2057: Rename title and heading HTML classes](https://github.com/nhsuk/nhsuk-frontend/pull/2057).
+
 ## 10.6.0 - 13 August 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/_index.scss
@@ -24,6 +24,8 @@
     }
   }
 
+  .nhsuk-error-summary__heading,
+  // Deprecated, to be removed in a future release
   .nhsuk-error-summary__title {
     margin-top: 0;
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
@@ -45,7 +45,7 @@
       text: headingOptions.text,
       html: headingOptions.html,
       level: 2,
-      className: "nhsuk-error-summary__title",
+      className: "nhsuk-error-summary__heading",
       attributes: headingOptions.attributes
     }) | trim | indent(4) }}
     <div class="nhsuk-error-summary__body">

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/_index.scss
@@ -73,26 +73,37 @@ $nhsuk-border-width-panel: $nhsuk-panel-border-width;
     }
   }
 
+  .nhsuk-panel__heading,
+  // Deprecated, to be removed in a future release
   .nhsuk-panel__title {
     margin-top: 0;
   }
 
+  .nhsuk-panel__heading,
+  .nhsuk-panel__heading--xl,
+  // Deprecated, to be removed in a future release
   .nhsuk-panel__title,
   .nhsuk-panel__title--xl {
     @include nhsuk-font-size(48);
     @include nhsuk-responsive-margin(5, "bottom");
   }
 
+  .nhsuk-panel__heading--l,
+  // Deprecated, to be removed in a future release
   .nhsuk-panel__title--l {
     @include nhsuk-font-size(36);
     @include nhsuk-responsive-margin(3, "bottom");
   }
 
+  .nhsuk-panel__heading--m,
+  // Deprecated, to be removed in a future release
   .nhsuk-panel__title--m {
     @include nhsuk-font-size(26);
     @include nhsuk-responsive-margin(3, "bottom");
   }
 
+  .nhsuk-panel__heading:last-child,
+  // Deprecated, to be removed in a future release
   .nhsuk-panel__title:last-child {
     margin-bottom: 0;
   }

--- a/packages/nhsuk-frontend/src/nhsuk/components/panel/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/panel/template.njk
@@ -6,7 +6,7 @@
 
 {#- Set classes for this component #}
 {%- set classNames = "nhsuk-panel" -%}
-{%- set classNamesTitle = "nhsuk-panel__title" -%}
+{%- set classNamesHeading = "nhsuk-panel__heading" -%}
 
 {#- Support heading as string (with deprecated options) #}
 {%- set headingOptions = params.heading if params.heading is mapping and params.heading is not escaped else {
@@ -36,8 +36,8 @@
     level: headingOptions.level,
     size: headingOptions.size,
     sizes: ["m", "l", "xl"],
-    className: classNamesTitle,
-    classPrefix: classNamesTitle ~ "--",
+    className: classNamesHeading,
+    classPrefix: classNamesHeading ~ "--",
     classes: headingOptions.classes,
     attributes: headingOptions.attributes
   }) | trim | indent(2) }}

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/_index.scss
@@ -16,6 +16,8 @@
     @include nhsuk-font($size: 19);
   }
 
+  .nhsuk-tabs__heading,
+  // Deprecated, to be removed in a future release
   .nhsuk-tabs__title {
     margin-bottom: nhsuk-spacing(2);
 
@@ -52,6 +54,8 @@
         @include nhsuk-clearfix;
       }
 
+      .nhsuk-tabs__heading,
+      // Deprecated, to be removed in a future release
       .nhsuk-tabs__title {
         display: none;
       }

--- a/packages/nhsuk-frontend/src/nhsuk/components/tabs/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tabs/template.njk
@@ -48,7 +48,7 @@
   {{ heading({
     text: params.visuallyHiddenText | default(params.title) | default("Contents"),
     level: 2,
-    className: "nhsuk-tabs__title"
+    className: "nhsuk-tabs__heading"
   }) | trim | indent(2) }}
 {% if params.items | length %}
   <ul class="nhsuk-tabs__list">


### PR DESCRIPTION
## Description

This PR renames some `__title` classes to `__heading`, missed from:

* https://github.com/nhsuk/nhsuk-frontend/pull/2047

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
