### PR TITLE
Remove redundant landmark roles from HTML5 elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1515,6 +1515,10 @@ This change was introduced in [pull request #2002: Add image component `backgrou
 - [#2048: Fix margin and line height issues for labels and legends as page headings](https://github.com/nhsuk/nhsuk-frontend/pull/2048)
 - [#2049: Fix radio button and check mark alignment on Windows 125% scaling](https://github.com/nhsuk/nhsuk-frontend/pull/2049)
 
+### :wrench: **Fixes**
+
+- [Remove redundant HTML landmark roles from HTML5 elements](https://github.com/olitreadwell/nhsuk-frontend/pull/7)
+
 ## 10.5.2 - 8 June 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend-review/.htmlvalidate.mjs
+++ b/packages/nhsuk-frontend-review/.htmlvalidate.mjs
@@ -92,27 +92,6 @@ export default defineConfig({
         }
       },
 
-      // Allow footer component <footer role="contentinfo">
-      footer: {
-        attributes: {
-          role: { enum: ['contentinfo'] }
-        }
-      },
-
-      // Allow header component <header role="banner">
-      header: {
-        attributes: {
-          role: { enum: ['banner'] }
-        }
-      },
-
-      // Allow contents list and pagination component <nav role="navigation">
-      nav: {
-        attributes: {
-          role: { enum: ['navigation'] }
-        }
-      },
-
       // Allow table component (responsive) <table role="table">
       table: {
         attributes: {

--- a/packages/nhsuk-frontend/src/nhsuk/components/contents-list/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/contents-list/template.njk
@@ -32,7 +32,7 @@
 </ol>
 {% endmacro -%}
 
-<nav class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %} role="navigation" aria-label="{{ ariaLabel }}"
+<nav class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %} aria-label="{{ ariaLabel }}"
   {{- nhsukAttributes(params.attributes) }}>
   <h2 class="nhsuk-u-visually-hidden">
     {{- params.visuallyHiddenText | default("Contents", true) -}}

--- a/packages/nhsuk-frontend/src/nhsuk/components/footer/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/footer/template.njk
@@ -36,7 +36,7 @@
 </ul>
 {% endmacro -%}
 
-<footer class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %} role="contentinfo"
+<footer class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %}
   {{- nhsukAttributes(params.attributes) }}>
   <div class="nhsuk-width-container {%- if params.containerClasses %} {{ params.containerClasses }}{% endif %}">
 {% if params.navigation %}

--- a/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/header/template.njk
@@ -95,8 +95,7 @@
       value: params.id,
       optional: true
     },
-    "data-module": "nhsuk-header",
-    role: "banner"
+    "data-module": "nhsuk-header"
   }) -}}
 
   {{- nhsukAttributes(params.attributes) -}}>

--- a/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/pagination/template.njk
@@ -42,7 +42,7 @@
   </li>
 {%- endmacro -%}
 
-<nav class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %} role="navigation" aria-label="{{ ariaLabel }}"
+<nav class="{{ classNames }}" {%- if params.id %} id="{{ params.id }}"{% endif %} aria-label="{{ ariaLabel }}"
   {{- nhsukAttributes(params.attributes) }}>
 {% if params.previous.href and params.items | length %}
   <a href="{{ params.previous.href }}" class="nhsuk-pagination__previous" rel="prev">


### PR DESCRIPTION
## Description

The header, footer, contents list and pagination components set explicit role attributes on native HTML5 elements that already map to those roles. The attributes (`banner`, `contentinfo`, `navigation`) were added as an Internet Explorer workaround and are redundant in every browser the design system supports.

Removed:

- `role="banner"` from the header component's `<header>` element
- `role="contentinfo"` from the footer component's `<footer>` element
- `role="navigation"` from the contents list and pagination components' `<nav>` elements

The matching allowances in the review app's HTML validation config are removed too, so the attributes can't come back unnoticed.

Left in place: the card `role="text"`, the do and don't list `role="list"` and the responsive table roles. The first two are VoiceOver workarounds that still need research; the table roles are part of the responsive table accessibility discussion.

One thing to know before reviewing: per HTML-AAM, `header` and `footer` only map to `banner` and `contentinfo` when they are not nested inside `section`, `article`, `main`, `aside` or `nav`. On real pages the header and footer are top-level, so the landmarks are unchanged. In the review app's example galleries the components are wrapped in sections, so they now get section-scoped roles instead of the forced landmarks. That matches the spec.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry