### PR TITLE
[v10] Fix small checkbox check mark alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend Changelog
 
+## Unreleased
+
+### :wrench: **Fixes**
+
+- Improved check mark alignment for small checkboxes at higher display scale factors.
+
 ## 10.6.1 - 25 August 2026
 
 Note: This release was created from the `support/10.x` branch.

--- a/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/checkboxes/_index.scss
@@ -307,8 +307,13 @@ $nhsuk-checkboxes-offset: $nhsuk-border-width-form-element;
 
       top: $check-mark-height + $input-offset - nhsuk-px-to-rem(0.5px);
       left: $check-mark-width + nhsuk-px-to-rem($nhsuk-checkboxes-offset + 1px);
+
       width: $check-mark-width;
       height: $check-mark-height;
+
+      // Keep the check mark optically centred at higher display scale factors
+      transform: translateX(nhsuk-px-to-rem(-0.5px)) rotate(-45deg) translate(-50%, -50%);
+
       border-width: 0 0 nhsuk-px-to-rem(3px) nhsuk-px-to-rem(3px);
     }
 


### PR DESCRIPTION
## Description

This addresses the small-checkbox check mark that appears too far right after the v10.6 centring change.

The v10.6 transform-based positioning is retained because it fixed the earlier Windows 125% scaling defect in #1887 and #2051. The small-checkbox rule adds a rem-based horizontal correction before the existing rotation and centring:

```scss
transform: translateX(nhsuk-px-to-rem(-0.5px))
  rotate(-45deg)
  translate(-50%, -50%);
```

At the default 16px root size this is a `-0.5px` CSS translation. Because the project emits rem values, the correction scales with text resizing; it was also tested with a 32px root size.

## Visual acceptance oracle

The acceptance test measures the horizontal distance between:

- the centre of the rendered check-mark bounding box; and
- the centre of the rendered checkbox-border bounding box.

Lower absolute error is better. This tests centring, rather than merely proving that pixels moved.

The matrix compared:

- the pre-v10.6 small-checkbox rendering as a historical control;
- the current v10.6 rule;
- fixed `-0.25px`, `-0.5px` and `-0.75px` corrections;
- the proposed `-0.03125rem` correction.

The historical rule is a reference, not an eligible replacement, because restoring it would reverse the transform-based Windows 125% correction from #2051. The proposed rule had to be the best eligible correction and remain within `0.05px` mean error of that historical control.

| Environment | Proposed mean error | Proposed maximum | Current mean error | Historical mean error |
| --- | ---: | ---: | ---: | ---: |
| macOS Chromium + WebKit approximation | 0.1028px | 0.4000px | 0.6861px | 0.0611px |
| Windows Chrome + Edge | 0.0417px | 0.2500px | 0.7194px | 0.0667px |

At the default root size, the proposed rule was exactly centred at DPR 1, 1.25, 1.5 and 2 in macOS Chromium, Windows Chrome and Windows Edge. In the WebKit approximation it improved the current horizontal result at three of four DPR values and reduced the mean error.

The 200% root-text-size and forced-colours checks also passed. The selected check mark remained rendered in forced-colours mode.

## Persistent evidence

- [Final centring workflow](https://github.com/AyobamiH/nhsuk-frontend/actions/runs/33170676223)
- [macOS score summary](https://github.com/AyobamiH/nhsuk-frontend/blob/automation/validate-checkbox-centering-2076/evidence/2076/checkbox-centering-macos/summary.md)
- [macOS comparison image](https://github.com/AyobamiH/nhsuk-frontend/blob/automation/validate-checkbox-centering-2076/evidence/2076/checkbox-centering-macos/comparison.png)
- [Windows score summary](https://github.com/AyobamiH/nhsuk-frontend/blob/automation/validate-checkbox-centering-2076/evidence/2076/checkbox-centering-windows/summary.md)
- [Windows comparison image](https://github.com/AyobamiH/nhsuk-frontend/blob/automation/validate-checkbox-centering-2076/evidence/2076/checkbox-centering-windows/comparison.png)
- [Native pull-request checks](https://github.com/AyobamiH/nhsuk-frontend/actions/runs/33153252803)

The evidence branch will be retained while this pull request is open.

## Coverage and limitations

Tested with:

- macOS Chromium;
- Playwright WebKit on macOS, explicitly treated as a Safari approximation;
- installed Chrome and Edge binaries on a Windows runner;
- DPR 1, 1.25, 1.5 and 2 browser-context emulation;
- 100% and 200% root text size;
- forced colours;
- repository-native visual, accessibility, package, Sass, lint, build and JavaScript checks.

The DPR matrix is browser-context emulation on the named operating system, not proof of physical monitor scaling. WebKit is not claimed as actual Safari. A maintainer or issue reporter can therefore provide the final physical-device or Safari visual confirmation without relying on an overstated automation claim.

## Testing

- `npm run lint`
- `npm run build`
- `npm run test:js -- --runInBand`
  - 105 test suites passed
  - 2,154 tests passed
  - 6 snapshots passed
- repository-native visual regression tests
- repository-native accessibility tests
- package import and require checks
- supported Dart Sass compatibility matrix
- objective cross-browser centring matrix

## Checklist

- [x] Tested against the [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Follows the [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry

Closes #2076
