### PR TITLE
Fix typos and stale doc references

### DIFF
--- a/bin/publish-preview.sh
+++ b/bin/publish-preview.sh
@@ -13,7 +13,7 @@ npm install --no-save --silent
 npm run build --workspace nhsuk-frontend
 echo
 
-# Check if there are files that need to be commited
+# Check if there are files that need to be committed
 if [[ -n $(git status --porcelain) ]]; then
   echo "⚠️ You have unstaged files, please commit these and then try again."
   exit 1

--- a/docs/contributing/automated-testing.md
+++ b/docs/contributing/automated-testing.md
@@ -12,7 +12,7 @@ For full documentation on the BackstopJS framework, read the [BackstopJS documen
 
 BackstopJS tests configuration and files can be found within the `backstop` folder in the [tests directory](https://github.com/nhsuk/nhsuk-frontend/tree/master/tests).
 
-`backstop.js` contains all the test configuration and tests scenarios.
+`backstop.config.js` contains all the test configuration and tests scenarios.
 
 **`id`** – Used for screenshot naming. Set this property when sharing reference files with teammates -- otherwise omit and BackstopJS will auto-generate one for you to avoid naming collisions with BackstopJS resources.
 
@@ -41,11 +41,11 @@ npm run test:visual
 
 This will start the application and run the tests concurrently.
 
-Each time that a test is run locally a new set of bitmaps will be created in `tests/backstop/<timestamp>/`.
+Each time that a test is run locally a new set of bitmaps will be created in `tests/backstop/bitmaps_test/`.
 
 Once the test bitmaps are generated, a report comparing the most recent test bitmaps against the current reference bitmaps will display.
 
-If you run tests frequently, your `tests/backstop/<timestamp>/` folder may have a lot of historic tests bitmaps, you can delete the contents of this folder with `npm run test:visual:clean`.
+If you run tests frequently, your `tests/backstop/bitmaps_test/` folder may have a lot of historic tests bitmaps, you can delete the contents of this folder with `npm run test:visual:clean`.
 
 #### Run an individual test
 
@@ -69,7 +69,7 @@ npm run test:visual:approve
 
 #### Add new tests scenarios
 
-If you want to add new tests you will need to add the test scenarios to the `backstop.js` file following the [scenario configuration guidelines](#tests-configuration). Once you have added the new tests you will need to update the reference bitmaps to include a reference for the new tests.
+If you want to add new tests you will need to add the test scenarios to the `backstop.config.js` file following the [scenario configuration guidelines](#tests-configuration). Once you have added the new tests you will need to update the reference bitmaps to include a reference for the new tests.
 
 ```sh
 npm run test:visual:ref

--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -79,7 +79,7 @@ For example:
 
 #### BEM further reading:
 
-- [Get BEM](http://getbem.com/introduction/)
+- [Get BEM](https://bem.info/en/methodology/)
 - [BEM Resources](https://github.com/sturobson/BEM-resources)
 - [Harry Roberts - BEMIT: Taking the BEM Naming Convention a Step Further](https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/)
 

--- a/docs/contributing/running-locally.md
+++ b/docs/contributing/running-locally.md
@@ -10,7 +10,7 @@ To run NHS.UK frontend locally you'll need to:
 
 > Type `git --version` to check if git is installed. This should print a version number like "git version 2.18.0".
 
-> Type `node -v` to check if Node is installed. This should print a version number like "v8.11.3".
+> Type `node -v` to check if Node is installed. This should print a version number like "v24.11.0".
 
 ## 1. Fork the repository
 

--- a/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
+++ b/packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk
@@ -37,7 +37,7 @@
   }) -}}
 
   {{- nhsukAttributes(params.attributes) -}}>
-  {#- Keep the role="alert" in a seperate child container to prevent a race condition between
+  {#- Keep the role="alert" in a separate child container to prevent a race condition between
   the focusing js at the alert, resulting in information getting missed in screen reader announcements #}
   <div role="alert">
     {{ nhsukHeading({

--- a/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss
@@ -106,7 +106,7 @@
 
     // Where possible use the cross as a mask instead. This lets us use
     // currentcolor, increasing the contrast of the image and matching the
-    // user's prefered foreground colour in e.g. forced colors mode.
+    // user's preferred foreground colour in e.g. forced colors mode.
     // We test for `mask-position` rather than `mask-image` because of a false
     // positive in Edge 17.
     @supports (mask-position: initial) {

--- a/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
+++ b/packages/nhsuk-frontend/src/nhsuk/components/tables/_index.scss
@@ -265,7 +265,7 @@
 
     // Where possible use the cross as a mask instead. This lets us use
     // currentcolor, increasing the contrast of the image and matching the
-    // user's prefered foreground colour in e.g. forced colors mode.
+    // user's preferred foreground colour in e.g. forced colors mode.
     // We test for `mask-position` rather than `mask-image` because of a false
     // positive in Edge 17.
     @supports (mask-position: initial) {


### PR DESCRIPTION
## Description

A small cleanup pass fixing typos and stale references across the repo:

- `bin/publish-preview.sh`: "commited" to "committed"
- `packages/nhsuk-frontend/src/nhsuk/components/input/_index.scss` and `tables/_index.scss`: "prefered" to "preferred"
- `packages/nhsuk-frontend/src/nhsuk/components/error-summary/template.njk`: "seperate" to "separate"
- `docs/contributing/automated-testing.md`: point to the actual `backstop.config.js` file and the `tests/backstop/bitmaps_test/` output path
- `docs/contributing/coding-standards.md`: replace the dead `getbem.com` link with the current BEM methodology docs
- `docs/contributing/running-locally.md`: update the example Node version to match the project's required version

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility) - comment and documentation only, no visual or behavioural change
- [x] Follows our [coding standards and style guide](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] CHANGELOG entry - documentation and comment only; prior doc-only changes add no CHANGELOG entry

Drafted with AI assistance; I found the errors, verified each one against the current code, and reviewed the diff line by line.
